### PR TITLE
TMDM-11498 Tabbing through or clicking on entry fields on the MDM Web UI seem to cause them to blank out behind the scenes on Save(Set display value and object value after validate).

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatNumberField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/FormatNumberField.java
@@ -145,8 +145,6 @@ public class FormatNumberField extends NumberField {
                 return false;
             }
 
-            this.setOjbectValue(d);
-
             if (validator != null) {
                 String msg = validator.validate(this, value);
                 if (msg != null) {
@@ -154,6 +152,11 @@ public class FormatNumberField extends NumberField {
                     return false;
                 }
             }
+
+            // Set display value and object value after validate.
+            setDiplayValue(value);
+            this.setOjbectValue(d);
+
             return true;
         }
     }
@@ -189,7 +192,6 @@ public class FormatNumberField extends NumberField {
         if (formatPattern == null) {
             displayValue = FormatUtil.changeNumberToFormatedValue(result);
         }
-        setDiplayValue(displayValue);
         if (rendered) {
             if (isEditable()) {
                 getInputEl().setValue(displayValue == null ? "" : displayValue); //$NON-NLS-1$


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Because we  set 'display value' before validation, which makes the validation value equal to 'display value '. During validation, it doesn't set 'Object value', however, node will use Object value to update itself when field lose focus. The node value will be Null in such a case.


**What is the new behavior?**
We have already moved the setting 'display value' and 'object value' to validation method. We will set these values when lose field focus at the first time. We will not do validation unless the value is changed when lose focus again.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
