### PR TITLE
TMDM-11384 : fulltext indexing doesn't work if some entity has compound key

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ClassCreator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ClassCreator.java
@@ -151,6 +151,7 @@ class ClassCreator extends DefaultMetadataVisitor<Void> {
             Collection<FieldMetadata> keyFields = complexType.getKeyFields();
             // Composite id class.
             if (keyFields.size() > 1) {
+                LOGGER.warn("Ignoring indexation for '" + complexType.getName() + "' due to composite key");  //$NON-NLS-1$//$NON-NLS-2$
                 String idClassName = getClassName(typeName) + "_ID"; //$NON-NLS-1$
                 CtClass newIdClass = classPool.makeClass(idClassName);
                 newIdClass.setInterfaces(new CtClass[] { serializable });

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ClassCreator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ClassCreator.java
@@ -148,13 +148,6 @@ class ClassCreator extends DefaultMetadataVisitor<Void> {
                 }
             }
 
-            // Mark new class as indexed for Hibernate search (full text) extensions.
-            ConstPool cp = classFile.getConstPool();
-            AnnotationsAttribute annotationsAttribute = new AnnotationsAttribute(cp, AnnotationsAttribute.visibleTag);
-            Annotation indexedAnnotation = new Annotation(Indexed.class.getName(), cp);
-            annotationsAttribute.setAnnotation(indexedAnnotation);
-            classFile.addAttribute(annotationsAttribute);
-
             Collection<FieldMetadata> keyFields = complexType.getKeyFields();
             // Composite id class.
             if (keyFields.size() > 1) {
@@ -208,6 +201,13 @@ class ClassCreator extends DefaultMetadataVisitor<Void> {
 
                 Class<? extends Wrapper> compiledNewClassId = classCreationStack.pop().toClass();
                 storageClassLoader.register(idClassName, compiledNewClassId);
+            } else {
+                // Mark new class as indexed for Hibernate search (full text) extensions.
+                ConstPool cp = classFile.getConstPool();
+                AnnotationsAttribute annotationsAttribute = new AnnotationsAttribute(cp, AnnotationsAttribute.visibleTag);
+                Annotation indexedAnnotation = new Annotation(Indexed.class.getName(), cp);
+                annotationsAttribute.setAnnotation(indexedAnnotation);
+                classFile.addAttribute(annotationsAttribute);
             }
 
             classCreationStack.push(newClass);
@@ -497,8 +497,10 @@ class ClassCreator extends DefaultMetadataVisitor<Void> {
                                 providedId.addMemberValue("bridge", new AnnotationMemberValue(fieldBridge, cp)); //$NON-NLS-1$
                                 AnnotationsAttribute attribute = (AnnotationsAttribute) currentClassFile
                                         .getAttribute(AnnotationsAttribute.visibleTag);
-                                attribute.addAnnotation(providedId);
-                                classIndexed.add(currentClass);
+                                if (attribute != null) {
+                                    attribute.addAnnotation(providedId);
+                                    classIndexed.add(currentClass);
+                                }
                             }
                         }
                     }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -967,8 +967,8 @@ public class HibernateStorage implements Storage {
             indexer.optimizeAfterPurge(true);
             indexer.idFetchSize(generateIdFetchSize()).threadsToLoadObjects(1).typesToIndexInParallel(5)
                     .batchSizeToLoadObjects(batchSize).startAndWait();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException("Exception occurred when re-indexing full-text for " + storageName + ".", e); //$NON-NLS-1$ //$NON-NLS-2$
         } finally {
             this.releaseSession();
             LOGGER.info("Re-indexing done."); //$NON-NLS-1$


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)

fulltext indexing doesn't work if some entity has compound key

**What is the new behavior?**

Make fulltext reindexing working with entity has compound key

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
