### PR TITLE
TMDM-7196 Can't import a file from Import/Export capability by browser Safari

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/UploadFileFormPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/UploadFileFormPanel.java
@@ -384,6 +384,19 @@ public class UploadFileFormPanel extends FormPanel implements Listener<FormEvent
                 });
             }
         });
+
+        // TMDM-7196 We can not get value from file field in safari.But we can get value after we choose file and click
+        // file field.
+        if (isSafari()) {
+            submit.addListener(Events.OnMouseOver, new Listener<BaseEvent>() {
+
+                @Override
+                public void handleEvent(BaseEvent be) {
+                    file.focus();
+                }
+            });
+        }
+
         this.addButton(submit);
         this.setButtonAlign(HorizontalAlignment.CENTER);
 
@@ -429,4 +442,10 @@ public class UploadFileFormPanel extends FormPanel implements Listener<FormEvent
         msg = msg.replace("</pre>", ""); //$NON-NLS-1$ //$NON-NLS-2$
         return msg;
     }
+
+    private native boolean isSafari()/*-{
+        var userAgent = navigator.userAgent;
+        return userAgent.indexOf("Safari") > -1
+                && userAgent.indexOf("Chrome") == -1;
+    }-*/;
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/servlet/UploadData.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/servlet/UploadData.java
@@ -79,6 +79,7 @@ public class UploadData extends HttpServlet {
 
         request.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
         response.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
+        response.setContentType("text/plain");
         if (!FileUploadBase.isMultipartContent(request)) {
             throw new ServletException(MESSAGES.getMessage("error_upload")); //$NON-NLS-1$
         }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/servlet/UploadData.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/servlet/UploadData.java
@@ -79,7 +79,7 @@ public class UploadData extends HttpServlet {
 
         request.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
         response.setCharacterEncoding("UTF-8"); //$NON-NLS-1$
-        response.setContentType("text/plain");
+        response.setContentType("text/plain"); //$NON-NLS-1$
         if (!FileUploadBase.isMultipartContent(request)) {
             throw new ServletException(MESSAGES.getMessage("error_upload")); //$NON-NLS-1$
         }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
1 Submit button doesn't work,because we can not get file field value when submit form.
2 Waiting bar can not hidden after import file.

**What is the new behavior?**
1 We can get file field value after click file field.Our solution is let file field get focus when mouse over submit button.And then we can get file field value when we submit form.
2 Miss MIME type will cause an error in safari,it will interrupt response in Safari.But it only cause an warning in other browser,so it doesn't work only in safari.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
