### PR TITLE
TMDM-11497 Export/Import excel file:handle case with empty separator while export multi value data.

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/DownloadFilePanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/DownloadFilePanel.java
@@ -100,6 +100,7 @@ public class DownloadFilePanel extends FormPanel {
         multipleValueSeparatorField.setFieldLabel(MessagesFactory.getMessages().multiple_value_separator_field_label());
         multipleValueSeparatorField.setMaxLength(1);
         multipleValueSeparatorField.setValue("|"); //$NON-NLS-1$
+        multipleValueSeparatorField.setAllowBlank(false);
         this.add(multipleValueSeparatorField, new FormData("67.3%")); //$NON-NLS-1$
 
         fkResovled = new CheckBox();

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/UploadFileFormPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/UploadFileFormPanel.java
@@ -225,6 +225,7 @@ public class UploadFileFormPanel extends FormPanel implements Listener<FormEvent
         multipleValueSeparatorField.setName("multipleValueSeparator"); //$NON-NLS-1$
         multipleValueSeparatorField.setMaxLength(1);
         multipleValueSeparatorField.setValue("|"); //$NON-NLS-1$
+        multipleValueSeparatorField.setAllowBlank(false);
         MultiField<String> multipleValueField = new MultiField<String>();
         LabelField lf = new LabelField();
         multipleValueField.setFieldLabel(MessagesFactory.getMessages().multiple_value_separator_field_label());


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
Can't parse Multiple Value when Multiple Value Separator is empty.


**What is the new behavior?**
Value of Multiple Value Separator Field can't be empty.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
