### PR TITLE
TPS-2043 [6.1.2] Java NPE when foreign key filter is set to "Is emptyor is null" with predicat NOT (TMDM-10734)

### DIFF
--- a/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
+++ b/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
@@ -321,6 +321,8 @@ public abstract class Util {
                 operator = WSWhereOperator.STARTSWITH;
             } else if (values[1].equals("Strict Contains")) {
                 operator = WSWhereOperator.STRICTCONTAINS;
+            } else if (values[1].equals(WhereCondition.EMPTY_NULL)) {
+                operator = WSWhereOperator.EMPTY_NULL;
             }
             wc.setOperator(operator);
             if (values[2] != null && values[2].matches("^\".*\"$")) {

--- a/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
+++ b/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
@@ -104,6 +104,13 @@ public class UtilTest extends TestCase {
         assertEquals(WSWhereOperator.EMPTY_NULL, whereCondition.getOperator());
         assertNull(whereCondition.getRightValueOrPath());
         assertEquals(WSStringPredicate.NONE, whereCondition.getStringPredicate());
+        
+        String[] values1 = { "ProductFamily/Name", "Is Empty Or Null", "", "Not" };
+        whereCondition = Util.convertLine(values1);
+        assertEquals("ProductFamily/Name", whereCondition.getLeftPath());
+        assertEquals(WSWhereOperator.EMPTY_NULL, whereCondition.getOperator());
+        assertEquals("", whereCondition.getRightValueOrPath());
+        assertEquals(WSStringPredicate.NOT, whereCondition.getStringPredicate());
     }
 
     private JSONArray parsingForeignKeyQueryResults(String[] results, boolean isQueryFkList) throws Exception {


### PR DESCRIPTION
Backport