### PR TITLE
TMDM-10563 page info is incorrect use fulltext search when records count greater than page size (#209)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
@@ -286,7 +286,7 @@ class FullTextQueryHandler extends AbstractQueryHandler {
                 }
             };
         }
-        return new FullTextStorageResults(pageSize, list.size(), iterator);
+        return new FullTextStorageResults(pageSize, query.getResultSize(), iterator);
     }
 
     private StorageResults createResults(ScrollableResults scrollableResults) {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -526,7 +526,8 @@ public class StorageFullTextTest extends StorageTestCase {
         qb.limit(2);
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getCount());
+            assertEquals(3, results.getCount());
+            assertEquals(2, results.getSize());
         } finally {
             results.close();
         }
@@ -542,7 +543,8 @@ public class StorageFullTextTest extends StorageTestCase {
         qb.limit(2);
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getCount());
+            assertEquals(4, results.getCount());
+            assertEquals(2, results.getSize());
         } finally {
             results.close();
         }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
When used full text search,  if the result is larger than page size, the page info is incorrect.


**What is the new behavior?**
Modify the page info when use the full text earch.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
