### PR TITLE
TMDM-10860 Not a Correct value in Journal events "oldvalue"

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/DataRecordAccessor.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/DataRecordAccessor.java
@@ -409,6 +409,10 @@ public class DataRecordAccessor implements Accessor {
                         if (value instanceof DataRecord) {
                             current = (DataRecord) value;
                         }
+                    // We can't get sub element value of ReferenceFieldMetadata,like Product/Family/Name.Because we can't use path Product/Family/Name to retrieve value from Product document.
+                    } else if (field instanceof ReferenceFieldMetadata && tokenizer.hasMoreElements()) {
+                        cachedExist = false;
+                        return false;
                     }
                 }
             }

--- a/org.talend.mdm.core/test/com/amalto/core/history/accessor/record/DataRecordAccessorTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/accessor/record/DataRecordAccessorTest.java
@@ -9,7 +9,7 @@
  */
 package com.amalto.core.history.accessor.record;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -50,6 +50,11 @@ public class DataRecordAccessorTest extends DataRecordDataWriterTestCase{
 
         setDataRecordField(record, "supplier", referenced);
         DataRecordAccessor dataRecordAccessor = new DataRecordAccessor(repository, record, "supplier");
+        assertEquals(true, dataRecordAccessor.exist());
         assertEquals("PartyCompany", dataRecordAccessor.getActualType());
+        
+        setDataRecordField(record, "supplier", referenced);
+        dataRecordAccessor = new DataRecordAccessor(repository, record, "supplier/name");
+        assertEquals(false, dataRecordAccessor.exist());
     }
 }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Use path "PartyProduct/supplier/name" to retrieve value.The path PartyProduct/supplier/name is existed in entity PartyProduct now,because PartyProduct has name element and is same with element of referenced entity PartyCompany. The check logic has a issue.


**What is the new behavior?**
We shouldn't Use path "PartyProduct/supplier/name" to retrieve value,because element PartyProduct/supplier reference entity PartyCompany,we can't get sub element value of PartyCompany from PartyProduct document.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
