### PR TITLE
TMDM-9922 1 After bulk update entity 'Product',browse entity 'Product…

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/BulkUpdatePanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/BulkUpdatePanel.java
@@ -94,6 +94,7 @@ public class BulkUpdatePanel extends ContentPanel {
         bulkUpdateDetailPanel.initBanner(pkInfoList, itemBean.getDescription());
         bulkUpdateDetailPanel.addTabItem(itemBean.getLabel(), itemPanel, ItemsDetailPanel.SINGLETON, itemBean.getConcept());
         bulkUpdateDetailPanel.initBreadCrumb(new BreadCrumb(breads, bulkUpdateDetailPanel));
+        detailPanel.removeAll();
         detailPanel.add(bulkUpdateDetailPanel);
         detailPanel.layout();
     }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/MultiOccurrenceChangeItem.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/MultiOccurrenceChangeItem.java
@@ -165,10 +165,12 @@ public class MultiOccurrenceChangeItem extends HorizontalPanel {
                                 field.clear();
                                 field.setReadOnly(true);
                                 field.addStyleName(disabledStyle);
-                                addRemoveHandler.removeAllNode(treeDetail.getSelectedItem());
                                 updateMultiOccurrenceButtonStatus(false);
                                 itemNode.setValid(true);
                                 itemNode.setEdited(false);
+                                if (!isAddRemoveHandlerNull()) {
+                                    addRemoveHandler.removeAllNode(treeDetail.getSelectedItem());
+                                }
                             }
                         }
                     });


### PR DESCRIPTION
…Family',click 'Bulk update',the page display enity of 'Product' while it should display 'ProductFamily'

2 Click pen button to edit then unedit a mandatory field,click "Save and close" button,unable to save the record.
3 Click pen button to edit then unedit a non-mandatory field,click "Save and close" button,the value of the field is lost
4 After bulk update a field, the field is always in edit mode when bulk update again.