### PR TITLE
TMDM-11716 [DEV] Defer to TAC the responsibility to manage the  administration role (release/7.0.1EP)

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
@@ -2485,6 +2485,9 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
 
     @Override
     public WSRolePK putRole(WSPutRole wsRole) throws RemoteException {
+        if (ICoreConstants.SYSTEM_ROLE_LIST.contains(wsRole.getWsRole().getName())) {
+            throw new RemoteException("System roles are built-in and managed by TAC.");
+        }
         String user = null;
         Boolean isUpdate = null;
         try {

--- a/org.talend.mdm.core/src/com/amalto/core/server/DefaultRole.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/DefaultRole.java
@@ -97,7 +97,7 @@ public class DefaultRole implements Role {
         Collection<ObjectPOJOPK> c = ObjectPOJO.findAllPKs(RolePOJO.class, regex);
         ArrayList<RolePOJOPK> l = new ArrayList<RolePOJOPK>();
         for (ObjectPOJOPK currentObject : c) {
-            if (currentObject.getIds().length > 0 && currentObject.getIds()[0].startsWith(ICoreConstants.SYSTEM_ROLE_PREFIX)) {
+            if (currentObject.getIds().length > 0 && ICoreConstants.SYSTEM_ROLE_LIST.contains(currentObject.getIds()[0])) {
                 continue;
             }
             l.add(new RolePOJOPK(currentObject));


### PR DESCRIPTION


* TMDM-11716 [DEV] Defer to TAC the responsibility to manage the administration role
-  Remove WS calls the ability to add the role 'administration'

* TMDM-11716 [DEV] Defer to TAC the responsibility to manage the administration role

* TMDM-11716 [DEV] Defer to TAC the responsibility to manage the administration role

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
