### PR TITLE
TMDM-10909: Wrong liquibase changelog path prevented to deploy datamodel 

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -278,8 +278,8 @@ public class LiquibaseSchemaAdapter  {
                 changeLogDir.mkdir();
             }
 
-            File changeLogFile = new File(changeLogDir, DateUtils.format(System.currentTimeMillis(), "yyyyMMddHHmm") + SEPARATOR //$NON-NLS-1$ //$NON-NLS-2$
-                    + System.currentTimeMillis() + SEPARATOR + storageType + ".xml"); //$NON-NLS-1$ //$NON-NLS-2$
+            File changeLogFile = new File(changeLogDir, DateUtils.format(System.currentTimeMillis(), "yyyyMMddHHmm") + SEPARATOR //$NON-NLS-1$
+                    + System.currentTimeMillis() + SEPARATOR + storageType + ".xml"); //$NON-NLS-1$
             if (!changeLogFile.exists()) {
                 changeLogFile.createNewFile();
             }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
@@ -873,8 +873,8 @@ public class StorageAdaptTest extends TestCase {
 
     private static void setMDMRootURL() {
         URL targetDir = StorageAdaptTest.class.getClassLoader().getResource(".");
-        LOGGER.info("Using MDM ROOT URL: " + targetDir.toExternalForm());
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, targetDir.toExternalForm());
+        LOGGER.info("Using MDM ROOT: " + targetDir.getFile());
+        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT, targetDir.getFile());
     }
 
     // TMDM-10525 [Impact Analysis] Move a simple field from optional to mandatory 1

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
@@ -15,6 +15,7 @@ import static com.amalto.core.query.user.UserQueryBuilder.from;
 
 import java.io.File;
 import java.lang.reflect.Method;
+import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -28,6 +29,7 @@ import java.util.Set;
 
 import junit.framework.TestCase;
 
+import org.apache.log4j.Logger;
 import org.h2.jdbc.JdbcSQLException;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
@@ -54,6 +56,8 @@ import com.amalto.core.storage.record.XmlStringDataRecordReader;
 public class StorageAdaptTest extends TestCase {
 
     protected static final String STORAGE_NAME = "Test";
+
+    private static final Logger LOGGER = Logger.getLogger(StorageAdaptTest.class);
 
     @Override
     public void setUp() throws Exception {
@@ -867,6 +871,12 @@ public class StorageAdaptTest extends TestCase {
         storage.end();
     }
 
+    private static void setMDMRootURL() {
+        URL targetDir = StorageAdaptTest.class.getClassLoader().getResource(".");
+        LOGGER.info("Using MDM ROOT URL: " + targetDir.toExternalForm());
+        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, targetDir.toExternalForm());
+    }
+
     // TMDM-10525 [Impact Analysis] Move a simple field from optional to mandatory 1
     public void test12_MoveFieldFromOptionalToMandatory_ForNoValueInDB() throws Exception {
         /*
@@ -875,7 +885,7 @@ public class StorageAdaptTest extends TestCase {
          * age type is int, have no the default value married type is boolean contains the default value birthday type
          * is data, have no default value
          */
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         HibernateStorage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -962,7 +972,7 @@ public class StorageAdaptTest extends TestCase {
          * is data, have no default value
          */
 
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         HibernateStorage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1048,7 +1058,7 @@ public class StorageAdaptTest extends TestCase {
          * age type is int, have no the default value married type is boolean contains the default value birthday type
          * is data, have no default value
          */
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1134,7 +1144,7 @@ public class StorageAdaptTest extends TestCase {
          * age type is int, have no the default value married type is boolean contains the default value birthday type
          * is data, have no default value
          */
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1207,7 +1217,7 @@ public class StorageAdaptTest extends TestCase {
     // TMDM-10529 [Impact Analysis] Delete an optional simple field, then recreate the same optional field with another
     // type
     public void test13_DeleteOptionField_ForNoData() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1277,7 +1287,7 @@ public class StorageAdaptTest extends TestCase {
     // TMDM-10529 [Impact Analysis] Delete an optional simple field, then recreate the same optional field with another
     // type
     public void test13_DeleteOptionField_ForWithData() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1380,7 +1390,7 @@ public class StorageAdaptTest extends TestCase {
 
     // TMDM-10531: [Impact Analysis] Move a simple field from mandatory to optional
     public void test14_MoveSimpleFieldFormMandatoryToOption_ForNoData() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1444,7 +1454,7 @@ public class StorageAdaptTest extends TestCase {
 
     // TMDM-10531: [Impact Analysis] Move a simple field from mandatory to optional
     public void test14_MoveSimpleFieldFormMandatoryToOption_WithData() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1540,7 +1550,7 @@ public class StorageAdaptTest extends TestCase {
 
     // TMDM-10533: [Impact Analysis] Deleting a mandatory field
     public void test15_DeleteMandatoryField_ForNoData() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1609,7 +1619,7 @@ public class StorageAdaptTest extends TestCase {
 
     // TMDM-10533: [Impact Analysis] Deleting a mandatory field
     public void test15_DeleteMandatoryField_ForWithData() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1712,7 +1722,7 @@ public class StorageAdaptTest extends TestCase {
 
     // TMDM-10534：[Impact Analysis] Move a complex mandatory field (containing a simple optional field) to optional
     public void test16_MoveComplexFieldFromMandatoryToOptional() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -1902,7 +1912,7 @@ public class StorageAdaptTest extends TestCase {
     }
 
     public void test17_forRepeatable() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        setMDMRootURL();
 
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
         Storage storage = new HibernateStorage("Person", StorageType.MASTER);
@@ -2060,9 +2070,6 @@ public class StorageAdaptTest extends TestCase {
     }
 
     private void deleteLiquibaseChangeLogFile() {
-        String mdmRootLocation = System.getProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL).replace("file:/", "");
-        String filePath = mdmRootLocation + "/data/liqubase-changelog/";
-        File file = new File(filePath);
-        file.deleteOnExit();
+        // do nothing
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
@@ -42,8 +42,8 @@ public class LiquibaseSchemaAdapterTest {
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
         URL targetDir = LiquibaseSchemaAdapterTest.class.getClassLoader().getResource(".");
-        LOGGER.info("Using MDM ROOT URL: " + targetDir.toExternalForm());
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, targetDir.toExternalForm());
+        LOGGER.info("Using MDM ROOT URL: " + targetDir.getFile());
+        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT, targetDir.getFile());
         
         ServerContext.INSTANCE.get(new MockServerLifecycle());
         
@@ -195,9 +195,13 @@ public class LiquibaseSchemaAdapterTest {
         String changeLogFilePath = adapter.getChangeLogFilePath(changeList);
         assertNotNull(changeLogFilePath);
 
+        File mdmRootFileDir = new File(System.getProperty(LiquibaseSchemaAdapter.MDM_ROOT));
+        File changeLogDir = new File(mdmRootFileDir, LiquibaseSchemaAdapter.DATA_LIQUIBASE_CHANGELOG_PATH);
+
         File changeLogFile = new File(changeLogFilePath);
         assertTrue(changeLogFile.exists());
         assertTrue(changeLogFile.isFile());
         assertTrue(changeLogFile.getName().endsWith(".xml"));
+        assertEquals(changeLogDir.getAbsolutePath(), changeLogFile.getParentFile().getParentFile().getAbsolutePath());
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
@@ -3,6 +3,7 @@ package com.amalto.core.storage.hibernate;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.net.URL;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -10,6 +11,7 @@ import java.util.Set;
 import liquibase.change.AbstractChange;
 import liquibase.change.core.DropNotNullConstraintChange;
 
+import org.apache.log4j.Logger;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.junit.AfterClass;
@@ -23,13 +25,15 @@ import org.talend.mdm.commmon.metadata.compare.Compare;
 
 import com.amalto.core.server.MockServerLifecycle;
 import com.amalto.core.server.ServerContext;
-import com.amalto.core.storage.Storage;
 import com.amalto.core.storage.StorageType;
+import com.amalto.core.storage.adapt.StorageAdaptTest;
 import com.amalto.core.storage.datasource.DataSourceDefinition;
 import com.amalto.core.storage.datasource.RDBMSDataSource;
 
 
 public class LiquibaseSchemaAdapterTest {
+
+    private static final Logger LOGGER = Logger.getLogger(StorageAdaptTest.class);
 
     private static LiquibaseSchemaAdapter adapter;
 
@@ -37,7 +41,9 @@ public class LiquibaseSchemaAdapterTest {
     
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {
-        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, System.getProperty("user.dir"));
+        URL targetDir = LiquibaseSchemaAdapterTest.class.getClassLoader().getResource(".");
+        LOGGER.info("Using MDM ROOT URL: " + targetDir.toExternalForm());
+        System.setProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL, targetDir.toExternalForm());
         
         ServerContext.INSTANCE.get(new MockServerLifecycle());
         
@@ -67,10 +73,7 @@ public class LiquibaseSchemaAdapterTest {
 
     @AfterClass
     public static void tearDownAfterClass() throws Exception {
-        String mdmRootLocation = System.getProperty(LiquibaseSchemaAdapter.MDM_ROOT_URL).replace("file:/", "");
-        String filePath = mdmRootLocation + "/data/liqubase-changelog/";
-        File file = new File(filePath);
-        file.deleteOnExit();
+
     }
 
     @Test
@@ -176,5 +179,25 @@ public class LiquibaseSchemaAdapterTest {
         assertEquals("x_bb_x_talend_id", ((DropNotNullConstraintChange) changeList.get(0)).getColumnName());
         assertEquals("x_ee", ((DropNotNullConstraintChange) changeList.get(1)).getColumnName());
         assertEquals("x_uu_x_talend_id", ((DropNotNullConstraintChange) changeList.get(2)).getColumnName());
+    }
+
+    @Test
+    public void testGetChangeLogFilePath() throws Exception {
+        MetadataRepository original = new MetadataRepository();
+        original.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_1.xsd")); //$NON-NLS-1$
+        original = original.copy();
+        MetadataRepository updated2 = new MetadataRepository();
+        updated2.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_2.xsd")); //$NON-NLS-1$
+        Compare.DiffResults diffResults = Compare.compare(original, updated2);
+
+        List<AbstractChange> changeList = adapter.analyzeModifyChange(diffResults);
+
+        String changeLogFilePath = adapter.getChangeLogFilePath(changeList);
+        assertNotNull(changeLogFilePath);
+
+        File changeLogFile = new File(changeLogFilePath);
+        assertTrue(changeLogFile.exists());
+        assertTrue(changeLogFile.isFile());
+        assertTrue(changeLogFile.getName().endsWith(".xml"));
     }
 }


### PR DESCRIPTION
- Fix wrong computation of a path from a file URL leading to unsuccessful deployment having a wrong file path for liquibase changelog
- Fix creation of missing directories
- Fix generated directory name
- Fix Unit tests generating data in user directory