### PR TITLE
TMDM-11733 beforeSaving process doesn't work if removing field of record

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/server/DefaultItemTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/server/DefaultItemTest.java
@@ -10,11 +10,6 @@
  */
 package com.amalto.core.server;
 
-import static com.amalto.core.query.user.UserQueryBuilder.eq;
-import static com.amalto.core.query.user.UserQueryBuilder.from;
-
-import java.io.IOException;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -36,15 +31,11 @@ import com.amalto.core.delegator.ILocalUser;
 import com.amalto.core.objects.datacluster.DataClusterPOJOPK;
 import com.amalto.core.objects.view.ViewPOJO;
 import com.amalto.core.objects.view.ViewPOJOPK;
-import com.amalto.core.query.user.UserQueryBuilder;
 import com.amalto.core.server.api.Item;
 import com.amalto.core.storage.Storage;
-import com.amalto.core.storage.StorageResults;
 import com.amalto.core.storage.StorageType;
 import com.amalto.core.storage.record.DataRecord;
 import com.amalto.core.storage.record.DataRecordReader;
-import com.amalto.core.storage.record.DataRecordWriter;
-import com.amalto.core.storage.record.DataRecordXmlWriter;
 import com.amalto.core.storage.record.XmlStringDataRecordReader;
 import com.amalto.core.util.ArrayListHolder;
 import com.amalto.core.util.Util;

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/server/DefaultItemTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/server/DefaultItemTest.java
@@ -10,6 +10,11 @@
  */
 package com.amalto.core.server;
 
+import static com.amalto.core.query.user.UserQueryBuilder.eq;
+import static com.amalto.core.query.user.UserQueryBuilder.from;
+
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -18,6 +23,7 @@ import java.util.List;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
+import org.apache.commons.lang.StringUtils;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
 import org.w3c.dom.Document;
@@ -30,11 +36,15 @@ import com.amalto.core.delegator.ILocalUser;
 import com.amalto.core.objects.datacluster.DataClusterPOJOPK;
 import com.amalto.core.objects.view.ViewPOJO;
 import com.amalto.core.objects.view.ViewPOJOPK;
+import com.amalto.core.query.user.UserQueryBuilder;
 import com.amalto.core.server.api.Item;
 import com.amalto.core.storage.Storage;
+import com.amalto.core.storage.StorageResults;
 import com.amalto.core.storage.StorageType;
 import com.amalto.core.storage.record.DataRecord;
 import com.amalto.core.storage.record.DataRecordReader;
+import com.amalto.core.storage.record.DataRecordWriter;
+import com.amalto.core.storage.record.DataRecordXmlWriter;
 import com.amalto.core.storage.record.XmlStringDataRecordReader;
 import com.amalto.core.util.ArrayListHolder;
 import com.amalto.core.util.Util;
@@ -450,6 +460,11 @@ public class DefaultItemTest extends TestCase {
         @Override
         public boolean isAdmin(Class<?> objectTypeClass) throws XtentisException {
             return true;
+        }
+
+        @Override
+        public String getUserXML() {
+            return StringUtils.EMPTY;
         }
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
@@ -204,24 +204,6 @@ public class DataRecord {
         return currentValue;
     }
 
-    public boolean containsFieldToValue(FieldMetadata field) {
-        if (field == null) {
-            return false;
-        }
-        return fieldToValue.containsKey(field);
-    }
-
-    public boolean containsFieldToValue(String fieldName) {
-        StringTokenizer tokenizer = new StringTokenizer(fieldName, "/"); //$NON-NLS-1$
-        DataRecord current = this;
-        while (tokenizer.hasMoreTokens()) {
-            String currentPathElement = tokenizer.nextToken();
-            FieldMetadata field = current.getType().getField(currentPathElement);
-            return fieldToValue.containsKey(field);
-        }
-        return false;
-    }
-
     public List<Object> find(FieldMetadata field) {
         // Build path elements
         String path = field.getPath();

--- a/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriterTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriterTestCase.java
@@ -225,6 +225,36 @@ public class DataRecordIncludeNullValueXmlWriterTestCase extends DataRecordDataW
     }
 
     @Test
+    public void testMultiContainedTypeWithEmptyDataRecord() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("WithMultiContained");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "ABCD");
+        FieldMetadata field = type.getField("Contained");
+        Assert.assertTrue(field instanceof ContainedTypeFieldMetadata);
+        ContainedTypeFieldMetadata containedField = (ContainedTypeFieldMetadata) field;
+        ContainedComplexTypeMetadata tm = (ContainedComplexTypeMetadata) containedField.getType();
+        List<DataRecord> list = new ArrayList<DataRecord>();
+        DataRecord contained1 = createDataRecord(tm);
+        list.add(contained1);
+
+        DataRecord contained2 = createDataRecord(tm);
+        list.add(contained2);
+
+        DataRecord contained3 = createDataRecord(tm);
+        setDataRecordField(contained3, "ContainedId", "CID2");
+        setDataRecordField(contained3, "ContainedName", null);
+        list.add(contained3);
+
+        setDataRecordField(record, "Contained", list);
+
+        String result = toXmlString(record);
+
+        Assert.assertEquals(
+                "<WithMultiContained><Id>ABCD</Id><Contained><ContainedId>CID2</ContainedId><ContainedName></ContainedName></Contained></WithMultiContained>",
+                result);
+    }
+
+    @Test
     public void testMultiContainedTypeWithNullList() throws Exception {
         ComplexTypeMetadata type = repository.getComplexType("WithMultiContained");
         DataRecord record = createDataRecord(type);

--- a/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriterTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordIncludeNullValueXmlWriterTestCase.java
@@ -225,7 +225,7 @@ public class DataRecordIncludeNullValueXmlWriterTestCase extends DataRecordDataW
     }
 
     @Test
-    public void testMultiContainedTypeWithEmptyDataRecord() throws Exception {
+    public void testMultiContainedTypeWithOneDataRecord() throws Exception {
         ComplexTypeMetadata type = repository.getComplexType("WithMultiContained");
         DataRecord record = createDataRecord(type);
         setDataRecordField(record, "Id", "ABCD");
@@ -251,6 +251,34 @@ public class DataRecordIncludeNullValueXmlWriterTestCase extends DataRecordDataW
 
         Assert.assertEquals(
                 "<WithMultiContained><Id>ABCD</Id><Contained><ContainedId>CID2</ContainedId><ContainedName></ContainedName></Contained></WithMultiContained>",
+                result);
+    }
+
+    @Test
+    public void testMultiContainedTypeWithEmptyDataRecord() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("WithMultiContained");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "ABCD");
+        FieldMetadata field = type.getField("Contained");
+        Assert.assertTrue(field instanceof ContainedTypeFieldMetadata);
+        ContainedTypeFieldMetadata containedField = (ContainedTypeFieldMetadata) field;
+        ContainedComplexTypeMetadata tm = (ContainedComplexTypeMetadata) containedField.getType();
+        List<DataRecord> list = new ArrayList<DataRecord>();
+        DataRecord contained1 = createDataRecord(tm);
+        list.add(contained1);
+
+        DataRecord contained2 = createDataRecord(tm);
+        list.add(contained2);
+
+        DataRecord contained3 = createDataRecord(tm);
+        list.add(contained3);
+
+        setDataRecordField(record, "Contained", list);
+
+        String result = toXmlString(record);
+
+        Assert.assertEquals(
+                "<WithMultiContained><Id>ABCD</Id><Contained><ContainedId></ContainedId><ContainedName></ContainedName></Contained></WithMultiContained>",
                 result);
     }
 


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-11733

**What is the current behavior?** (You should also link to an open issue here)
For ContainedTypeFieldMetadata type field and this field is multiple, value of this field, is not null but is empty, can't generate the xml formate content.


**What is the new behavior?**
For multipel ContainedTypeFieldMetadata type field, the value is list, if the list is empty, keep one datarecord in the new list container.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
