### PR TITLE
TMDM-11363 JMS connection problem when pushing Lucene indexes for replication

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
@@ -286,7 +286,7 @@ class FullTextQueryHandler extends AbstractQueryHandler {
                 }
             };
         }
-        return new FullTextStorageResults(pageSize, list.size(), iterator);
+        return new FullTextStorageResults(pageSize, query.getResultSize(), iterator);
     }
 
     private StorageResults createResults(ScrollableResults scrollableResults) {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -520,7 +520,8 @@ public class StorageFullTextTest extends StorageTestCase {
         qb.limit(2);
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getCount());
+            assertEquals(3, results.getCount());
+            assertEquals(2, results.getSize());
         } finally {
             results.close();
         }
@@ -536,7 +537,8 @@ public class StorageFullTextTest extends StorageTestCase {
         qb.limit(2);
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getCount());
+            assertEquals(4, results.getCount());
+            assertEquals(2, results.getSize());
         } finally {
             results.close();
         }

--- a/org.talend.mdm.core/resources/META-INF/mdm-context.xml
+++ b/org.talend.mdm.core/resources/META-INF/mdm-context.xml
@@ -46,7 +46,8 @@ http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/ac
     
     <!-- Caching connection factory for JMS template performances -->
     <bean id="jmsPooledConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
-        <constructor-arg ref="jmsConnectionFactory"/>
+        <property name="targetConnectionFactory" ref="jmsConnectionFactory"/>
+        <property name="sessionCacheSize" value="${mdm.routing.engine.broker.sessionCacheSize:1}"/>
     </bean>
     
     <!-- Single connection and several sessions -->


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Can't set `sessionCacheSize` for `org.springframework.jms.connection.CachingConnectionFactory`

**What is the new behavior?**
Be able to set `sessionCacheSize` for `org.springframework.jms.connection.CachingConnectionFactory` via config of `mdm.routing.engine.broker.sessionCacheSize` in **mdm.conf**

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
