### PR TITLE
TMDM-11690 SET READ_COMMITTED_SNAPSHOT as ON for SQL Server database in order to avoid locked table.

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/prepare/SQLServerStorageInitializer.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/prepare/SQLServerStorageInitializer.java
@@ -11,12 +11,17 @@
 
 package com.amalto.core.storage.prepare;
 
-import com.amalto.core.storage.Storage;
-import com.amalto.core.storage.datasource.DataSource;
-import com.amalto.core.storage.datasource.RDBMSDataSource;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.apache.log4j.Logger;
 
-import java.sql.*;
+import com.amalto.core.storage.Storage;
+import com.amalto.core.storage.StorageType;
+import com.amalto.core.storage.datasource.DataSource;
+import com.amalto.core.storage.datasource.RDBMSDataSource;
 
 class SQLServerStorageInitializer implements StorageInitializer {
 
@@ -51,6 +56,13 @@ class SQLServerStorageInitializer implements StorageInitializer {
                 try {
                     statement.execute("USE master;"); //$NON-NLS-1$
                     statement.execute("CREATE DATABASE " + dataSource.getDatabaseName() + ";"); //$NON-NLS-1$ //$NON-NLS-2$
+                    if (storage.getType() == StorageType.MASTER || storage.getType() == StorageType.STAGING) {
+                        // The default isolation level of SQL Server database is READ_COMMITTED. When transaction 1
+                        // update table A without commit, transaction 2 that selects table A will be paused. We need to
+                        // set READ_COMMITTED_SNAPSHOT as "ON" to run transaction 2 .
+                        statement.execute("ALTER DATABASE " + dataSource.getDatabaseName() + " SET ALLOW_SNAPSHOT_ISOLATION ON;"); //$NON-NLS-1$ //$NON-NLS-2$
+                        statement.execute("ALTER DATABASE " + dataSource.getDatabaseName() + " SET READ_COMMITTED_SNAPSHOT ON;"); //$NON-NLS-1$ //$NON-NLS-2$
+                    }
                 } catch (SQLException e) {
                     // Assumes database is already created.
                     LOGGER.warn("Exception occurred during CREATE DATABASE statement.", e);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-11690
**What is the current behavior?** (You should also link to an open issue here)
The default Isolation Level of SQL Server database is READ_COMMITTED. When transaction 1 update table A without commit, transaction 2 that  selects table A will be paused.

**What is the new behavior?**
 We need to set READ_COMMITTED_SNAPSHOT as "ON" to avoid that transaction 2 be paused.
READ_COMMITTED_SNAPSHOT means we will get the lastest committed snapshot before selecting operation but not before the  beginning of transaction 2.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
