### PR TITLE
TMDM-11397 Warn user when custom layout associated to a view is not found

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsService.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsService.java
@@ -119,7 +119,7 @@ public interface BrowseRecordsService extends RemoteService {
 
     List<ItemResult> updateItems(List<UpdateItemModel> updateItems, String language) throws ServiceException;
 
-    ColumnTreeLayoutModel getColumnTreeLayout(String concept, String customFormName) throws ServiceException;
+    ColumnTreeLayoutModel getColumnTreeLayout(String concept, String customFormName, ViewBean vBean) throws ServiceException;
 
     ForeignKeyModel getForeignKeyModel(String concept, String ids, boolean isStaging, String language) throws ServiceException;
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsServiceAsync.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsServiceAsync.java
@@ -104,7 +104,8 @@ public interface BrowseRecordsServiceAsync {
 
     void saveItem(String concept, String ids, String xml, boolean isCreate, String language, AsyncCallback<ItemResult> callback);
 
-    void getColumnTreeLayout(String concept, String customFormName, AsyncCallback<ColumnTreeLayoutModel> callback);
+    void getColumnTreeLayout(String concept, String customFormName, ViewBean vBean,
+            AsyncCallback<ColumnTreeLayoutModel> callback);
 
     void getForeignKeyModel(String concept, String ids, boolean isStaging, String language,
             AsyncCallback<ForeignKeyModel> callback);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.java
@@ -148,6 +148,8 @@ public interface BrowseRecordsMessages extends Messages {
 
     String match_group();
 
+    String missing_linkedLayout(String layout, String view);
+
     String advsearch_filter();
 
     String advsearch_morelabel();

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.java
@@ -148,7 +148,7 @@ public interface BrowseRecordsMessages extends Messages {
 
     String match_group();
 
-    String missing_linkedLayout(String layout, String view);
+    String missing_customForm(String customForm, String view);
 
     String advsearch_filter();
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
@@ -445,9 +445,9 @@ public class BrowseRecordsController extends Controller {
 
             @Override
             public void onSuccess(ViewBean viewbean) {
-                String missingLinedLayout = viewbean.getMissingLinkedLayout();
+                String missingLinedLayout = viewbean.getMissingCustomForm();
                 if (missingLinedLayout != null) {
-                    String message = MessagesFactory.getMessages().missing_linkedLayout(missingLinedLayout, viewbean.getViewPK());
+                    String message = MessagesFactory.getMessages().missing_customForm(missingLinedLayout, viewbean.getViewPK());
                     MessageBox.alert(MessagesFactory.getMessages().warning_title(), message, null);
                 }
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
@@ -445,6 +445,11 @@ public class BrowseRecordsController extends Controller {
 
             @Override
             public void onSuccess(ViewBean viewbean) {
+                String missingLinedLayout = viewbean.getMissingLinkedLayout();
+                if (missingLinedLayout != null) {
+                    String message = MessagesFactory.getMessages().missing_linkedLayout(missingLinedLayout, viewbean.getViewPK());
+                    MessageBox.alert(MessagesFactory.getMessages().warning_title(), message, null);
+                }
 
                 // Init CURRENT_VIEW
                 BrowseRecords.getSession().put(UserSession.CURRENT_VIEW, viewbean);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
@@ -1818,7 +1818,7 @@ public class BrowseRecordsAction implements BrowseRecordsService {
             CustomFormPOJO customForm = com.amalto.core.util.Util.getCustomFormCtrlLocal().getUserCustomForm(pk);
 
             if (StringUtils.isNotBlank(customFormName) && (customForm == null || !customFormName.equals(customForm.getName()))) {
-                vBean.setMissingLinkedLayout(customFormName);
+                vBean.setMissingCustomForm(customFormName);
                 LOG.error("Couldn't find custom layout '" + customFormName + "' associated to view '" + vBean.getViewPK()//$NON-NLS-1$//$NON-NLS-2$
                         + "'");//$NON-NLS-1$
             }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
@@ -670,7 +670,7 @@ public class BrowseRecordsAction implements BrowseRecordsService {
         // searchables
         vb.setSearchables(ViewHelper.getSearchables(wsView, model, language, entityModel));
         // bind layout model
-        vb.setColumnLayoutModel(getColumnTreeLayout(concept, wsView.getCustomForm()));
+        vb.setColumnLayoutModel(getColumnTreeLayout(concept, wsView.getCustomForm(), vb));
         return vb;
     }
 
@@ -1811,10 +1811,18 @@ public class BrowseRecordsAction implements BrowseRecordsService {
     }
 
     @Override
-    public ColumnTreeLayoutModel getColumnTreeLayout(String concept, String customFormName) throws ServiceException {
+    public ColumnTreeLayoutModel getColumnTreeLayout(String concept, String customFormName, ViewBean vBean)
+            throws ServiceException {
         try {
             CustomFormPOJOPK pk = new CustomFormPOJOPK(getCurrentDataModel(), concept, customFormName);
             CustomFormPOJO customForm = com.amalto.core.util.Util.getCustomFormCtrlLocal().getUserCustomForm(pk);
+
+            if (StringUtils.isNotBlank(customFormName) && (customForm == null || !customFormName.equals(customForm.getName()))) {
+                vBean.setMissingLinkedLayout(customFormName);
+                LOG.error("Couldn't find custom layout '" + customFormName + "' associated to view '" + vBean.getViewPK()//$NON-NLS-1$//$NON-NLS-2$
+                        + "'");//$NON-NLS-1$
+            }
+
             if (customForm == null) {
                 return null;
             }
@@ -1945,7 +1953,7 @@ public class BrowseRecordsAction implements BrowseRecordsService {
                     LocalUser.getLocalUser().getUsername(), null);
 
             String updateReport = updateReportPOJO.serialize();
-            WSTypedContent wsTypedContent = new WSTypedContent(null, new WSByteArray(updateReport.getBytes("UTF-8")),//$NON-NLS-1$
+            WSTypedContent wsTypedContent = new WSTypedContent(null, new WSByteArray(updateReport.getBytes("UTF-8")), //$NON-NLS-1$
                     "text/xml; charset=utf-8");//$NON-NLS-1$
             WSExecuteTransformerV2 wsExecuteTransformerV2 = new WSExecuteTransformerV2(wsTransformerContext, wsTypedContent);
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/shared/ViewBean.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/shared/ViewBean.java
@@ -40,6 +40,8 @@ public class ViewBean implements Serializable, IsSerializable {
     
     private ColumnTreeLayoutModel columnLayoutModel;
 
+    private String missingLinekdLayout;
+
     public ColumnTreeLayoutModel getColumnLayoutModel() {
         return columnLayoutModel;
     }
@@ -108,5 +110,13 @@ public class ViewBean implements Serializable, IsSerializable {
         this.bindingEntityModel = bindingEntityModel;
     }
     
+
+    public String getMissingLinkedLayout() {
+        return this.missingLinekdLayout;
+    }
+
+    public void setMissingLinkedLayout(String missingLinedLayout) {
+        this.missingLinekdLayout = missingLinedLayout;
+    }
 
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/shared/ViewBean.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/shared/ViewBean.java
@@ -40,7 +40,7 @@ public class ViewBean implements Serializable, IsSerializable {
     
     private ColumnTreeLayoutModel columnLayoutModel;
 
-    private String missingLinekdLayout;
+    private String missingCustomForm;
 
     public ColumnTreeLayoutModel getColumnLayoutModel() {
         return columnLayoutModel;
@@ -111,12 +111,11 @@ public class ViewBean implements Serializable, IsSerializable {
     }
     
 
-    public String getMissingLinkedLayout() {
-        return this.missingLinekdLayout;
+    public String getMissingCustomForm() {
+        return this.missingCustomForm;
     }
 
-    public void setMissingLinkedLayout(String missingLinedLayout) {
-        this.missingLinekdLayout = missingLinedLayout;
+    public void setMissingCustomForm(String missingCustomForm) {
+        this.missingCustomForm = missingCustomForm;
     }
-
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.properties
+++ b/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.properties
@@ -343,7 +343,7 @@ source=Source
 status=Status
 error=Error
 match_group=Match group
-missing_linkedLayout=Couldn''t find custom layout ''{0}'' associated to view ''{1}''
+missing_customForm=Couldn''t find custom layout ''{0}'' associated to view ''{1}''
 browse_staging_records=BrowseRecords->
 
 status_000=New record (default value when a new row is inserted in staging area).

--- a/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.properties
+++ b/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages.properties
@@ -343,6 +343,7 @@ source=Source
 status=Status
 error=Error
 match_group=Match group
+missing_linkedLayout=Couldn''t find custom layout ''{0}'' associated to view ''{1}''
 browse_staging_records=BrowseRecords->
 
 status_000=New record (default value when a new row is inserted in staging area).

--- a/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_en.properties
+++ b/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_en.properties
@@ -343,7 +343,7 @@ source=Source
 status=Status
 error=Error
 match_group=Match group
-missing_linkedLayout=Couldn''t find custom layout ''{0}'' associated to view ''{1}''
+missing_customForm=Couldn''t find custom layout ''{0}'' associated to view ''{1}''
 browse_staging_records=BrowseRecords->
 
 status_000=New record (default value when a new row is inserted in staging area).

--- a/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_en.properties
+++ b/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_en.properties
@@ -343,6 +343,7 @@ source=Source
 status=Status
 error=Error
 match_group=Match group
+missing_linkedLayout=Couldn''t find custom layout ''{0}'' associated to view ''{1}''
 browse_staging_records=BrowseRecords->
 
 status_000=New record (default value when a new row is inserted in staging area).

--- a/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_fr.properties
+++ b/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_fr.properties
@@ -323,6 +323,7 @@ source=Source
 status=Statut
 error=Erreur
 match_group=Groupe de correspondance
+missing_linkedLayout=La mise en page ''{0}'' associée \u00e0 la vue ''{1}'' n''a pas \u00e9t\u00e9 trouv\u00e9e
 browse_staging_records=Acc\u00e8s aux donn\u00e9es->
 
 status_000=Nouvel enregistrement (valeur par d\u00e9faut lorsqu''une ligne est ins\u00e9r\u00e9e dans la staging area).

--- a/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_fr.properties
+++ b/org.talend.mdm.webapp.browserecords/src/main/resources/org/talend/mdm/webapp/browserecords/client/i18n/BrowseRecordsMessages_fr.properties
@@ -323,7 +323,7 @@ source=Source
 status=Statut
 error=Erreur
 match_group=Groupe de correspondance
-missing_linkedLayout=La mise en page ''{0}'' associée \u00e0 la vue ''{1}'' n''a pas \u00e9t\u00e9 trouv\u00e9e
+missing_customForm=La mise en page personnalis\u00e9e ''{0}'' associ\u00e9e \u00e0 la vue ''{1}'' n''a pas \u00e9t\u00e9 trouv\u00e9e
 browse_staging_records=Acc\u00e8s aux donn\u00e9es->
 
 status_000=Nouvel enregistrement (valeur par d\u00e9faut lorsqu''une ligne est ins\u00e9r\u00e9e dans la staging area).

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/MockGridRefreshGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/MockGridRefreshGWTTest.java
@@ -501,7 +501,7 @@ public class MockGridRefreshGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+        public void getColumnTreeLayout(String concept, String customFormName, ViewBean vBean,
                 AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/MockGridRefreshGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/MockGridRefreshGWTTest.java
@@ -501,7 +501,8 @@ public class MockGridRefreshGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String customFormName, AsyncCallback<ColumnTreeLayoutModel> callback) {
+        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+                AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 
         @Override

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsToolBarGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsToolBarGWTTest.java
@@ -335,7 +335,7 @@ public class ItemsToolBarGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+        public void getColumnTreeLayout(String concept, String customFormName, ViewBean vBean,
                 AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsToolBarGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsToolBarGWTTest.java
@@ -335,7 +335,8 @@ public class ItemsToolBarGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String customFormName, AsyncCallback<ColumnTreeLayoutModel> callback) {
+        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+                AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 
         @Override

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatDateFieldGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatDateFieldGWTTest.java
@@ -279,7 +279,8 @@ public class FormatDateFieldGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String customFormName, AsyncCallback<ColumnTreeLayoutModel> callback) {
+        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+                AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 
         @Override

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatDateFieldGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatDateFieldGWTTest.java
@@ -279,7 +279,7 @@ public class FormatDateFieldGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+        public void getColumnTreeLayout(String concept, String customFormName, ViewBean vBean,
                 AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/TreeDetailGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/TreeDetailGWTTest.java
@@ -1200,7 +1200,8 @@ public class TreeDetailGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String customFormName, AsyncCallback<ColumnTreeLayoutModel> callback) {
+        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+                AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 
         @Override

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/TreeDetailGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/TreeDetailGWTTest.java
@@ -1200,7 +1200,7 @@ public class TreeDetailGWTTest extends GWTTestCase {
         }
 
         @Override
-        public void getColumnTreeLayout(String concept, String viewPk, ViewBean vBean,
+        public void getColumnTreeLayout(String concept, String customFormName, ViewBean vBean,
                 AsyncCallback<ColumnTreeLayoutModel> callback) {
         }
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-11397

**What is the current behavior?**
silently use the view just as if there were no custom layout


**What is the new behavior?**
warn user (as well in log file) that a custom layout linked to a view is missing or is not accessible for current user, and then fallback to the view itself


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
