### PR TITLE
TMDM-11363: JMS connections issues while reindexing

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/prepare/FullTextIndexCleaner.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/prepare/FullTextIndexCleaner.java
@@ -50,7 +50,7 @@ public class FullTextIndexCleaner implements StorageCleaner, StorageInitializer 
                     throw new IllegalStateException("Could not successfully delete '" + indexDirectory.getAbsolutePath() + "'", e);
                 }
             } else {
-                LOGGER.warn("Directory '" + dataSourceIndexDirectory + "' does not exist. No need to clean full text indexes.");
+                LOGGER.warn("Directory '" + indexDirectory + "' does not exist. No need to clean full text indexes.");
             }
         }
     }

--- a/org.talend.mdm.core/resources/META-INF/activemq-provider.xml
+++ b/org.talend.mdm.core/resources/META-INF/activemq-provider.xml
@@ -6,7 +6,7 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
 
 	<!-- Connection Factory definition -->
-	<bean id="jmsConnectionFactory" class="com.amalto.core.util.ActiveMQConnectionFactoryExtension">
+	<bean id="spiJmsConnectionFactory" class="com.amalto.core.util.ActiveMQConnectionFactoryExtension">
 		<property name="brokerURL" value="${mdm.routing.engine.broker.url}"/>
 		<property name="userName" value="${mdm.routing.engine.broker.userName}"/>
 		<property name="password" value="${mdm.routing.engine.broker.password}"/>

--- a/org.talend.mdm.core/resources/META-INF/mdm-context.xml
+++ b/org.talend.mdm.core/resources/META-INF/mdm-context.xml
@@ -44,23 +44,24 @@ http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/ac
     <import resource="${mdm.jms.provider.xml:activemq-provider.xml}"/>
     
     <!-- Caching connection factory for JMS template performances -->
-    <bean id="jmsPooledConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
-        <constructor-arg ref="jmsConnectionFactory"/>
+    <bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+        <property name="targetConnectionFactory" ref="spiJmsConnectionFactory"/>
+        <property name="sessionCacheSize" value="${mdm.routing.engine.broker.sessionCacheSize:1}"/>
     </bean>
     
     <!-- Single connection and several sessions -->
     <bean id="jmsSingleConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
-    	<constructor-arg ref="jmsConnectionFactory"/>
+    	<constructor-arg ref="spiJmsConnectionFactory"/>
     </bean>
     
     <!-- Single connection and several sessions -->
     <bean id="jmsSingleConnectionFactoryForExpired" class="org.springframework.jms.connection.SingleConnectionFactory">
-    	<constructor-arg ref="jmsConnectionFactory"/>
+    	<constructor-arg ref="spiJmsConnectionFactory"/>
     </bean>
 
 	<!-- JMSTemplate used to send messages to routing events queue -->
     <bean id="routingEngineJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-        <property name="connectionFactory" ref="jmsPooledConnectionFactory"/>
+        <property name="connectionFactory" ref="jmsConnectionFactory"/>
         <property name="defaultDestination" ref="routingEventsQueue"/>
     </bean>
     

--- a/org.talend.mdm.webapp.openmdm/src/main/webapp/WEB-INF/beans.xml
+++ b/org.talend.mdm.webapp.openmdm/src/main/webapp/WEB-INF/beans.xml
@@ -11,8 +11,8 @@ http://www.springframework.org/schema/security http://www.springframework.org/sc
 http://www.hazelcast.com/schema/spring http://www.hazelcast.com/schema/spring/hazelcast-spring.xsd">
 
     <!-- MDM -->
-    <import resource="classpath*:META-INF/mdm-context.xml" />
     <context:property-placeholder location="${mdm.root.url}/conf/mdm.conf" ignore-unresolvable="true" local-override="false"/>
+    <import resource="classpath*:META-INF/mdm-context.xml" />
 
     <!-- CXF Services -->
     <import resource="classpath:META-INF/cxf/cxf.xml" />


### PR DESCRIPTION
The ConnectionFactory used with a JMSTemplate object should always return pooled Connections (or a single shared Connection) as well as pooled Sessions and MessageProducers.
- Fix to use of CachingConnectionFactory, this factory switches the “reconnectOnException” property to “true” by default, allowing for automatic recovery of the underlying Connection.
- Consider also the ability to raise the “sessionCacheSize” value in case of a high-concurrency environment using a mdm.conf 'mdm.routing.engine.broker.sessionCacheSize' property.
- Fix incorrect console log message

**What is the current behavior?** (You can also link to an open issue here)
ConnectionFactory isn't pooled for reindexation replication in Cluster as well as for Staging tasks cancellation.

**What is the new behavior?**
Change bean name (instead of changing code which is getting non-pooled CF) of the pooled CF defined for routing events, so that everywhere the right CF is used.
Give the ability to tune CF when huge JMS traffic.


**Please check if the PR fulfills these requirements**

- [x ] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
