### PR TITLE
TMDM-11262 : Full text search could not return result when data records contains multi occurrence fields

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
@@ -379,7 +379,14 @@ class FullTextQueryHandler extends AbstractQueryHandler {
     }
 
     private static Object getReferencedId(DataRecord next, ReferenceFieldMetadata field) {
-        DataRecord record = (DataRecord) next.get(field);
+        DataRecord record;
+        Object recordObject = next.get(field);
+        if (recordObject != null && recordObject instanceof List) {
+            record = (DataRecord)((List<Object>)recordObject).get(0);
+        } else {
+            record = (DataRecord) next.get(field);
+        }
+        
         if (record != null) {
             Collection<FieldMetadata> keyFields = record.getType().getKeyFields();
             if (keyFields.size() == 1) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
@@ -382,9 +382,13 @@ class FullTextQueryHandler extends AbstractQueryHandler {
         DataRecord record;
         Object recordObject = next.get(field);
         if (recordObject != null && recordObject instanceof List) {
-            record = (DataRecord)((List<Object>)recordObject).get(0);
+            if (((List<Object>)recordObject).size() > 0) {
+                record = (DataRecord)((List<Object>)recordObject).get(0);
+            } else {
+                return null;
+            }
         } else {
-            record = (DataRecord) next.get(field);
+            record = (DataRecord)recordObject;
         }
         
         if (record != null) {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -1649,7 +1649,7 @@ public class StorageFullTextTest extends StorageTestCase {
         }
     }
     
-    public void testFullTextSearchResultContainsMultiOccurReferanceFields() throws Exception {
+    public void testFullTextSearchResultContainsMultiOccurReferenceFields() throws Exception {
         UserQueryBuilder qb = from(product).select(product.getField("Name")).select(product.getField("Supplier")).where(fullText("car"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -1649,6 +1649,20 @@ public class StorageFullTextTest extends StorageTestCase {
         }
     }
     
+    public void testFullTextSearchResultContainsMultiOccurReferanceFields() throws Exception {
+        UserQueryBuilder qb = from(product).select(product.getField("Name")).select(product.getField("Supplier")).where(fullText("car"));
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(1, results.getCount());
+            for (DataRecord result : results) {
+                assertEquals("Renault car", (String)result.get("Name"));
+                assertEquals("2", ((List)result.get("Supplier")).get(0));
+            }
+        } finally {
+            results.close();
+        }
+    }
+    
     public void testFullTextSearchOnComplexType() throws Exception {
         UserQueryBuilder qb = from(persons).where(fullText("1"));
         qb.limit(5);


### PR DESCRIPTION
What is the current behavior? (You can also link to an open issue here)
https://jira.talendforge.org/browse/TMDM-11262
Full text search could not return result when data records contains multi occurrence reference fields.

What is the new behavior?
Don't display error message when do full text search result contains multi occurrence reference fields.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: