### PR TITLE
TMDM-11351: fix incorrect search with multiple filters when one of the filters is ‘Empty or Null’ condition

### DIFF
--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/ForeignKeyHelper.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/ForeignKeyHelper.java
@@ -45,6 +45,7 @@ import org.talend.mdm.webapp.base.client.util.MultilanguageMessageParser;
 import org.talend.mdm.webapp.base.server.util.CommonUtil;
 import org.talend.mdm.webapp.base.server.util.Constants;
 import org.talend.mdm.webapp.base.shared.EntityModel;
+import org.talend.mdm.webapp.base.shared.OperatorValueConstants;
 import org.talend.mdm.webapp.base.shared.TypeModel;
 import org.talend.mdm.webapp.base.shared.XpathUtil;
 import org.w3c.dom.Element;
@@ -613,6 +614,10 @@ public class ForeignKeyHelper {
                 Map<String, String> conditionMap = org.talend.mdm.webapp.base.shared.util.CommonUtil
                         .buildConditionByCriteria(cria);
                 String value = conditionMap.get("Value"); //$NON-NLS-1$
+                if (OperatorValueConstants.EMPTY_NULL.equals(conditionMap.get("Operator"))) { //$NON-NLS-1$
+                    conditions.add(conditionMap);
+                    continue;
+                }
                 value = StringEscapeUtils.unescapeXml(value);
                 value = parseRightValueOrPath(xml, dataObject, value, currentXpath);
                 if (isFkPath(conditionMap.get("Xpath"))) { //$NON-NLS-1$

--- a/org.talend.mdm.webapp.base/src/test/java/org/talend/mdm/webapp/base/server/ForeignKeyHelperTest.java
+++ b/org.talend.mdm.webapp.base/src/test/java/org/talend/mdm/webapp/base/server/ForeignKeyHelperTest.java
@@ -229,7 +229,7 @@ public class ForeignKeyHelperTest extends TestCase {
         currentXpath = "Product/Type";
         model.setForeignKeyFilter("ProductType/Type/@xsi:type$$=$$ProductTypeOne$$#");
         foreignKeyFilter = ForeignKeyHelper.getForeignKeyFilter(ifFKFilter, currentXpath.split("/")[0], xml, currentXpath, model); //$NON-NLS-1$
-        model.setForeignkey("ProductFamily/Id");
+        model.setForeignkey("ProductType/Id");
         model.getForeignKeyInfo().clear();
         result = ForeignKeyHelper.getForeignKeyHolder(model, foreignKeyFilter);
         whereItem = result.whereItem;
@@ -279,6 +279,7 @@ public class ForeignKeyHelperTest extends TestCase {
         model.setForeignKeyFilter("ProductFamily/Id$$=$$\"[3]\"$$#");
         xml = "<Product><id>1</id><Name>Shirts</Name><Family>[3]</Family></Product>";
         model.getForeignKeyInfo().clear();
+        model.setForeignkey("ProductFamily/Id"); //$NON-NLS-1$
         foreignKeyFilter = ForeignKeyHelper.getForeignKeyFilter(ifFKFilter, currentXpath.split("/")[0], xml, currentXpath, model); //$NON-NLS-1$
         model.setFilterValue("");
         result = ForeignKeyHelper.getForeignKeyHolder(model, foreignKeyFilter);
@@ -318,6 +319,45 @@ public class ForeignKeyHelperTest extends TestCase {
         assertEquals(WSWhereOperator.CONTAINS, condition1.getOperator());
         assertEquals("1", condition1.getRightValueOrPath());
 
+        // 12. two filter, one is Empty or null
+        ifFKFilter = true;
+        model.setForeignKeyFilter("ProductFamily/Name$$=$$Product/Name$$Or#ProductFamily/ChangeStatus$$Is Empty Or Null$$$$#");
+        xml = "<Product><id>1</id><Name>Shirts</Name><Family>[3]</Family></Product>";
+        foreignKeyFilter = ForeignKeyHelper.getForeignKeyFilter(ifFKFilter, currentXpath.split("/")[0], xml, currentXpath, model); //$NON-NLS-1$
+        model.getForeignKeyInfo().clear();
+        model.setFilterValue("");
+        result = ForeignKeyHelper.getForeignKeyHolder(model, foreignKeyFilter);
+        whereItem = result.whereItem;
+        condition1 = whereItem.getWhereCondition();
+        assertNull(condition1);
+        assertNull(whereItem.getWhereAnd());
+        assertNotNull(whereItem.getWhereOr());
+        assertEquals("ProductFamily/Name", whereItem.getWhereOr().getWhereItems()[0].getWhereCondition().getLeftPath()); //$NON-NLS-1$
+        assertEquals(WSWhereOperator.EQUALS, whereItem.getWhereOr().getWhereItems()[0].getWhereCondition().getOperator());
+        assertEquals("Shirts", whereItem.getWhereOr().getWhereItems()[0].getWhereCondition().getRightValueOrPath()); //$NON-NLS-1$
+        assertEquals("ProductFamily/ChangeStatus", whereItem.getWhereOr().getWhereItems()[1].getWhereCondition().getLeftPath()); //$NON-NLS-1$
+        assertEquals(WSWhereOperator.EMPTY_NULL, whereItem.getWhereOr().getWhereItems()[1].getWhereCondition().getOperator());
+        assertNull(whereItem.getWhereOr().getWhereItems()[1].getWhereCondition().getRightValueOrPath()); // $NON-NLS-1$
+
+        // 13. two filter, one filter xpath=Product/Name and operation is Empty or null
+        ifFKFilter = true;
+        model.setForeignKeyFilter("ProductFamily/Name$$=$$Product/Name$$Or#Product/Name$$Is Empty Or Null$$$$#");
+        xml = "<Product><id>1</id><Name>Shirts</Name><Family>[3]</Family></Product>";
+        foreignKeyFilter = ForeignKeyHelper.getForeignKeyFilter(ifFKFilter, currentXpath.split("/")[0], xml, currentXpath, model); //$NON-NLS-1$
+        model.getForeignKeyInfo().clear();
+        model.setFilterValue("");
+        result = ForeignKeyHelper.getForeignKeyHolder(model, foreignKeyFilter);
+        whereItem = result.whereItem;
+        condition1 = whereItem.getWhereCondition();
+        assertNull(condition1);
+        assertNull(whereItem.getWhereAnd());
+        assertNotNull(whereItem.getWhereOr());
+        assertEquals("ProductFamily/Name", whereItem.getWhereOr().getWhereItems()[0].getWhereCondition().getLeftPath()); //$NON-NLS-1$
+        assertEquals(WSWhereOperator.EQUALS, whereItem.getWhereOr().getWhereItems()[0].getWhereCondition().getOperator());
+        assertEquals("Shirts", whereItem.getWhereOr().getWhereItems()[0].getWhereCondition().getRightValueOrPath()); //$NON-NLS-1$
+        assertEquals("Product/Name", whereItem.getWhereOr().getWhereItems()[1].getWhereCondition().getLeftPath()); //$NON-NLS-1$
+        assertEquals(WSWhereOperator.EMPTY_NULL, whereItem.getWhereOr().getWhereItems()[1].getWhereCondition().getOperator());
+        assertNull(whereItem.getWhereOr().getWhereItems()[1].getWhereCondition().getRightValueOrPath()); // $NON-NLS-1$
     }
 
     // TMDM-9417 Polymorphism Entity / Foreign Key / label issue

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeySelector.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeySelector.java
@@ -215,7 +215,8 @@ public class ForeignKeySelector extends ForeignKeyField implements ReturnCriteri
                 Map<String, String> conditionMap = org.talend.mdm.webapp.base.shared.util.CommonUtil
                         .buildConditionByCriteria(cria);
                 if (OperatorValueConstants.EMPTY_NULL.equals(conditionMap.get("Operator"))) { //$NON-NLS-1$
-                    return foreignKeyFilter;
+                    conditions.add(conditionMap);
+                    continue;
                 }
                 String filterValue = conditionMap.get("Value"); //$NON-NLS-1$
                 if (filterValue == null || this.foreignKeyPath == null) {

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/foreignkey/ForeignKeySelectorGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/foreignkey/ForeignKeySelectorGWTTest.java
@@ -133,10 +133,10 @@ public class ForeignKeySelectorGWTTest extends GWTTestCase {
         assertEquals("ProductFamily/ChangeStatus$$Is Empty Or Null$$123456$$#", foreignKeySelector.parseForeignKeyFilter()); //$NON-NLS-1$
 
         subelementType
-                .setForeignKeyFilter("ProductFamily/ChangeStatus$$Is Empty Or Null$$ProductFamily/Name$$=$$Product/Name$$#"); //$NON-NLS-1$
+                .setForeignKeyFilter("ProductFamily/ChangeStatus$$Is Empty Or Null$$Or#ProductFamily/Name$$=$$Product/Name$$#"); //$NON-NLS-1$
         foreignKeySelector = new ForeignKeySelector(subelementType, itemsDetailPanel, family);
         assertEquals(
-                "ProductFamily/ChangeStatus$$Is Empty Or Null$$ProductFamily/Name$$=$$Product/Name$$#", foreignKeySelector.parseForeignKeyFilter()); //$NON-NLS-1$
+                "ProductFamily/ChangeStatus$$Is Empty Or Null$$Or$$#ProductFamily/Name$$=$$talend$$#", foreignKeySelector.parseForeignKeyFilter()); //$NON-NLS-1$
 
         // test Person datamodel
         ItemNodeModel person = new ItemNodeModel();

--- a/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
+++ b/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
@@ -9,6 +9,7 @@
  */
 package com.amalto.webapp.core.util;
 
+import com.amalto.core.webservice.WSWhereItem;
 import junit.framework.TestCase;
 
 import org.codehaus.jettison.json.JSONArray;
@@ -108,6 +109,46 @@ public class UtilTest extends TestCase {
         assertEquals(WSWhereOperator.EMPTY_NULL, whereCondition.getOperator());
         assertEquals("", whereCondition.getRightValueOrPath());
         assertEquals(WSStringPredicate.NOT, whereCondition.getStringPredicate());
+    }
+
+    public void testGetConditionFromFKFilter() {
+        String fkFilter = "ProductFamily/ChangeStatus$$=$$1$$Or#Product/Name$$Is Empty Or Null$$$$#";
+
+        WSWhereItem  whereItem = Util.getConditionFromFKFilter(foreignKey, foreignKeyInfo, fkFilter, false);
+        assertNull(whereItem.getWhereCondition());
+        assertNotNull(whereItem.getWhereOr());
+        assertEquals(2, whereItem.getWhereOr().getWhereItems().length);
+
+        WSWhereItem whereItem1 = whereItem.getWhereOr().getWhereItems()[0];
+        assertNotNull(whereItem1.getWhereCondition());
+        assertEquals("ProductFamily/ChangeStatus", whereItem1.getWhereCondition().getLeftPath());
+        assertEquals("EQUALS", whereItem1.getWhereCondition().getOperator().name());
+        assertEquals("1", whereItem1.getWhereCondition().getRightValueOrPath());
+
+        WSWhereItem whereItem2 = whereItem.getWhereOr().getWhereItems()[1];
+        assertNotNull(whereItem2.getWhereCondition());
+        assertEquals("Product/Name", whereItem2.getWhereCondition().getLeftPath());
+        assertEquals("EMPTY_NULL", whereItem2.getWhereCondition().getOperator().name());
+        assertNull(whereItem2.getWhereCondition().getRightValueOrPath());
+
+        fkFilter = "ProductFamily/ChangeStatus$$=$$1$$Or#ProductFamily/Name$$Is Empty Or Null$$$$#";
+
+        whereItem = Util.getConditionFromFKFilter(foreignKey, foreignKeyInfo, fkFilter, false);
+        assertNull(whereItem.getWhereCondition());
+        assertNotNull(whereItem.getWhereOr());
+        assertEquals(2, whereItem.getWhereOr().getWhereItems().length);
+
+        whereItem1 = whereItem.getWhereOr().getWhereItems()[0];
+        assertNotNull(whereItem1.getWhereCondition());
+        assertEquals("ProductFamily/ChangeStatus", whereItem1.getWhereCondition().getLeftPath());
+        assertEquals("EQUALS", whereItem1.getWhereCondition().getOperator().name());
+        assertEquals("1", whereItem1.getWhereCondition().getRightValueOrPath());
+
+        whereItem2 = whereItem.getWhereOr().getWhereItems()[1];
+        assertNotNull(whereItem2.getWhereCondition());
+        assertEquals("ProductFamily/Name", whereItem2.getWhereCondition().getLeftPath());
+        assertEquals("EMPTY_NULL", whereItem2.getWhereCondition().getOperator().name());
+        assertNull(whereItem2.getWhereCondition().getRightValueOrPath());
     }
 
     private JSONArray parsingForeignKeyQueryResults(String[] results, boolean isQueryFkList) throws Exception {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
if your search has multiple filters, and one of the filters is an ‘Empty or Null’ condition, issued query is not correct.


**What is the new behavior?**
if your search has multiple filters, and one of the filters is an ‘Empty or Null’ condition, issued query is now performing correctly with all filters taken into account.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
