### PR TITLE
TMDM-12390 NPE when deploy data model

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/services/SystemModels.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/services/SystemModels.java
@@ -253,6 +253,13 @@ public class SystemModels {
     public String analyzeModelChange(@ApiParam("Model name") @PathParam("model") String modelName, 
             @ApiParam("Optional language to get localized result") @QueryParam("lang") String locale, 
             InputStream dataModel) {
+        DataModelPOJO dataModelPOJO;
+        try {
+            dataModelPOJO = DataModelPOJO.load(DataModelPOJO.class, new DataModelPOJOPK(modelName));
+        } catch (XtentisException e) {
+            LOGGER.error("An error occurred while fetching Data Model.", e);
+            throw new RuntimeException("An error occurred while fetching Data Model.", e); //$NON-NLS-1$
+        }
         Map<ImpactAnalyzer.Impact, List<Change>> impacts;
         List<String> typeNamesToDrop = new ArrayList<String>();
         if (!isSystemStorageAvailable()) {
@@ -263,7 +270,7 @@ public class SystemModels {
         } else {
             StorageAdmin storageAdmin = ServerContext.INSTANCE.get().getStorageAdmin();
             Storage storage = storageAdmin.get(modelName, StorageType.MASTER);
-            if (storage == null) {
+            if (storage == null || dataModelPOJO == null) {
                 LOGGER.warn("Container '" + modelName + "' does not exist. Skip impact analyzing for model change."); //$NON-NLS-1$//$NON-NLS-2$
                 return StringUtils.EMPTY;
             }


### PR DESCRIPTION
Jira:　https://jira.talendforge.org/browse/TMDM-12390

**What is the current behavior?** (You should also link to an open issue here)
After undeploy datamodel, redeploy datamodel, throw NPE. beacuse it only remove from database, but can't remove from storage.


**What is the new behavior?**
When undeploy data model, also delete from storage


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
