### PR TITLE
TMDM-11795 Global logout support

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -122,6 +122,12 @@ public class Util {
 
     private static final Logger LOGGER = Logger.getLogger(Util.class);
 
+    public static final String ROOT_LOCATION_PARAM = "mdmRootLocation";
+
+    public static final String ROOT_LOCATION_KEY = "mdm.root";
+
+    public static final String ROOT_LOCATION_URL_KEY = "mdm.root.url";
+
     private static final String USER_PROPERTY_PREFIX = "${user_context";
 
     private static final ScriptEngineManager SCRIPT_FACTORY = new ScriptEngineManager();

--- a/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
+++ b/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
@@ -9,6 +9,10 @@
  */
 package org.talend.mdm.webapp.general.server.servlet;
 
+import static com.amalto.core.util.Util.ROOT_LOCATION_KEY;
+import static com.amalto.core.util.Util.ROOT_LOCATION_PARAM;
+import static com.amalto.core.util.Util.ROOT_LOCATION_URL_KEY;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
@@ -22,12 +26,6 @@ import org.springframework.util.ResourceUtils;
 import org.springframework.web.util.ServletContextPropertyUtils;
 
 public class MDMContextListener implements ServletContextListener {
-
-    public static final String ROOT_LOCATION_PARAM = "mdmRootLocation"; //$NON-NLS-1$
-
-    public static final String ROOT_LOCATION_KEY = "mdm.root"; //$NON-NLS-1$
-
-    public static final String ROOT_LOCATION_URL_KEY = "mdm.root.url"; //$NON-NLS-1$
 
     @Override
     public void contextInitialized(ServletContextEvent event) {


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
https://jira.talendforge.org/browse/TMDM-11795


**What is the new behavior?**
- Global Logout will be enabled all the time
- For standalone environment, HashMap Store Type will always be used
- For cluster environment, Hazelcast Store Type will always be be used (system.cluster=true)
- For cluster environment, Auto Increment should not be affected although it uses same Hazelcast instance with Global Logout


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: