### PR TITLE
TMDM-9734 : fix Multi-Occur reference fields display '[null]' when dofulltext search

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -106,6 +106,13 @@ public class StorageFullTextTest extends StorageTestCase {
                 + "            <Color>Klein blue2</Color>\n" + "        </Colors>\n" + "    </Features>\n"
                 + "    <Family>[1]</Family>\n" + "    <Status>Pending</Status>\n" + "    <Supplier>[2]</Supplier>\n"
                 + "    <Supplier>[1]</Supplier>\n" + "</Product>"));
+        allRecords.add(factory.read(repository, product, "<Product>\n" + "    <Id>3</Id>\n" + "    <Name>kevin cui</Name>\n"
+                + "    <ShortDescription>A person</ShortDescription>\n"
+                + "    <LongDescription>Long description 3</LongDescription>\n" + "    <Price>100</Price>\n" + "    <Features>\n"
+                + "        <Sizes>\n" + "            <Size>Large</Size>\n" + "        <Size>Large</Size></Sizes>\n"
+                + "        <Colors>\n" + "            <Color>Blue 3</Color>\n" + "            <Color>Blue 4</Color>\n"
+                + "            <Color>Kevin blue3</Color>\n" + "        </Colors>\n" + "    </Features>\n"
+                + "    <Family></Family>\n" + "    <Status>Pending</Status>\n" + "</Product>"));
         allRecords.add(factory.read(repository, supplier, "<Supplier>\n" + "    <Id>1</Id>\n"
                 + "    <SupplierName>Renault</SupplierName>\n" + "    <Contact>" + "        <Name>Jean Voiture</Name>\n"
                 + "        <Phone>33123456789</Phone>\n" + "        <Email>test@test.org</Email>\n" + "    </Contact>\n"
@@ -383,7 +390,7 @@ public class StorageFullTextTest extends StorageTestCase {
             for (DataRecord result : results) {
                 LOG.info("result = " + result);
             }
-            assertEquals(2, results.getCount());
+            assertEquals(3, results.getCount());
         } finally {
             results.close();
         }
@@ -553,7 +560,7 @@ public class StorageFullTextTest extends StorageTestCase {
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getCount());
+            assertEquals(3, results.getCount());
         } finally {
             results.close();
         }
@@ -618,12 +625,12 @@ public class StorageFullTextTest extends StorageTestCase {
         UserQueryBuilder qb = from(supplier).and(product).where(fullText("*"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(6, results.getCount());
+            assertEquals(7, results.getCount());
             int actualCount = 0;
             for (DataRecord result : results) {
                 actualCount++;
             }
-            assertEquals(6, actualCount);
+            assertEquals(7, actualCount);
         } finally {
             results.close();
         }
@@ -631,12 +638,12 @@ public class StorageFullTextTest extends StorageTestCase {
         qb = from(supplier).and(product).where(fullText("**"));
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(6, results.getCount());
+            assertEquals(7, results.getCount());
             int actualCount = 0;
             for (DataRecord result : results) {
                 actualCount++;
             }
-            assertEquals(6, actualCount);
+            assertEquals(7, actualCount);
         } finally {
             results.close();
         }
@@ -662,7 +669,7 @@ public class StorageFullTextTest extends StorageTestCase {
         qb = from(supplier).and(product).where(fullText("     "));
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(6, results.getCount());
+            assertEquals(7, results.getCount());
         } finally {
             results.close();
         }
@@ -1471,7 +1478,7 @@ public class StorageFullTextTest extends StorageTestCase {
 
         qb = from(product).where(contains(product.getField("Features/Sizes/Size"), "large"));
         results = storage.fetch(qb.getSelect());
-        assertEquals(2, results.getCount());
+        assertEquals(3, results.getCount());
     }
 
     public void testContainsWithReservedCharacters() throws Exception {
@@ -1657,6 +1664,18 @@ public class StorageFullTextTest extends StorageTestCase {
             for (DataRecord result : results) {
                 assertEquals("Renault car", (String)result.get("Name"));
                 assertEquals("2", ((List)result.get("Supplier")).get(0));
+            }
+        } finally {
+            results.close();
+        }
+        
+        qb = from(product).select(product.getField("Name")).select(product.getField("Supplier")).where(fullText("kevin"));
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(1, results.getCount());
+            for (DataRecord result : results) {
+                assertEquals("kevin cui", (String)result.get("Name"));
+                assertNull(result.get("Supplier"));
             }
         } finally {
             results.close();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -83,51 +83,17 @@ public class StorageFullTextTest extends StorageTestCase {
         }
         DataRecordReader<String> factory = new XmlStringDataRecordReader();
         List<DataRecord> allRecords = new LinkedList<DataRecord>();
-        allRecords.add(factory.read(repository, productFamily, "<ProductFamily>\n" + "    <Id>1</Id>\n"
-                + "    <Name>ProductFamily1</Name>\n" + "</ProductFamily>"));
-        allRecords.add(factory.read(repository, productFamily, "<ProductFamily>\n" + "    <Id>2</Id>\n"
-                + "    <Name>ProductFamily2</Name>\n" + "</ProductFamily>"));
-        allRecords.add(factory.read(repository, productFamily, "<ProductFamily>\n" + "    <Id>3</Id>\n"
-                + "    <Name>ProductFamily3</Name>\n" + "</ProductFamily>"));
-        allRecords.add(factory.read(repository, productFamily, "<ProductFamily>\n" + "    <Id>4</Id>\n"
-                + "    <Name>test_name4</Name>\n" + "</ProductFamily>"));
-        allRecords.add(factory.read(repository, product, "<Product>\n" + "    <Id>1</Id>\n" + "    <Name>talend</Name>\n"
-                + "    <ShortDescription>Short description word</ShortDescription>\n"
-                + "    <LongDescription>Long description</LongDescription>\n" + "    <Price>10</Price>\n" + "    <Features>\n"
-                + "        <Sizes>\n" + "            <Size>Small</Size>\n" + "            <Size>Medium</Size>\n"
-                + "            <Size>Large</Size>\n" + "        </Sizes>\n" + "        <Colors>\n"
-                + "            <Color>Blue</Color>\n" + "            <Color>Red</Color>\n" + "        </Colors>\n"
-                + "    </Features>\n" + "    <Status>Pending</Status>\n" + "    <Supplier>[1]</Supplier>\n" + "</Product>"));
-        allRecords.add(factory.read(repository, product, "<Product>\n" + "    <Id>2</Id>\n" + "    <Name>Renault car</Name>\n"
-                + "    <ShortDescription>A car</ShortDescription>\n"
-                + "    <LongDescription>Long description 2</LongDescription>\n" + "    <Price>10</Price>\n" + "    <Features>\n"
-                + "        <Sizes>\n" + "            <Size>Large</Size>\n" + "        <Size>Large</Size></Sizes>\n"
-                + "        <Colors>\n" + "            <Color>Blue 2</Color>\n" + "            <Color>Blue 1</Color>\n"
-                + "            <Color>Klein blue2</Color>\n" + "        </Colors>\n" + "    </Features>\n"
-                + "    <Family>[1]</Family>\n" + "    <Status>Pending</Status>\n" + "    <Supplier>[2]</Supplier>\n"
-                + "    <Supplier>[1]</Supplier>\n" + "</Product>"));
-        allRecords.add(factory.read(repository, product, "<Product>\n" + "    <Id>3</Id>\n" + "    <Name>kevin cui</Name>\n"
-                + "    <ShortDescription>A person</ShortDescription>\n"
-                + "    <LongDescription>Long description 3</LongDescription>\n" + "    <Price>100</Price>\n" + "    <Features>\n"
-                + "        <Sizes>\n" + "            <Size>Large</Size>\n" + "        <Size>Large</Size></Sizes>\n"
-                + "        <Colors>\n" + "            <Color>Blue 3</Color>\n" + "            <Color>Blue 4</Color>\n"
-                + "            <Color>Kevin blue3</Color>\n" + "        </Colors>\n" + "    </Features>\n"
-                + "    <Family></Family>\n" + "    <Status>Pending</Status>\n" + "</Product>"));
-        allRecords.add(factory.read(repository, supplier, "<Supplier>\n" + "    <Id>1</Id>\n"
-                + "    <SupplierName>Renault</SupplierName>\n" + "    <Contact>" + "        <Name>Jean Voiture</Name>\n"
-                + "        <Phone>33123456789</Phone>\n" + "        <Email>test@test.org</Email>\n" + "    </Contact>\n"
-                + "</Supplier>"));
-        allRecords.add(factory.read(repository, supplier, "<Supplier>\n" + "    <Id>2</Id>\n"
-                + "    <SupplierName>Starbucks Talend</SupplierName>\n" + "    <Contact>" + "        <Name>Jean Cafe</Name>\n"
-                + "        <Phone>33234567890</Phone>\n" + "        <Email>test@testfactory.org</Email>\n" + "    </Contact>\n"
-                + "</Supplier>"));
-        allRecords.add(factory.read(repository, supplier, "<Supplier>\n" + "    <Id>3</Id>\n"
-                + "    <SupplierName>Talend</SupplierName>\n" + "    <Contact>" + "        <Name>Jean Paul</Name>\n"
-                + "        <Phone>33234567890</Phone>\n" + "        <Email>test@talend.com</Email>\n" + "    </Contact>\n"
-                + "</Supplier>"));
-        allRecords.add(factory.read(repository, supplier, "<Supplier>\n" + "    <Id>4</Id>\n"
-                + "    <SupplierName>IdSoftware</SupplierName>\n" + "    <Contact>" + "        <Name>John Carmack</Name>\n"
-                + "        <Phone>123456789</Phone>\n" + "        <Email></Email>\n" + "    </Contact>\n" + "</Supplier>"));
+        allRecords.add(factory.read(repository, productFamily, "<ProductFamily><Id>1</Id><Name>ProductFamily1</Name></ProductFamily>"));
+        allRecords.add(factory.read(repository, productFamily, "<ProductFamily><Id>2</Id><Name>ProductFamily2</Name></ProductFamily>"));
+        allRecords.add(factory.read(repository, productFamily, "<ProductFamily><Id>3</Id><Name>ProductFamily3</Name></ProductFamily>"));
+        allRecords.add(factory.read(repository, productFamily, "<ProductFamily><Id>4</Id><Name>test_name4</Name></ProductFamily>"));
+        allRecords.add(factory.read(repository, product, "<Product><Id>1</Id><Name>talend</Name><ShortDescription>Short description word</ShortDescription><LongDescription>Long description</LongDescription><Price>10</Price><Features><Sizes><Size>Small</Size><Size>Medium</Size><Size>Large</Size></Sizes><Colors><Color>Blue</Color><Color>Red</Color></Colors></Features><Status>Pending</Status><Supplier>[1]</Supplier></Product>"));
+        allRecords.add(factory.read(repository, product, "<Product><Id>2</Id><Name>Renault car</Name><ShortDescription>A car</ShortDescription><LongDescription>Long description 2</LongDescription><Price>10</Price><Features><Sizes><Size>Large</Size><Size>Large</Size></Sizes><Colors><Color>Blue 2</Color><Color>Blue 1</Color><Color>Klein blue2</Color></Colors></Features><Family>[1]</Family><Status>Pending</Status><Supplier>[2]</Supplier><Supplier>[1]</Supplier></Product>"));
+        allRecords.add(factory.read(repository, product, "<Product><Id>3</Id><Name>kevin cui</Name><ShortDescription>A person</ShortDescription><LongDescription>Long description 3</LongDescription><Price>100</Price><Features><Sizes><Size>Large</Size><Size>Large</Size></Sizes><Colors><Color>Blue 3</Color><Color>Blue 4</Color><Color>Kevin blue3</Color></Colors></Features><Family></Family><Status>Pending</Status></Product>"));
+        allRecords.add(factory.read(repository, supplier, "<Supplier><Id>1</Id><SupplierName>Renault</SupplierName><Contact><Name>Jean Voiture</Name><Phone>33123456789</Phone><Email>test@test.org</Email></Contact></Supplier>"));
+        allRecords.add(factory.read(repository, supplier, "<Supplier><Id>2</Id><SupplierName>Starbucks Talend</SupplierName><Contact><Name>Jean Cafe</Name><Phone>33234567890</Phone><Email>test@testfactory.org</Email></Contact></Supplier>"));
+        allRecords.add(factory.read(repository, supplier, "<Supplier><Id>3</Id><SupplierName>Talend</SupplierName><Contact><Name>Jean Paul</Name><Phone>33234567890</Phone><Email>test@talend.com</Email></Contact></Supplier>"));
+        allRecords.add(factory.read(repository, supplier, "<Supplier><Id>4</Id><SupplierName>IdSoftware</SupplierName><Contact><Name>John Carmack</Name><Phone>123456789</Phone><Email></Email></Contact></Supplier>"));
 
         allRecords
                 .add(factory

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
@@ -257,14 +257,18 @@ public class DataRecord {
             List list = (List) fieldToValue.get(field);
             // fields that may contain data records.
             if (field instanceof ReferenceFieldMetadata || field instanceof ContainedTypeFieldMetadata) {
-                if (list == null) {
-                    list = new LinkedList();
-                    fieldToValue.put(field, list);
-                }
-                if (o instanceof Collection) {
-                    list.addAll((Collection) o);
+                if (o != null) {
+                    if (list == null) {
+                        list = new LinkedList();
+                        fieldToValue.put(field, list);
+                    }
+                    if (o instanceof Collection) {
+                        list.addAll((Collection) o);
+                    } else {
+                        list.add(o);
+                    }
                 } else {
-                    list.add(o);
+                    fieldToValue.put(field, o);
                 }
             } else {
                 if (list == null && o instanceof List) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
For Product/Family 0-many full text search return [null] element.

**What is the new behavior?**
It should return empty element.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
