### PR TITLE
TMDM-12496 Read only FK can be modified in grid list (#604)

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyCellField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyCellField.java
@@ -25,6 +25,8 @@ public class ForeignKeyCellField extends ForeignKeyField {
 
     public ForeignKeyCellField(ForeignKeyField foreignKeyField, String foreignKeyFilter) {
         super(foreignKeyField.getDataType());
+        super.setReadOnly(foreignKeyField.isReadOnly());
+        super.setEnabled(!foreignKeyField.isReadOnly());
         this.foreignKeyFilter = foreignKeyFilter;
     }
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/celleditor/FormatCellEditorGWTTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/celleditor/FormatCellEditorGWTTest.java
@@ -26,6 +26,7 @@ import org.talend.mdm.webapp.browserecords.client.model.ItemBean;
 import org.talend.mdm.webapp.browserecords.client.util.DateUtil;
 import org.talend.mdm.webapp.browserecords.client.util.UserSession;
 import org.talend.mdm.webapp.browserecords.client.widget.ItemsListPanel;
+import org.talend.mdm.webapp.browserecords.client.widget.ForeignKey.ForeignKeyCellField;
 import org.talend.mdm.webapp.browserecords.client.widget.ForeignKey.ForeignKeyField;
 import org.talend.mdm.webapp.browserecords.client.widget.inputfield.FormatDateField;
 
@@ -170,14 +171,14 @@ public class FormatCellEditorGWTTest extends GWTTestCase {
         assertEquals("2012-12-03T12:30:55", dateStr);
         assertEquals(DateUtil.tryConvertStringToDate("2012-12-03T12:30:55"), selectedItem.getOriginalMap().get(field.getName()));
     }
-    
+
     public void testFKCellEditor() {
         UserSession session = new UserSession();
         AppHeader appHeader = new AppHeader();
         appHeader.setAutoValidate(false);
         session.put(UserSession.APP_HEADER, appHeader);
         Registry.register(BrowseRecords.USER_SESSION, session);
-        
+
         List<String> foreignKeyInfo = new ArrayList<String>();
         foreignKeyInfo.add("ProductFamily/name");
         SimpleTypeModel simpleTypeModel = new SimpleTypeModel();
@@ -185,19 +186,26 @@ public class FormatCellEditorGWTTest extends GWTTestCase {
         simpleTypeModel.setMaxOccurs(-1);
         simpleTypeModel.setForeignkey("ProductFamily/Id");
         simpleTypeModel.setForeignKeyInfo(foreignKeyInfo);
-        
+        simpleTypeModel.setReadOnly(true);
+
         Map<String, String> fkInfo = new LinkedHashMap<String, String>();
         fkInfo.put("ProductFamily/Name", "f3");
-        
+
         foreignKeyField = new ForeignKeyField(simpleTypeModel);
         ForeignKeyBean fkBean = new ForeignKeyBean();
         fkBean.setForeignKeyInfo(fkInfo);
-        
+        foreignKeyField.setReadOnly(simpleTypeModel.isReadOnly());
+        foreignKeyField.setEnabled(!simpleTypeModel.isReadOnly());
+
         foreignKeyField.setValue(fkBean);
         FKCellEditor cellEditor = new FKCellEditor(foreignKeyField);
         cellEditor.preProcessValue("any string");
-        
+
         assertNull(foreignKeyField.getSuggestBox().getValue());
+        assertEquals(true, foreignKeyField.isReadOnly());
+        assertEquals(false, foreignKeyField.isEnabled());
+        assertEquals(false, foreignKeyField.getSuggestBox().isEnabled());
+        assertEquals(true, foreignKeyField.getSuggestBox().isReadOnly());
     }
 
     public void testForeignKeyCellEditor() {
@@ -228,6 +236,56 @@ public class FormatCellEditorGWTTest extends GWTTestCase {
         ForeignKeyBean foreignKeyBean = (ForeignKeyBean) result;
         assertEquals(1, foreignKeyBean.getForeignKeyInfo().size());
         assertEquals("TestFamily", foreignKeyBean.getDisplayInfo());
+    }
+
+    public void testForeignKeyCellField() {
+        UserSession session = new UserSession();
+        AppHeader appHeader = new AppHeader();
+        appHeader.setAutoValidate(false);
+        session.put(UserSession.APP_HEADER, appHeader);
+        Registry.register(BrowseRecords.USER_SESSION, session);
+
+        List<String> foreignKeyInfo = new ArrayList<String>();
+        foreignKeyInfo.add("ProductFamily/name");
+        SimpleTypeModel simpleTypeModel = new SimpleTypeModel();
+        simpleTypeModel.setAutoExpand(false);
+        simpleTypeModel.setMaxOccurs(-1);
+        simpleTypeModel.setForeignkey("ProductFamily/Id");
+        simpleTypeModel.setForeignKeyInfo(foreignKeyInfo);
+        simpleTypeModel.setReadOnly(true);
+
+        Map<String, String> fkInfo = new LinkedHashMap<String, String>();
+        fkInfo.put("ProductFamily/Name", "f3");
+
+        foreignKeyField = new ForeignKeyField(simpleTypeModel);
+        foreignKeyField.setReadOnly(simpleTypeModel.isReadOnly());
+        foreignKeyField.setEnabled(!simpleTypeModel.isReadOnly());
+        ForeignKeyBean fkBean = new ForeignKeyBean();
+        fkBean.setForeignKeyInfo(fkInfo);
+
+        foreignKeyField.setValue(fkBean);
+        ForeignKeyCellField cellEditor = new ForeignKeyCellField(foreignKeyField, "Family/Name");
+
+        assertEquals(true, cellEditor.isReadOnly());
+        assertEquals(false, cellEditor.isEnabled());
+        assertEquals(false, cellEditor.getSuggestBox().isEnabled());
+        assertEquals(true, cellEditor.getSuggestBox().isReadOnly());
+
+        // for read-only=false
+        simpleTypeModel.setReadOnly(false);
+        foreignKeyField = new ForeignKeyField(simpleTypeModel);
+        foreignKeyField.setReadOnly(simpleTypeModel.isReadOnly());
+        foreignKeyField.setEnabled(!simpleTypeModel.isReadOnly());
+        fkBean = new ForeignKeyBean();
+        fkBean.setForeignKeyInfo(fkInfo);
+
+        foreignKeyField.setValue(fkBean);
+        cellEditor = new ForeignKeyCellField(foreignKeyField, "Family/Name");
+
+        assertEquals(false, cellEditor.isReadOnly());
+        assertEquals(true, cellEditor.isEnabled());
+        assertEquals(true, cellEditor.getSuggestBox().isEnabled());
+        assertEquals(false, cellEditor.getSuggestBox().isReadOnly());
     }
 
     private void mockGrid() {


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-12496

**What is the current behavior?** (You should also link to an open issue here)
Read only FK can be modified in grid list


**What is the new behavior?**
unenable for the read only FK field in grid list


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
