### PR TITLE
TMDM-11695 : Columns shifted in View when a composite primary key used as foreign key

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ProjectionIterator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ProjectionIterator.java
@@ -369,7 +369,11 @@ class ProjectionIterator implements CloseableIterator<DataRecord> {
             FieldMetadata fieldMetadata = field.getFieldMetadata();
             if (!isAlias) {
                 if (fieldMetadata instanceof ReferenceFieldMetadata) {
-                    createReferenceElement(((ReferenceFieldMetadata) fieldMetadata));
+                    FieldMetadata referencedField = ((ReferenceFieldMetadata)mappingMetadataRepository.getMappingFromUser(fieldMetadata.getContainingType()).getDatabase(fieldMetadata)).getReferencedField();
+                    if (referencedField instanceof CompoundFieldMetadata) {
+                        ((ReferenceFieldMetadata)fieldMetadata).setReferencedField(referencedField);
+                    }
+                    createReferenceElement((ReferenceFieldMetadata) fieldMetadata);
                 } else {
                     TypeMetadata type = fieldMetadata.getType();
                     if (fieldMetadata instanceof SimpleTypeFieldMetadata) {
@@ -378,7 +382,6 @@ class ProjectionIterator implements CloseableIterator<DataRecord> {
                     } else {
                         createElement(type.getName(), fieldMetadata.getName());
                     }
-                    
                 }
             }
             if (fieldMetadata instanceof ReferenceFieldMetadata

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/CompositeForeignKey.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/CompositeForeignKey.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">  
+  <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>  
+  <xsd:element name="DEPARTEMENT"> 
+    <xsd:annotation> 
+      <xsd:appinfo source="X_Write">CRE_ROLE</xsd:appinfo> 
+    </xsd:annotation>  
+    <xsd:complexType> 
+      <xsd:all> 
+        <xsd:element name="DEPARTEMENTId" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">CRE_ROLE</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="NAME" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">CRE_ROLE</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="REGION_REF" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">CRE_ROLE</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey">REGION/REGIONId</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="DONNEES" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">CRE_ROLE</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="DONNEES2" type="xsd:int"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">CRE_ROLE</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element> 
+      </xsd:all> 
+    </xsd:complexType>  
+    <xsd:unique name="DEPARTEMENT"> 
+      <xsd:selector xpath="."/>  
+      <xsd:field xpath="DEPARTEMENTId"/> 
+    </xsd:unique> 
+  </xsd:element>  
+  <xsd:element name="REGION"> 
+    <xsd:complexType> 
+      <xsd:all> 
+        <xsd:element name="REGIONId" type="xsd:string"/>  
+        <xsd:element maxOccurs="1" minOccurs="1" name="NAME" type="xsd:string"/>  
+        <xsd:element maxOccurs="1" minOccurs="1" name="CODE" type="xsd:int"/> 
+      </xsd:all> 
+    </xsd:complexType>  
+    <xsd:unique name="REGION"> 
+      <xsd:selector xpath="."/>  
+      <xsd:field xpath="CODE"/>  
+      <xsd:field xpath="REGIONId"/>  
+      <xsd:field xpath="NAME"/> 
+    </xsd:unique> 
+  </xsd:element> 
+</xsd:schema>


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Can't get correct filed information when records contains composite primary key field.

**What is the new behavior?**
Add composite primary key field information when do search.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
