### PR TITLE
TMDM-10734 : Java NPE when foreign key filter is set to "Is empty or is null" with predicat NOT

### DIFF
--- a/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
+++ b/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
@@ -319,6 +319,8 @@ public abstract class Util {
                 operator = WSWhereOperator.NOT_EQUALS;
             } else if (values[1].equals("Starts With")) {
                 operator = WSWhereOperator.STARTSWITH;
+            } else if (values[1].equals(WhereCondition.EMPTY_NULL)) {
+                operator = WSWhereOperator.EMPTY_NULL;
             }
             wc.setOperator(operator);
             if (values[2] != null && values[2].matches("^\".*\"$")) {

--- a/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
+++ b/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
@@ -104,6 +104,13 @@ public class UtilTest extends TestCase {
         assertEquals(WSWhereOperator.EMPTY_NULL, whereCondition.getOperator());
         assertNull(whereCondition.getRightValueOrPath());
         assertEquals(WSStringPredicate.NONE, whereCondition.getStringPredicate());
+        
+        String[] values1 = { "ProductFamily/Name", "Is Empty Or Null", "", "Not" };
+        whereCondition = Util.convertLine(values1);
+        assertEquals("ProductFamily/Name", whereCondition.getLeftPath());
+        assertEquals(WSWhereOperator.EMPTY_NULL, whereCondition.getOperator());
+        assertEquals("", whereCondition.getRightValueOrPath());
+        assertEquals(WSStringPredicate.NOT, whereCondition.getStringPredicate());
     }
 
     private JSONArray parsingForeignKeyQueryResults(String[] results, boolean isQueryFkList) throws Exception {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
 foreign key filter is set to "Is empty or is null" with predicat NOT


**What is the new behavior?**
set "Is empty or is null" to operation and let the foreign work


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
