### PR TITLE
TMDM-11363 JMS connection problem when pushing Lucene indexes for replication

### DIFF
--- a/org.talend.mdm.core/resources/META-INF/activemq-provider.xml
+++ b/org.talend.mdm.core/resources/META-INF/activemq-provider.xml
@@ -6,7 +6,7 @@ http://www.springframework.org/schema/beans http://www.springframework.org/schem
 http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/activemq-core.xsd">
 
 	<!-- Connection Factory definition -->
-	<bean id="spiJmsConnectionFactory" class="com.amalto.core.util.ActiveMQConnectionFactoryExtension">
+	<bean id="jmsConnectionFactory" class="com.amalto.core.util.ActiveMQConnectionFactoryExtension">
 		<property name="brokerURL" value="${mdm.routing.engine.broker.url}"/>
 		<property name="userName" value="${mdm.routing.engine.broker.userName}"/>
 		<property name="password" value="${mdm.routing.engine.broker.password}"/>

--- a/org.talend.mdm.core/resources/META-INF/mdm-context.xml
+++ b/org.talend.mdm.core/resources/META-INF/mdm-context.xml
@@ -44,24 +44,24 @@ http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/ac
     <import resource="${mdm.jms.provider.xml:activemq-provider.xml}"/>
     
     <!-- Caching connection factory for JMS template performances -->
-    <bean id="jmsConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
-        <property name="targetConnectionFactory" ref="spiJmsConnectionFactory"/>
+    <bean id="jmsPooledConnectionFactory" class="org.springframework.jms.connection.CachingConnectionFactory">
+        <property name="targetConnectionFactory" ref="jmsConnectionFactory"/>
         <property name="sessionCacheSize" value="${mdm.routing.engine.broker.sessionCacheSize:1}"/>
     </bean>
     
     <!-- Single connection and several sessions -->
     <bean id="jmsSingleConnectionFactory" class="org.springframework.jms.connection.SingleConnectionFactory">
-    	<constructor-arg ref="spiJmsConnectionFactory"/>
+        <constructor-arg ref="jmsConnectionFactory"/>
     </bean>
     
     <!-- Single connection and several sessions -->
     <bean id="jmsSingleConnectionFactoryForExpired" class="org.springframework.jms.connection.SingleConnectionFactory">
-    	<constructor-arg ref="spiJmsConnectionFactory"/>
+        <constructor-arg ref="jmsConnectionFactory"/>
     </bean>
 
 	<!-- JMSTemplate used to send messages to routing events queue -->
     <bean id="routingEngineJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-        <property name="connectionFactory" ref="jmsConnectionFactory"/>
+        <property name="connectionFactory" ref="jmsPooledConnectionFactory"/>
         <property name="defaultDestination" ref="routingEventsQueue"/>
     </bean>
     

--- a/org.talend.mdm.core/src/com/amalto/core/storage/task/staging/StagingTaskManagerFactory.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/task/staging/StagingTaskManagerFactory.java
@@ -31,16 +31,14 @@ public class StagingTaskManagerFactory implements ApplicationContextAware, Dispo
     private DefaultMessageListenerContainer listener;
     
     public StagingTaskManager createStagingTaskManager(){
-        if(isClusterEnabled()){
+        if (isClusterEnabled()) {
             ClusteredStagingTaskManager clusteredManager = new ClusteredStagingTaskManager();
-            ConnectionFactory connectionFactory = this.getConnectionFactory();
             Topic topic = this.getTopic();
-            clusteredManager.setJmsTemplate(createJmsTemplate(connectionFactory, topic));
+            clusteredManager.setJmsTemplate(createJmsTemplate(getPooledConnectionFactory(), topic));
             clusteredManager.setRepository(this.repository);
-            this.startMessageListener(connectionFactory, topic, clusteredManager);
+            this.startMessageListener(getNonPooledConnectionFactory(), topic, clusteredManager);
             return clusteredManager;
-        }
-        else {
+        } else {
             LocalStagingTaskManager localManagermanager = new LocalStagingTaskManager();
             localManagermanager.setRepository(this.repository);
             return localManagermanager;
@@ -67,12 +65,16 @@ public class StagingTaskManagerFactory implements ApplicationContextAware, Dispo
         template.setDefaultDestination(this.getTopic());
         return template;
     }
-    
-    private ConnectionFactory getConnectionFactory(){
+
+    private ConnectionFactory getNonPooledConnectionFactory() {
         return this.applicationContext.getBean("jmsConnectionFactory", ConnectionFactory.class);
     }
-    
-    private Topic getTopic(){
+
+    private ConnectionFactory getPooledConnectionFactory() {
+        return this.applicationContext.getBean("jmsPooledConnectionFactory", ConnectionFactory.class);
+    }
+
+    private Topic getTopic() {
         return this.applicationContext.getBean("stagingTaskCancellationTopic", Topic.class);
     }
     


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
- `StagingTaskManagerFactory` use non-pooled `jmsConnectionFactory` for both message producer & consumer
- Can't set `sessionCacheSize` for `org.springframework.jms.connection.CachingConnectionFactory`
- Fix regression caused by bean naming of `jmsConnectionFactory`

**What is the new behavior?**
- `StagingTaskManagerFactory` use pooled `jmsConnectionFactory` for both message producer, and non-pooled for consumer
- Be able to set `sessionCacheSize` for `org.springframework.jms.connection.CachingConnectionFactory` via config of `mdm.routing.engine.broker.sessionCacheSize` in **mdm.conf**
- Regression fixed

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
