### PR TITLE
TMDM-11069 : Fix unstable junit test case (RoutingEngineTest#testExpiration)

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/server/routing/ExpiredMessageListener.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/routing/ExpiredMessageListener.java
@@ -10,27 +10,23 @@
 
 package com.amalto.core.server.routing;
 
+import java.util.Arrays;
+import java.util.List;
+
+import javax.jms.Message;
+
+import org.apache.activemq.command.ActiveMQMessage;
+import org.apache.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import com.amalto.core.objects.ItemPOJOPK;
-import com.amalto.core.objects.Service;
 import com.amalto.core.objects.datacluster.DataClusterPOJOPK;
-import com.amalto.core.objects.routing.CompletedRoutingOrderV2POJO;
 import com.amalto.core.objects.routing.FailedRoutingOrderV2POJO;
 import com.amalto.core.objects.routing.RoutingRulePOJO;
 import com.amalto.core.objects.routing.RoutingRulePOJOPK;
 import com.amalto.core.server.api.RoutingRule;
 import com.amalto.core.server.security.SecurityConfig;
-import com.amalto.core.util.Util;
-import com.amalto.core.util.XtentisException;
-import org.apache.activemq.command.ActiveMQMessage;
-import org.apache.activemq.command.ProducerInfo;
-import org.apache.log4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
-import javax.jms.JMSException;
-import javax.jms.Message;
-import java.util.List;
 
 @Component
 public class ExpiredMessageListener {
@@ -41,10 +37,12 @@ public class ExpiredMessageListener {
     RoutingRule routingRules;
 
     // Called by Spring, do not remove
+    @SuppressWarnings("unchecked")
     public void consume(final Message msg) {
         try {
             ActiveMQMessage message = (ActiveMQMessage) ((ActiveMQMessage) msg).getDataStructure();
-            final List<String> rules = (List<String>) message.getObjectProperty("rules"); //$NON-NLS-1$
+            Object rulesObj = message.getObjectProperty("rules"); //$NON-NLS-1$
+            final List<String> rules = rulesObj instanceof List ? (List<String>) rulesObj : Arrays.asList(rulesObj.toString());
             final String pk = message.getStringProperty("pk"); //$NON-NLS-1$
             String type = message.getStringProperty("type"); //$NON-NLS-1$
             String container = message.getStringProperty("container"); //$NON-NLS-1$

--- a/org.talend.mdm.core/test/com/amalto/core/server/routing/RoutingEngineTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/server/routing/RoutingEngineTest.java
@@ -205,7 +205,7 @@ public class RoutingEngineTest {
         int previous = routingEngine.getConsumeCallCount();
         routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
         routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
-        Thread.sleep(1000); // Give some time to process message
+        Thread.sleep(1500); // Give some time to process message
         assertEquals(previous + 1, routingEngine.getConsumeCallCount());
         // Expired message: put 2 messages, there's only one JMS consumer, service pauses for 100 ms, and expiration
         // is 300 ms
@@ -214,7 +214,7 @@ public class RoutingEngineTest {
         previous = routingEngine.getConsumeCallCount();
         routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
         routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
-        Thread.sleep(1000); // Give some time to process messages
+        Thread.sleep(1500); // Give some time to process messages
         assertEquals(previous + 2, routingEngine.getConsumeCallCount());
         routingEngine.stop();
     }

--- a/org.talend.mdm.core/test/com/amalto/core/server/routing/RoutingEngineTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/server/routing/RoutingEngineTest.java
@@ -190,34 +190,33 @@ public class RoutingEngineTest {
         item.putItem(new ItemPOJO(container, "Person", new String[] { "1", "2" }, 0, "<Person><id>1</id><id2>2</id2></Person>"),
                 dataModel);
         // Adds a routing rule
-        TestRoutingEngine routingEngine = (TestRoutingEngine) context.getBean(RoutingEngine.class);
-        routingEngine.start();
         clearRules();
         RoutingRulePOJO rule = new RoutingRulePOJO("testTypeMatchRule");
         rule.setConcept("*");
         rule.setServiceJNDI("amalto/local/service/test/no_op_service");
         routingRule.putRoutingRule(rule);
-        // Expired message: put 2 messages, there's only one JMS consumer, service pauses for 400 ms, and expiration is
+
+        TestRoutingEngine routingEngine = (TestRoutingEngine) context.getBean(RoutingEngine.class);
+        routingEngine.start();
+        // Expired message: put 2 messages, there's only one JMS consumer, service pauses for 500 ms, and expiration is
         // 300 ms
         // -> only 1 message should be consumed.
         NoOpService.setPauseTime(500);
         int previous = routingEngine.getConsumeCallCount();
-        RoutingRulePOJOPK[] routes = routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
-        assertEquals(1, routes.length);
+        routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
         routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
         Thread.sleep(1000); // Give some time to process message
         assertEquals(previous + 1, routingEngine.getConsumeCallCount());
-        // Expired message: put 2 messages, there's only one JMS consumer, service pauses for *200* ms, and expiration
+        // Expired message: put 2 messages, there's only one JMS consumer, service pauses for 100 ms, and expiration
         // is 300 ms
         // -> only 2 message should be consumed.
-        NoOpService.setPauseTime(200);
+        NoOpService.setPauseTime(100);
         previous = routingEngine.getConsumeCallCount();
-        routes = routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
-        Thread.sleep(1000); // Give some time to process messages
-        assertEquals(1, routes.length);
+        routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
         routingEngine.route(new ItemPOJOPK(container, "Person", new String[] { "1", "2" }));
         Thread.sleep(1000); // Give some time to process messages
         assertEquals(previous + 2, routingEngine.getConsumeCallCount());
+        routingEngine.stop();
     }
 
     @Test


### PR DESCRIPTION
1, When message expired, the ` message.getObjectProperty("rules")` may got `String`, so we will meet exception as bellow:
```
Caused by: java.lang.ClassCastException: java.lang.String cannot be cast to java.util.List
	at com.amalto.core.server.routing.ExpiredMessageListener.consume(ExpiredMessageListener.java:47)
	... 16 more
```
2, If sending time is too long, and consuming time is too short, the second message may not be expired after consumed the first message, so we need to adjust the service's pause time to make sure the second expired.
3, We should avoid sleep 1000 ms between route the first and second messages, else the service's pause time won't take effect, because the there is only one message in the queue at the same time, and we can't test the case of setting pause time to 200 ms indeed.