### PR TITLE
TMDM-11733 beforeSaving process does not work if removing field of record

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriter.java
@@ -217,7 +217,7 @@ public class DataRecordIncludeNullValueXmlWriter extends DataRecordXmlWriter {
                     }
                     out.write("</" + simpleField.getName() + ">"); //$NON-NLS-1$ //$NON-NLS-2$
                 } else {
-                    if (value != null) {
+                    if (value != null && !((List) value).isEmpty()) {
                         List valueAsList = (List) value;
                         for (Object currentValue : valueAsList) {
                             if (currentValue != null) {

--- a/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriterTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriterTestCase.java
@@ -88,7 +88,7 @@ public class DataRecordIncludeNullValueXmlWriterTestCase extends DataRecordDataW
         setDataRecordField(record, "Id", "12345");
         setDataRecordField(record, "Repeat", new ArrayList<String>());
         String result = toXmlString(record);
-        Assert.assertEquals("<WithArray><Id>12345</Id></WithArray>", result);
+        Assert.assertEquals("<WithArray><Id>12345</Id><Repeat></Repeat></WithArray>", result);
     }
 
     @Test


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-11733

**What is the current behavior?** (You should also link to an open issue here)
Can't remove the simple filed value, beacuse the generate xml content of empty field  in datarecord is
empty.

**What is the new behavior?**
If value of simple field in datarecord, generate content like this: `<field></field>`


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
