### PR TITLE
TMDM-9993 WebUI should take in account the language set to sort entities against multi-lingual element

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * 
+ * This source code is available under agreement available at
+ * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ * 
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+
+package com.amalto.core.storage.hibernate;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Criteria;
+import org.hibernate.HibernateException;
+import org.hibernate.criterion.CriteriaQuery;
+import org.hibernate.criterion.SimpleProjection;
+import org.hibernate.type.StringType;
+import org.hibernate.type.Type;
+import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.FieldMetadata;
+
+import com.amalto.core.storage.datasource.RDBMSDataSource.DataSourceDialect;
+
+@SuppressWarnings("serial")
+public class MultilingualProjection extends SimpleProjection {
+
+    private final String language;
+
+    private final FieldMetadata field;
+
+    private final TableResolver resolver;
+
+    private final DataSourceDialect dataSourceDialect;
+
+    MultilingualProjection(String language, FieldMetadata fieldMetadata, DataSourceDialect dataSourceDialect, TableResolver resolver) {
+        this.language = language;
+        this.field = fieldMetadata;
+        this.dataSourceDialect = dataSourceDialect;
+        this.resolver = resolver;
+    }
+
+    @Override
+    public String toSqlString(Criteria criteria, int position, CriteriaQuery criteriaQuery) throws HibernateException {
+        ComplexTypeMetadata containingType = field.getContainingType();
+
+        String columnName = resolver.get(field);
+        String containerTable = resolver.get(containingType);
+
+        final String colName = criteriaQuery.getColumn(criteria, containerTable + "." + columnName); //$NON-NLS-1$
+        
+        if (dataSourceDialect == DataSourceDialect.ORACLE_10G) {
+            columnName = columnName.toUpperCase();
+            containerTable = containerTable.toUpperCase();
+        }
+
+        StringBuilder sqlFragment = new StringBuilder();
+
+        String sql = StringUtils.EMPTY;
+        switch (dataSourceDialect) {
+        case H2:
+        case MYSQL:
+            sql = "SUBSTRING(" + colName + ", LOCATE('" + language + "', " + colName; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            break;
+        case SQL_SERVER:
+            sql = "SUBSTRING(" + colName + ", CHARINDEX('" + language + "', " + colName + "), LEN(" + colName; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            break;
+        case POSTGRES:
+            sql = "SUBSTRING(" + colName + ", POSITION('" + language + "' IN " + colName; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            break;
+        case ORACLE_10G:
+            sql = "SUBSTR(" + colName + ", INSTR(" + colName + ", '" + language + "'"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+            break;
+        case DB2:
+            sql = "SUBSTR(" + colName + ", LOCATE('" + language + "', " + colName; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+            break;
+        default:
+            throw new NotImplementedException("Support for repeatable element not implemented for dialect '" + dataSourceDialect //$NON-NLS-1$
+                    + "'.");//$NON-NLS-1$
+        }
+
+        sql += "))"; //$NON-NLS-1$
+        sqlFragment.append(sql).append(" as y").append(position).append('_'); //$NON-NLS-1$ //$NON-NLS-2$
+
+        return sqlFragment.toString();
+    }
+
+    @Override
+    public String[] getColumnAliases(String alias, int loc) {
+        return new String[] { StringUtils.EMPTY };
+    }
+    
+    @Override
+    public Type[] getTypes(Criteria criteria, CriteriaQuery criteriaQuery) throws HibernateException {
+        return new Type[] { new StringType() };
+    }
+
+    @Override
+    public Type[] getTypes(String alias, Criteria criteria, CriteriaQuery criteriaQuery) {
+        return new Type[] { new StringType() };
+    }
+    
+}

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -837,7 +837,7 @@ class StandardQueryHandler extends AbstractQueryHandler {
             if (StringUtils.isNotBlank(language)) {
                 MultilingualProjection multiProjection = new MultilingualProjection(language, userFieldMetadata,
                         ((RDBMSDataSource) storage.getDataSource()).getDialectName(), resolver);
-                projectionList.add(multiProjection.as(Types.MULTI_LINGUAL + "_" + Thread.currentThread().getId()));
+                projectionList.add(multiProjection.as(Types.MULTI_LINGUAL + "_"));
             }
 
             ComplexTypeMetadata containingType = getContainingType(userFieldMetadata);
@@ -1645,7 +1645,7 @@ class StandardQueryHandler extends AbstractQueryHandler {
         } else {
             String language = DataRecord.SortLanguage.get();
             if (StringUtils.isNotBlank(language)) {
-                condition.criterionFieldNames.add(Types.MULTI_LINGUAL + "_" + Thread.currentThread().getId());
+                condition.criterionFieldNames.add(Types.MULTI_LINGUAL + "_");
             } else {
                 condition.criterionFieldNames.add(alias + '.' + fieldMetadata.getName());
             }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -203,7 +203,17 @@ public class StorageQueryTest extends StorageTestCase {
                         .read(repository,
                                 person,
                                 "<Person><id>4</id><score>200000.00</score><lastname>Leblanc</lastname><middlename>John</middlename><firstname>Julien</firstname><age>30</age><Status>Friend</Status></Person>"));
-        allRecords.add(factory.read(repository, b, "<B><id>1</id><textB>TextB</textB></B>"));
+        allRecords
+                .add(factory
+                        .read(repository,
+                                person,
+                                "<Person><id>5</id><score>140000.00</score><lastname>John</lastname><resume>[EN:apple][FR:pomme]</resume><middlename>Mike</middlename><firstname>Bill</firstname><addresses><address>[2&amp;2][true]</address><address>[1][false]</address></addresses><age>10</age><Status>Employee</Status><Available>true</Available></Person>"));
+        allRecords
+                .add(factory
+                        .read(repository,
+                                person,
+                                "<Person><id>6</id><score>150000.00</score><lastname>Eric</lastname><resume>[EN:jelle][FR:gelee]</resume><middlename>Mike</middlename><firstname>Binary</firstname><addresses><address>[2&amp;2][true]</address><address>[1][false]</address></addresses><age>10</age><Status>Employee</Status><Available>true</Available></Person>"));
+ allRecords.add(factory.read(repository, b, "<B><id>1</id><textB>TextB</textB></B>"));
         allRecords.add(factory.read(repository, d, "<D><id>2</id><textB>TextBD</textB><textD>TextDD</textD></D>"));
         allRecords.add(factory.read(repository, a, "<A><id>1</id><textA>TextA</textA><nestedB><text>Text1</text></nestedB></A>"));
         allRecords.add(factory.read(repository, a,
@@ -584,7 +594,7 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).isa(person);
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -658,8 +668,8 @@ public class StorageQueryTest extends StorageTestCase {
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
             for (DataRecord result : results) {
                 assertNotNull(result.get(keyField));
             }
@@ -854,8 +864,8 @@ public class StorageQueryTest extends StorageTestCase {
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(3, results.getSize());
-            assertEquals(3, results.getCount());
+            assertEquals(5, results.getSize());
+            assertEquals(5, results.getCount());
             for (DataRecord result : results) {
                 assertNotNull(result.get(keyField));
             }
@@ -889,12 +899,12 @@ public class StorageQueryTest extends StorageTestCase {
         FieldMetadata personId = person.getField("id");
         UserQueryBuilder qb = from(person).orderBy(personLastName, OrderBy.Direction.ASC).orderBy(personId,
                 OrderBy.Direction.DESC);
-        String[] ascExpectedValues = { "Dupond", "Dupont", "Leblanc", "Leblanc" };
+        String[] ascExpectedValues = { "Dupond", "Dupont", "Eric", "John", "Leblanc", "Leblanc" };
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
             int i = 0;
             for (DataRecord result : results) {
                 assertEquals(ascExpectedValues[i++], result.get(personLastName));
@@ -955,12 +965,12 @@ public class StorageQueryTest extends StorageTestCase {
         // Test ASC direction
         FieldMetadata personLastName = person.getField("lastname");
         UserQueryBuilder qb = from(person).select(personLastName).orderBy(person.getField("id"), OrderBy.Direction.ASC);
-        String[] ascExpectedValues = { "Dupond", "Dupont", "Leblanc", "Leblanc" };
+        String[] ascExpectedValues = { "Dupond", "Dupont", "Leblanc", "Leblanc", "John", "Eric"};
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
 
             int i = 0;
             for (DataRecord result : results) {
@@ -987,12 +997,12 @@ public class StorageQueryTest extends StorageTestCase {
         // Test ASC direction
         FieldMetadata personLastName = person.getField("lastname");
         UserQueryBuilder qb = from(person).orderBy(personLastName, OrderBy.Direction.ASC);
-        String[] ascExpectedValues = { "Dupond", "Dupont", "Leblanc", "Leblanc" };
+        String[] ascExpectedValues = { "Dupond", "Dupont", "Eric", "John", "Leblanc", "Leblanc" };
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
 
             int i = 0;
             for (DataRecord result : results) {
@@ -1007,12 +1017,12 @@ public class StorageQueryTest extends StorageTestCase {
     public void testOrderByDESC() throws Exception {
         FieldMetadata personLastName = person.getField("lastname");
         UserQueryBuilder qb = from(person).orderBy(personLastName, OrderBy.Direction.DESC);
-        String[] descExpectedValues = { "Leblanc", "Leblanc", "Dupont", "Dupond" };
+        String[] descExpectedValues = { "Leblanc", "Leblanc", "John", "Eric", "Dupont", "Dupond" };
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
 
             int i = 0;
             for (DataRecord result : results) {
@@ -1028,8 +1038,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person);
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -1128,8 +1138,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(neq(person.getField("lastname"), "Dupond"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(3, results.getSize());
-            assertEquals(3, results.getCount());
+            assertEquals(5, results.getSize());
+            assertEquals(5, results.getCount());
         } finally {
             results.close();
         }
@@ -1172,8 +1182,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(gt(person.getField("score"), "100000"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -1183,8 +1193,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(lt(person.getField("age"), "20"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(1, results.getSize());
-            assertEquals(1, results.getCount());
+            assertEquals(3, results.getSize());
+            assertEquals(3, results.getCount());
         } finally {
             results.close();
         }
@@ -1216,8 +1226,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(lt(person.getField("score"), "1000000"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -1227,8 +1237,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(gte(person.getField("age"), "10"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -1238,8 +1248,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(gte(person.getField("age"), "10")).where(lte(person.getField("age"), "30"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -1282,8 +1292,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(lte(person.getField("age"), "20"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getSize());
-            assertEquals(2, results.getCount());
+            assertEquals(4, results.getSize());
+            assertEquals(4, results.getCount());
         } finally {
             results.close();
         }
@@ -1315,8 +1325,8 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).where(lte(person.getField("score"), "170000"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getSize());
-            assertEquals(2, results.getCount());
+            assertEquals(4, results.getSize());
+            assertEquals(4, results.getCount());
         } finally {
             results.close();
         }
@@ -1476,8 +1486,8 @@ public class StorageQueryTest extends StorageTestCase {
                 .join(person.getField("addresses/address"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(6, results.getSize());
-            assertEquals(6, results.getCount());
+            assertEquals(10, results.getSize());
+            assertEquals(10, results.getCount());
         } finally {
             results.close();
         }
@@ -1528,8 +1538,8 @@ public class StorageQueryTest extends StorageTestCase {
                 .join(person.getField("addresses/address"));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(6, results.getSize());
-            assertEquals(6, results.getCount());
+            assertEquals(10, results.getSize());
+            assertEquals(10, results.getCount());
         } finally {
             results.close();
         }
@@ -1580,8 +1590,8 @@ public class StorageQueryTest extends StorageTestCase {
         StorageResults results = storage.fetch(qb.getSelect());
 
         try {
-            assertEquals(6, results.getSize());
-            assertEquals(6, results.getCount());
+            assertEquals(10, results.getSize());
+            assertEquals(10, results.getCount());
         } finally {
             results.close();
         }
@@ -1605,7 +1615,7 @@ public class StorageQueryTest extends StorageTestCase {
         StorageResults results = storage.fetch(qb.getSelect());
         try {
             assertEquals(1, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
             for (DataRecord result : results) {
                 assertNotNull(result.get("id"));
             }
@@ -1615,26 +1625,26 @@ public class StorageQueryTest extends StorageTestCase {
         qb = from(person).limit(-1);
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
             int actualCount = 0;
             for (DataRecord result : results) {
                 actualCount++;
             }
-            assertEquals(4, actualCount);
+            assertEquals(6, actualCount);
         } finally {
             results.close();
         }
         qb = from(person);
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
             int actualCount = 0;
             for (DataRecord result : results) {
                 actualCount++;
             }
-            assertEquals(4, actualCount);
+            assertEquals(6, actualCount);
         } finally {
             results.close();
         }
@@ -1642,7 +1652,7 @@ public class StorageQueryTest extends StorageTestCase {
         results = storage.fetch(qb.getSelect());
         try {
             assertEquals(1, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -1650,16 +1660,15 @@ public class StorageQueryTest extends StorageTestCase {
         results = storage.fetch(qb.getSelect());
         try {
             assertEquals(1, results.getSize());
-            assertEquals(4, results.getCount());
-            assertFalse(results.iterator().hasNext());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
         qb = from(person).selectId(person).limit(-1);
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getSize());
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getSize());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -1756,7 +1765,7 @@ public class StorageQueryTest extends StorageTestCase {
 
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
             for (DataRecord result : results) {
                 assertNotNull(result.get("timestamp"));
                 assertNull(result.get("taskid"));
@@ -2002,7 +2011,7 @@ public class StorageQueryTest extends StorageTestCase {
         UserQueryBuilder qb = from(person).selectId(person).where(lte(person.getField("id"), person.getField("score")));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -2102,7 +2111,7 @@ public class StorageQueryTest extends StorageTestCase {
                 and(gte(timestamp(), "0"), lte(timestamp(), String.valueOf(System.currentTimeMillis()))));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -2114,7 +2123,7 @@ public class StorageQueryTest extends StorageTestCase {
                         eq(person.getField("id"), "1")));
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -2571,8 +2580,8 @@ public class StorageQueryTest extends StorageTestCase {
     public void testNativeQueryWithReturn() throws Exception {
         UserQueryBuilder qb = from("SELECT * FROM PERSON;");
         StorageResults results = storage.fetch(qb.getExpression());
-        assertEquals(4, results.getCount());
-        assertEquals(4, results.getSize());
+        assertEquals(6, results.getCount());
+        assertEquals(6, results.getSize());
         for (DataRecord result : results) {
             assertNotNull(result.get("col0") != null);
         }
@@ -2597,7 +2606,7 @@ public class StorageQueryTest extends StorageTestCase {
         qb = from(person).where(eq(person.getField("firstname"), "My SQL modified firstname"));
         results = storage.fetch(qb.getExpression());
         try {
-            assertEquals(4, results.getCount());
+            assertEquals(6, results.getCount());
         } finally {
             results.close();
         }
@@ -2643,13 +2652,122 @@ public class StorageQueryTest extends StorageTestCase {
         }
     }
 
+    public void testMultiLingualSearchSort() throws Exception {
+        DataRecord.SortLanguage.set("EN");
+        UserQueryBuilder qb = from(person).select(person.getField("id")).select(person.getField("resume"))
+                .orderBy(person.getField("resume"), Direction.ASC);
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(6, results.getCount());
+            int i = 1;
+            for (DataRecord result : results) {
+                if (i == 1) {
+                    assertEquals("2", result.get(person.getField("id")));
+                } else if (i == 2) {
+                    assertEquals("3", result.get(person.getField("id")));
+                } else if (i == 3) {
+                    assertEquals("4", result.get(person.getField("id")));
+                } else if (i == 4) {
+                    assertEquals("5", result.get(person.getField("id")));
+                } else if (i == 5) {
+                    assertEquals("6", result.get(person.getField("id")));
+                } else if (i == 6) {
+                    assertEquals("1", result.get(person.getField("id")));
+                }
+                i++;
+            }
+        } finally {
+            results.close();
+        }
+
+        qb = from(person).select(person.getField("resume")).select(person.getField("id"))
+                .orderBy(person.getField("resume"), Direction.DESC);
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(6, results.getCount());
+            int i = 1;
+            for (DataRecord result : results) {
+                if (i == 1) {
+                    assertEquals("1", result.get(person.getField("id")));
+                } else if (i == 2) {
+                    assertEquals("6", result.get(person.getField("id")));
+                } else if (i == 3) {
+                    assertEquals("5", result.get(person.getField("id")));
+                } else if (i == 4) {
+                    assertEquals("2", result.get(person.getField("id")));
+                } else if (i == 5) {
+                    assertEquals("3", result.get(person.getField("id")));
+                } else if (i == 6) {
+                    assertEquals("4", result.get(person.getField("id")));
+                }
+                i++;
+            }
+        } finally {
+            results.close();
+        }
+
+        DataRecord.SortLanguage.set("FR");
+        qb = from(person).select(person.getField("resume")).select(person.getField("id"))
+                .orderBy(person.getField("resume"), Direction.ASC);
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(6, results.getCount());
+            assertEquals(6, results.getCount());
+            int i = 1;
+            for (DataRecord result : results) {
+                if (i == 1) {
+                    assertEquals("2", result.get(person.getField("id")));
+                } else if (i == 2) {
+                    assertEquals("3", result.get(person.getField("id")));
+                } else if (i == 3) {
+                    assertEquals("4", result.get(person.getField("id")));
+                } else if (i == 4) {
+                    assertEquals("6", result.get(person.getField("id")));
+                } else if (i == 5) {
+                    assertEquals("1", result.get(person.getField("id")));
+                } else if (i == 6) {
+                    assertEquals("5", result.get(person.getField("id")));
+                }
+                i++;
+            }
+        } finally {
+            results.close();
+        }
+
+        qb = from(person).select(person.getField("resume")).select(person.getField("id"))
+                .orderBy(person.getField("resume"), Direction.DESC);
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(6, results.getCount());
+            int i = 1;
+            for (DataRecord result : results) {
+                if (i == 1) {
+                    assertEquals("5", result.get(person.getField("id")));
+                } else if (i == 2) {
+                    assertEquals("1", result.get(person.getField("id")));
+                } else if (i == 3) {
+                    assertEquals("6", result.get(person.getField("id")));
+                } else if (i == 4) {
+                    assertEquals("2", result.get(person.getField("id")));
+                } else if (i == 5) {
+                    assertEquals("3", result.get(person.getField("id")));
+                } else if (i == 6) {
+                    assertEquals("4", result.get(person.getField("id")));
+                }
+                i++;
+            }
+        } finally {
+            results.close();
+        }
+    }
+
     public void testSortOnXPath() throws Exception {
         UserQueryBuilder qb = from(person).selectId(person);
         TypedExpression sortField = UserQueryHelper.getFields(person, "../../i").get(0);
         qb.orderBy(sortField, OrderBy.Direction.DESC);
 
         StorageResults storageResults = storage.fetch(qb.getSelect());
-        String[] expected = { "4", "3", "2", "1" };
+        String[] expected = { "6", "5", "4", "3", "2", "1" };
         int i = 0;
         for (DataRecord result : storageResults) {
             assertEquals(expected[i++], result.get("id"));
@@ -4013,7 +4131,7 @@ public class StorageQueryTest extends StorageTestCase {
         try {
             for (DataRecord result : results) {
                 assertNotNull(result.get("count"));
-                assertEquals(4l, result.get("count"));
+                assertEquals(6l, result.get("count"));
             }
         } finally {
             results.close();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -2678,8 +2678,10 @@ public class StorageQueryTest extends StorageTestCase {
             }
         } finally {
             results.close();
+            DataRecord.SortLanguage.remove();
         }
 
+        DataRecord.SortLanguage.set("EN");
         qb = from(person).select(person.getField("resume")).select(person.getField("id"))
                 .orderBy(person.getField("resume"), Direction.DESC);
         results = storage.fetch(qb.getSelect());
@@ -2704,6 +2706,7 @@ public class StorageQueryTest extends StorageTestCase {
             }
         } finally {
             results.close();
+            DataRecord.SortLanguage.remove();
         }
 
         DataRecord.SortLanguage.set("FR");
@@ -2732,8 +2735,10 @@ public class StorageQueryTest extends StorageTestCase {
             }
         } finally {
             results.close();
+            DataRecord.SortLanguage.remove();
         }
 
+        DataRecord.SortLanguage.set("FR");
         qb = from(person).select(person.getField("resume")).select(person.getField("id"))
                 .orderBy(person.getField("resume"), Direction.DESC);
         results = storage.fetch(qb.getSelect());
@@ -2758,6 +2763,7 @@ public class StorageQueryTest extends StorageTestCase {
             }
         } finally {
             results.close();
+            DataRecord.SortLanguage.remove();
         }
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
@@ -12,6 +12,7 @@ package com.amalto.core.storage.record;
 
 import java.util.*;
 
+import org.apache.commons.lang3.StringUtils;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
@@ -395,7 +396,7 @@ public class DataRecord {
             threadLocal.remove();
         }
     }
-    
+
     /**
      * Used to control if only validate a record but not save it.
      *
@@ -417,6 +418,33 @@ public class DataRecord {
         }
 
         public static boolean get() {
+            return threadLocal.get();
+        }
+
+        public static void remove() {
+            threadLocal.remove();
+        }
+    }
+
+    /**
+     * Used to store sort language if use multilingual field sort.
+     *
+     */
+    public static class SortLanguage {
+
+        private static ThreadLocal<String> threadLocal = new ThreadLocal<String>() {
+
+            public String initialValue() {
+                return StringUtils.EMPTY;
+            }
+        };
+
+
+        public static void set(String value) {
+            threadLocal.set(value);
+        }
+
+        public static String get() {
             return threadLocal.get();
         }
 

--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/ForeignKeyHelper.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/ForeignKeyHelper.java
@@ -221,7 +221,9 @@ public class ForeignKeyHelper {
                             .getStrings();
                 }
             } finally {
-                DataRecord.SortLanguage.remove();
+                if (isSrotLanguage) {
+                    DataRecord.SortLanguage.remove();
+                }
             }
         }
         if (results != null) {

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
@@ -34,7 +34,6 @@ import org.dom4j.DocumentHelper;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
-import org.talend.mdm.commmon.metadata.Types;
 import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.datamodel.management.BusinessConcept;
 import org.talend.mdm.commmon.util.datamodel.management.ReusableType;


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-9993

**What is the current behavior?** (You should also link to an open issue here)
Ccan not sort for multilingual field.


**What is the new behavior?**
Add the sort for multilingual field, master grid and forigner pick.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
