### PR TITLE
TMDM-11050 Menu "Match lineage" and "Match Plan" are lost

### DIFF
--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/shared/Constants.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/shared/Constants.java
@@ -14,8 +14,12 @@ public class Constants {
     public final static int PAGE_SIZE = 20;
 
     public final static String PORTAL_CONFIG_PREFIX = "mdm_pref_"; //$NON-NLS-1$
-    
-    public static final String TDS_ACCESSTASK = "/#/accesstasks/";
-    
-    public static final String TDS_NAME = "DataStewardship";
+
+    public static final String TDS_ACCESSTASK = "/#/accesstasks/"; //$NON-NLS-1$
+
+    public static final String TDS_NAME = "DataStewardship"; //$NON-NLS-1$
+
+    public static final String HAS_MATCH_GROUP = "HAS_MATCH_GROUP"; //$NON-NLS-1$
+
+    public static final String HAS_TASK = "HAS_TASK"; //$NON-NLS-1$
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsService.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsService.java
@@ -147,7 +147,7 @@ public interface BrowseRecordsService extends RemoteService {
     String getGoldenRecordIdByGroupId(String dataClusterPK, String viewPK, String concept, String[] keys, String groupId)
             throws ServiceException;
 
-    int checkTask(String dataClusterPK, String concept, String groupId) throws ServiceException;
+    Map<String, Integer> checkTask(String dataClusterPK, String concept, String groupId) throws ServiceException;
 
     List<ItemBean> getRecords(String concept, List<String> idsList) throws ServiceException;
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsServiceAsync.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsServiceAsync.java
@@ -139,7 +139,7 @@ public interface BrowseRecordsServiceAsync {
     void getGoldenRecordIdByGroupId(String dataClusterPK, String viewPK, String concept, String[] keys, String groupId,
             AsyncCallback<String> callback);
 
-    void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Integer> callback);
+    void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Map<String, Integer>> callback);
 
     void getRecords(String concept, List<String> idsList, AsyncCallback<List<ItemBean>> callback);
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemDetailToolBar.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemDetailToolBar.java
@@ -680,8 +680,8 @@ public class ItemDetailToolBar extends ToolBar {
 
                                 @Override
                                 public void onSuccess(Map<String, Integer> result) {
-                                    int countWithoutHasTask = result.get("withoutHasTask");
-                                    int countWithHasTask = result.get("withHasTask");
+                                    int countHasMatchGroup = result.get(Constants.HAS_MATCH_GROUP);
+                                    int countHasTask = result.get(Constants.HAS_TASK);
 
                                     if (isStaging) {
                                         getBrowseRecordsService().getGoldenRecordIdByGroupId(
@@ -734,7 +734,7 @@ public class ItemDetailToolBar extends ToolBar {
                                                     }
                                                 });
                                     } else {
-                                        if (dataLineageMenuItem == null && countWithoutHasTask > 0) {
+                                        if (dataLineageMenuItem == null && countHasMatchGroup > 0) {
                                             dataLineageMenuItem = new MenuItem(MessagesFactory.getMessages().stagingRecords_btn());
                                             dataLineageMenuItem.setId("dataLineageMenuItem"); //$NON-NLS-1$
                                             dataLineageMenuItem.setItemId("dataLineageMenuItem"); //$NON-NLS-1$
@@ -759,7 +759,7 @@ public class ItemDetailToolBar extends ToolBar {
                                             subActionsMenu.add(dataLineageMenuItem);
                                         }
                                     }
-                                    if (explainMenuItem == null && countWithoutHasTask > 0) {
+                                    if (explainMenuItem == null && countHasMatchGroup > 0) {
                                         explainMenuItem = new MenuItem(MessagesFactory.getMessages().explain_button());
                                         explainMenuItem.setId("explainMenuItem"); //$NON-NLS-1$
                                         explainMenuItem.setIcon(AbstractImagePrototype.create(Icons.INSTANCE.Save()));
@@ -789,7 +789,7 @@ public class ItemDetailToolBar extends ToolBar {
                                         subActionsMenu.add(explainMenuItem);
                                     }
 
-                                    if (openTaskMenuItem == null && countWithHasTask > 1) {
+                                    if (openTaskMenuItem == null && countHasTask > 1) {
                                         openTaskMenuItem = new MenuItem(MessagesFactory.getMessages().open_task());
                                         openTaskMenuItem.setId("openTaskMenuItem"); //$NON-NLS-1$
                                         openTaskMenuItem.setIcon(AbstractImagePrototype.create(Icons.INSTANCE.openTask()));

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemDetailToolBar.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemDetailToolBar.java
@@ -676,11 +676,12 @@ public class ItemDetailToolBar extends ToolBar {
                 }
                 if (hasTaskId) {
                     getBrowseRecordsService().checkTask(BrowseRecords.getSession().getAppHeader().getStagingDataCluster(),
-                            itemBean.getConcept(), itemBean.getTaskId(), new SessionAwareAsyncCallback<Integer>() {
+                            itemBean.getConcept(), itemBean.getTaskId(), new SessionAwareAsyncCallback<Map<String, Integer>>() {
 
                                 @Override
-                                public void onSuccess(Integer result) {
-                                    int count = result.intValue();
+                                public void onSuccess(Map<String, Integer> result) {
+                                    int countWithoutHasTask = result.get("withoutHasTask");
+                                    int countWithHasTask = result.get("withHasTask");
 
                                     if (isStaging) {
                                         getBrowseRecordsService().getGoldenRecordIdByGroupId(
@@ -733,7 +734,7 @@ public class ItemDetailToolBar extends ToolBar {
                                                     }
                                                 });
                                     } else {
-                                        if (dataLineageMenuItem == null && count > 0) {
+                                        if (dataLineageMenuItem == null && countWithoutHasTask > 0) {
                                             dataLineageMenuItem = new MenuItem(MessagesFactory.getMessages().stagingRecords_btn());
                                             dataLineageMenuItem.setId("dataLineageMenuItem"); //$NON-NLS-1$
                                             dataLineageMenuItem.setItemId("dataLineageMenuItem"); //$NON-NLS-1$
@@ -758,7 +759,7 @@ public class ItemDetailToolBar extends ToolBar {
                                             subActionsMenu.add(dataLineageMenuItem);
                                         }
                                     }
-                                    if (explainMenuItem == null && count > 0) {
+                                    if (explainMenuItem == null && countWithoutHasTask > 0) {
                                         explainMenuItem = new MenuItem(MessagesFactory.getMessages().explain_button());
                                         explainMenuItem.setId("explainMenuItem"); //$NON-NLS-1$
                                         explainMenuItem.setIcon(AbstractImagePrototype.create(Icons.INSTANCE.Save()));
@@ -788,7 +789,7 @@ public class ItemDetailToolBar extends ToolBar {
                                         subActionsMenu.add(explainMenuItem);
                                     }
 
-                                    if (openTaskMenuItem == null && count > 1) {
+                                    if (openTaskMenuItem == null && countWithHasTask > 1) {
                                         openTaskMenuItem = new MenuItem(MessagesFactory.getMessages().open_task());
                                         openTaskMenuItem.setId("openTaskMenuItem"); //$NON-NLS-1$
                                         openTaskMenuItem.setIcon(AbstractImagePrototype.create(Icons.INSTANCE.openTask()));
@@ -799,7 +800,7 @@ public class ItemDetailToolBar extends ToolBar {
                                             public void componentSelected(MenuEvent menuEvent) {
                                                 if (BrowseRecords.getSession().getAppHeader().isTdsEnabled()) {
                                                     String baseUrl = BrowseRecords.getSession().getAppHeader().getTdsBaseUrl();
-                                                    UrlUtil.openSingleWindow(baseUrl + Constants.TDS_ACCESSTASK + itemBean.getTaskId(),Constants.TDS_NAME);
+                                                    UrlUtil.openSingleWindow(baseUrl + Constants.TDS_ACCESSTASK + itemBean.getTaskId(), Constants.TDS_NAME);
                                                 } else {
                                                     initDSC(itemBean.getTaskId());
                                                 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
@@ -286,12 +286,12 @@ public class LineageListPanel extends ContentPanel {
     public void refresh() {
         selectStagingGridPanel();
         browseStagingRecordService.checkTask(cluster, entityModel.getConceptName(), taskId,
-                new SessionAwareAsyncCallback<Integer>() {
+                new SessionAwareAsyncCallback<Map<String, Integer>>() {
 
                     @Override
-                    public void onSuccess(Integer result) {
+                    public void onSuccess(Map<String, Integer> result) {
                         int gridContainerHeight = LineageListPanel.this.getHeight();
-                        if (result > 1) {
+                        if (result.get("withoutHasTask") > 1) {
                             openTaskToolBar.setVisible(true);
                         } else {
                             openTaskToolBar.setVisible(false);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
@@ -291,7 +291,7 @@ public class LineageListPanel extends ContentPanel {
                     @Override
                     public void onSuccess(Map<String, Integer> result) {
                         int gridContainerHeight = LineageListPanel.this.getHeight();
-                        if (result.get("withoutHasTask") > 1) {
+                        if (result.get(Constants.HAS_TASK) > 1) {
                             openTaskToolBar.setVisible(true);
                         } else {
                             openTaskToolBar.setVisible(false);

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/MockGridRefreshGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/MockGridRefreshGWTTest.java
@@ -611,7 +611,7 @@ public class MockGridRefreshGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Integer> callback) {
+        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Map<String, Integer>> callback) {
 
         }
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsToolBarGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsToolBarGWTTest.java
@@ -445,7 +445,7 @@ public class ItemsToolBarGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Integer> callback) {
+        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Map<String, Integer>> callback) {
 
         }
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatDateFieldGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatDateFieldGWTTest.java
@@ -393,7 +393,7 @@ public class FormatDateFieldGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Integer> callback) {
+        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Map<String, Integer>> callback) {
 
         }
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/TreeDetailGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/TreeDetailGWTTest.java
@@ -1310,7 +1310,7 @@ public class TreeDetailGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Integer> callback) {
+        public void checkTask(String dataClusterPK, String concept, String groupId, AsyncCallback<Map<String, Integer>> callback) {
 
         }
 


### PR DESCRIPTION
We check source record's count to control if show **Match Lineage** and **Match Plan** and **Open Task** buttons. 
After adding new metadata field **staging_hastask**, the counting condition changed to include **staging_hastask=true**, and it caused the regression.

The fixing strategy is: get the count with **staging_hastask=true** for **Open Task** button only, and keep the old counting logic for **Match Lineage** and **Match Plan**.