### PR TITLE
TMDM-12515 Can't prepare DB if field's type is MULTI_LINGUAL or boolean and has default value

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
@@ -18,9 +18,9 @@ import com.amalto.core.storage.hibernate.TypeMapping;
 @SuppressWarnings({ "nls"})
 public abstract class HibernateStorageUtils {
 
-    private static final String FALSE = Boolean.toString(false);
+    private static final String FALSE = Boolean.FALSE.toString();
 
-    private static final String TRUE = Boolean.toString(true);
+    private static final String TRUE = Boolean.TRUE.toString();
 
     public static String convertedDefaultValue(String fieldType, DataSourceDialect dialect, String defaultValueRule,
             String replexStr) {
@@ -63,7 +63,6 @@ public abstract class HibernateStorageUtils {
             return true;
         }
 
-        String[] searchStrings = new String[] { "\"", "'" };
         if (defaultValue.matches("('.*?'|\".*?\")")) {
             String lowerCaseDefaultValue = defaultValue.replaceAll("\"|'", "").toLowerCase();
             if (lowerCaseDefaultValue.equals(TRUE) || lowerCaseDefaultValue.equals(FALSE)) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
@@ -34,13 +34,13 @@ public abstract class HibernateStorageUtils {
                 if (isSQLServer(dialect) || isOracle(dialect) || isMySQL(dialect) || isDB2(dialect)) {
                     covertValue = "0";
                 } else {
-                    covertValue = Boolean.FALSE.toString();
+                    covertValue = FALSE;
                 }
             } else if (defaultValueRule.equalsIgnoreCase(MetadataRepository.FN_TRUE) || defaultValueRule.contains(TRUE)) {
                 if (isSQLServer(dialect) || isOracle(dialect) || isMySQL(dialect) || isDB2(dialect)) {
                     covertValue = "1";
                 } else {
-                    covertValue = Boolean.TRUE.toString();
+                    covertValue = TRUE;
                 }
             }
         } else if (defaultValueRule.startsWith("\"") && defaultValueRule.endsWith("\"")) {
@@ -50,7 +50,7 @@ public abstract class HibernateStorageUtils {
     }
 
     public static boolean isBooleanDefaultValue(String fieldType, String defaultValue) {
-        if (!fieldType.equals(TypeMapping.SQL_TYPE_BOOLEAN)) {
+        if (!TypeMapping.SQL_TYPE_BOOLEAN.equals(fieldType)) {
             return false;
         }
 
@@ -58,8 +58,8 @@ public abstract class HibernateStorageUtils {
     }
 
     public static boolean isBooleanDefaultValue(String defaultValue) {
-        if (defaultValue.equalsIgnoreCase(MetadataRepository.FN_FALSE)
-                || defaultValue.equalsIgnoreCase(MetadataRepository.FN_TRUE)) {
+        if (MetadataRepository.FN_FALSE.equalsIgnoreCase(defaultValue)
+                || MetadataRepository.FN_TRUE.equalsIgnoreCase(defaultValue)) {
             return true;
         }
 

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
@@ -9,6 +9,7 @@
  */
 package com.amalto.core.storage;
 
+import org.apache.commons.lang.StringUtils;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
 
 import com.amalto.core.storage.datasource.RDBMSDataSource;
@@ -58,14 +59,19 @@ public abstract class HibernateStorageUtils {
     }
 
     public static boolean isBooleanDefaultValue(String defaultValue) {
-        if (defaultValue.startsWith("\"") && defaultValue.endsWith("\"")
-                && (defaultValue.toLowerCase().contains(TRUE) || defaultValue.toLowerCase().contains(FALSE))) {
-            return true;
-        }
         if (defaultValue.equalsIgnoreCase(MetadataRepository.FN_FALSE)
                 || defaultValue.equalsIgnoreCase(MetadataRepository.FN_TRUE)) {
             return true;
         }
+
+        String[] searchStrings = new String[] { "\"", "'" };
+        if (StringUtils.startsWithAny(defaultValue, searchStrings) && StringUtils.endsWithAny(defaultValue, searchStrings)) {
+            String lowerCaseDefaultValue = defaultValue.replaceAll("\"|'", "").toLowerCase();
+            if (lowerCaseDefaultValue.equals(TRUE) || lowerCaseDefaultValue.equals(FALSE)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
@@ -13,32 +13,83 @@ import org.talend.mdm.commmon.metadata.MetadataRepository;
 
 import com.amalto.core.storage.datasource.RDBMSDataSource;
 import com.amalto.core.storage.datasource.RDBMSDataSource.DataSourceDialect;
+import com.amalto.core.storage.hibernate.TypeMapping;
 
+@SuppressWarnings({ "nls"})
 public abstract class HibernateStorageUtils {
 
-    public static String convertedDefaultValue(DataSourceDialect dialect, String defaultValueRule, String replexStr) {
+    private static final String FALSE = Boolean.toString(false);
+
+    private static final String TRUE = Boolean.toString(true);
+
+    public static String convertedDefaultValue(String fieldType, DataSourceDialect dialect, String defaultValueRule,
+            String replexStr) {
         if (defaultValueRule == null) {
             return null;
         }
-        
+
         String covertValue = defaultValueRule;
-        if (defaultValueRule.equalsIgnoreCase(MetadataRepository.FN_FALSE)) {
-            if (dialect == RDBMSDataSource.DataSourceDialect.SQL_SERVER
-                    || dialect == RDBMSDataSource.DataSourceDialect.ORACLE_10G) {
-                covertValue = "0"; //$NON-NLS-1$
-            } else {
-                covertValue = Boolean.FALSE.toString();
+        if (isBooleanDefaultValue(fieldType, defaultValueRule)) {
+            if (defaultValueRule.equalsIgnoreCase(MetadataRepository.FN_FALSE) || defaultValueRule.contains(FALSE)) {
+                if (isSQLServer(dialect) || isOracle(dialect) || isMySQL(dialect) || isDB2(dialect)) {
+                    covertValue = "0";
+                } else {
+                    covertValue = Boolean.FALSE.toString();
+                }
+            } else if (defaultValueRule.equalsIgnoreCase(MetadataRepository.FN_TRUE) || defaultValueRule.contains(TRUE)) {
+                if (isSQLServer(dialect) || isOracle(dialect) || isMySQL(dialect) || isDB2(dialect)) {
+                    covertValue = "1";
+                } else {
+                    covertValue = Boolean.TRUE.toString();
+                }
             }
-        } else if (defaultValueRule.equalsIgnoreCase(MetadataRepository.FN_TRUE)) {
-            if (dialect == RDBMSDataSource.DataSourceDialect.SQL_SERVER
-                    || dialect == RDBMSDataSource.DataSourceDialect.ORACLE_10G) {
-                covertValue = "1"; //$NON-NLS-1$
-            } else {
-                covertValue = Boolean.TRUE.toString();
-            }
-        } else if (defaultValueRule.startsWith("\"") && defaultValueRule.endsWith("\"")) { //$NON-NLS-1$ //$NON-NLS-2$
-            covertValue = defaultValueRule.replace("\"", replexStr); //$NON-NLS-1$
+        } else if (defaultValueRule.startsWith("\"") && defaultValueRule.endsWith("\"")) {
+            covertValue = defaultValueRule.replace("\"", replexStr);
         }
         return covertValue;
+    }
+
+    public static boolean isBooleanDefaultValue(String fieldType, String defaultValue) {
+        if (!fieldType.equals(TypeMapping.SQL_TYPE_BOOLEAN)) {
+            return false;
+        }
+
+        return isBooleanDefaultValue(defaultValue);
+    }
+
+    public static boolean isBooleanDefaultValue(String defaultValue) {
+        if (defaultValue.startsWith("\"") && defaultValue.endsWith("\"")
+                && (defaultValue.toLowerCase().contains(TRUE) || defaultValue.toLowerCase().contains(FALSE))) {
+            return true;
+        }
+        if (defaultValue.equalsIgnoreCase(MetadataRepository.FN_FALSE)
+                || defaultValue.equalsIgnoreCase(MetadataRepository.FN_TRUE)) {
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean isOracle(DataSourceDialect dialect) {
+        return dialect == RDBMSDataSource.DataSourceDialect.ORACLE_10G;
+    }
+
+    public static boolean isSQLServer(DataSourceDialect dialect) {
+        return dialect == RDBMSDataSource.DataSourceDialect.SQL_SERVER;
+    }
+
+    public static boolean isMySQL(DataSourceDialect dialect) {
+        return dialect == RDBMSDataSource.DataSourceDialect.MYSQL;
+    }
+
+    public static boolean isH2(DataSourceDialect dialect) {
+        return dialect == RDBMSDataSource.DataSourceDialect.H2;
+    }
+
+    public static boolean isPostgres(DataSourceDialect dialect) {
+        return dialect == RDBMSDataSource.DataSourceDialect.POSTGRES;
+    }
+
+    public static boolean isDB2(DataSourceDialect dialect) {
+        return dialect == RDBMSDataSource.DataSourceDialect.DB2;
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/HibernateStorageUtils.java
@@ -9,7 +9,6 @@
  */
 package com.amalto.core.storage;
 
-import org.apache.commons.lang.StringUtils;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
 
 import com.amalto.core.storage.datasource.RDBMSDataSource;
@@ -65,7 +64,7 @@ public abstract class HibernateStorageUtils {
         }
 
         String[] searchStrings = new String[] { "\"", "'" };
-        if (StringUtils.startsWithAny(defaultValue, searchStrings) && StringUtils.endsWithAny(defaultValue, searchStrings)) {
+        if (defaultValue.matches("('.*?'|\".*?\")")) {
             String lowerCaseDefaultValue = defaultValue.replaceAll("\"|'", "").toLowerCase();
             if (lowerCaseDefaultValue.equals(TRUE) || lowerCaseDefaultValue.equals(FALSE)) {
                 return true;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -340,8 +340,8 @@ public class HibernateStorage implements Storage {
 
                     if ( table == null ) {
                         table = new MDMTable();
-                        ((MDMTable)table).setDataSource(dataSource);
-                        table.setAbstract( isAbstract );
+                        ((MDMTable) table).setDataSource(dataSource);
+                        table.setAbstract(isAbstract);
                         table.setName( name );
                         table.setSchema( schema );
                         table.setCatalog( catalog );

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -340,6 +340,7 @@ public class HibernateStorage implements Storage {
 
                     if ( table == null ) {
                         table = new MDMTable();
+                        ((MDMTable)table).setDataSource(dataSource);
                         table.setAbstract( isAbstract );
                         table.setName( name );
                         table.setSchema( schema );
@@ -385,6 +386,7 @@ public class HibernateStorage implements Storage {
                             return indexes.iterator();
                         }
                     };
+                    ((MDMTable)table).setDataSource(dataSource);
                     table.setAbstract(isAbstract);
                     table.setName(name);
                     table.setSchema(schema);

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -386,7 +386,9 @@ public class HibernateStorage implements Storage {
                             return indexes.iterator();
                         }
                     };
-                    ((MDMTable)table).setDataSource(dataSource);
+                    if (table instanceof MDMTable) {
+                        ((MDMTable) table).setDataSource(dataSource);
+                    }
                     table.setAbstract(isAbstract);
                     table.setName(name);
                     table.setSchema(schema);

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -174,7 +174,8 @@ public class LiquibaseSchemaAdapter  {
                 FieldMetadata current = (FieldMetadata) modifyAction.getCurrent();
 
                 String defaultValueRule = current.getData(MetadataRepository.DEFAULT_VALUE_RULE);
-                defaultValueRule = HibernateStorageUtils.convertedDefaultValue(dataSource.getDialectName(), defaultValueRule, StringUtils.EMPTY);
+                defaultValueRule = HibernateStorageUtils.convertedDefaultValue(current.getType().getName(),
+                        dataSource.getDialectName(), defaultValueRule, StringUtils.EMPTY);
                 String tableName = getTableName(current);
                 String columnDataType = getColumnTypeName(current);
                 String columnName = getColumnName(current);

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
@@ -740,12 +740,13 @@ public class MappingGenerator extends DefaultMetadataVisitor<Element> {
         // default value
         String defaultValueRule = field.getData(MetadataRepository.DEFAULT_VALUE_RULE);
         if (StringUtils.isNotBlank(defaultValueRule)) {
+
             Attr defaultValueAttr = document.createAttribute("default"); //$NON-NLS-1$
 
             if (!field.getType().getName().equals(TypeMapping.SQL_TYPE_BOOLEAN)
-                    || HibernateStorageUtils.isBooleanDefaultValue(field.getType().getName(), defaultValueRule)) {
+                    || HibernateStorageUtils.isBooleanDefaultValue(field.getType().getName(), defaultValueRule.trim())) {
                 defaultValueAttr.setValue(HibernateStorageUtils.convertedDefaultValue(field.getType().getName(),
-                        dataSource.getDialectName(), defaultValueRule, "'"));
+                        dataSource.getDialectName(), defaultValueRule.trim(), "'"));
                 columnElement.getAttributes().setNamedItem(defaultValueAttr);
             }
         }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
@@ -741,8 +741,13 @@ public class MappingGenerator extends DefaultMetadataVisitor<Element> {
         String defaultValueRule = field.getData(MetadataRepository.DEFAULT_VALUE_RULE);
         if (StringUtils.isNotBlank(defaultValueRule)) {
             Attr defaultValueAttr = document.createAttribute("default"); //$NON-NLS-1$
-            defaultValueAttr.setValue(HibernateStorageUtils.convertedDefaultValue(dataSource.getDialectName(), defaultValueRule, "'"));
-            columnElement.getAttributes().setNamedItem(defaultValueAttr);
+
+            if (!field.getType().getName().equals(TypeMapping.SQL_TYPE_BOOLEAN)
+                    || HibernateStorageUtils.isBooleanDefaultValue(field.getType().getName(), defaultValueRule)) {
+                defaultValueAttr.setValue(HibernateStorageUtils.convertedDefaultValue(field.getType().getName(),
+                        dataSource.getDialectName(), defaultValueRule, "'"));
+                columnElement.getAttributes().setNamedItem(defaultValueAttr);
+            }
         }
     }
 

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TypeMapping.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TypeMapping.java
@@ -50,6 +50,8 @@ public abstract class TypeMapping {
     
     public static final String SQL_TYPE_TEXT = "text"; //$NON-NLS-1$
 
+    public static final String SQL_TYPE_BOOLEAN = "boolean"; //$NON-NLS-1$
+
     /**
      * Used to hold how many times a reusable type is reused within data model (may help to decide whether constrains
      * should be generated).

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -72,7 +72,6 @@ public class MDMTable extends Table {
                 }
                 buf.append(' ').append(dialect.getIdentityColumnString(col.getSqlTypeCode(p)));
             } else {
-
                 String sqlType = col.getSqlType(dialect, p);
                 buf.append(sqlType);
 
@@ -249,7 +248,7 @@ public class MDMTable extends Table {
                             statement.close();
                             connection.close();
                         } catch (SQLException e) {
-                            LOGGER.error("Unexpected error on connection close.", e);
+                            LOGGER.error("Unexpected error when closing connection.", e);
                         }
                     }
                     alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.engine.spi.Mapping;
@@ -297,7 +298,7 @@ public class MDMTable extends Table {
     }
 
     public static boolean isDefaultValueNeeded(String sqlType, Dialect dialect) {
-        if (LONGTEXT.equals(sqlType)) {
+        if (LONGTEXT.equals(sqlType) && dialect instanceof MySQLDialect) {
             return false;
         }
         return true;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -256,9 +256,8 @@ public class MDMTable extends Table {
                                 LOGGER.debug(alterDropConstraintSQL);
                             }
                         }
-
                     } catch (SQLException e) {
-                        LOGGER.debug("Error to fetch SQLServer default value constraint", e);
+                        LOGGER.debug("Error to fetch SQLServer default value constraint to Fetching SQLServer default value constraint failed.", e);
                     } finally {
                         try {
                             statement.close();
@@ -273,7 +272,6 @@ public class MDMTable extends Table {
                     } else {
                         alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
                     }
-
                 }
                 alter.append(dialect.getAddColumnSuffixString());
 
@@ -282,7 +280,6 @@ public class MDMTable extends Table {
                 }
                 results.add(alter.toString());
             }
-
         }
         return results.iterator();
     }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -41,6 +41,8 @@ import com.amalto.core.storage.hibernate.OracleCustomDialect;
 @SuppressWarnings({ "nls", "rawtypes", "deprecation", "serial" })
 public class MDMTable extends Table {
 
+    private static final String LONGTEXT = "longtext";
+
     protected RDBMSDataSource dataSource;
 
     private static final Logger LOGGER = Logger.getLogger(MDMTable.class);
@@ -254,7 +256,7 @@ public class MDMTable extends Table {
                     }
                     alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);
                 } else {
-                    if ("longtext".equals(sqlType) && (dialect instanceof MySQLDialect)) {
+                    if (LONGTEXT.equals(sqlType) && (dialect instanceof MySQLDialect)) {
                     } else {
                         alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
                     }
@@ -273,9 +275,9 @@ public class MDMTable extends Table {
     private StringBuffer covertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
         StringBuffer sb = new StringBuffer();
         if (StringUtils.isNotBlank(defaultValue)) {
-            if ("longtext".equals(sqlType) && (dialect instanceof MySQLDialect)) {
+            if (LONGTEXT.equals(sqlType) && (dialect instanceof MySQLDialect)) {
             } else {
-                sb.append(" default ").append(defaultValue);
+                sb.append(" DEFAULT ").append(defaultValue);
             }
         }
         return sb;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -79,7 +79,7 @@ public class MDMTable extends Table {
                 buf.append(sqlType);
 
                 String defaultValue = col.getDefaultValue();
-                buf.append(covertDefaultValue(dialect, sqlType, defaultValue));
+                buf.append(convertDefaultValue(dialect, sqlType, defaultValue));
 
                 if (col.isNullable()) {
                     buf.append(dialect.getNullColumnString());
@@ -159,7 +159,7 @@ public class MDMTable extends Table {
                 StringBuilder alter = new StringBuilder(root.toString()).append(dialect.getAddColumnString()).append(' ')
                         .append(columnName).append(' ').append(sqlType);
 
-                alter.append(covertDefaultValue(dialect, sqlType, defaultValue));
+                alter.append(convertDefaultValue(dialect, sqlType, defaultValue));
 
                 if (column.isNullable()) {
                     alter.append(dialect.getNullColumnString());
@@ -205,7 +205,7 @@ public class MDMTable extends Table {
 
                 alter.append(sqlType);
 
-                alter.append(covertDefaultValue(dialect, sqlType, defaultValue));
+                alter.append(convertDefaultValue(dialect, sqlType, defaultValue));
 
                 if (column.isNullable()) {
                     alter.append(dialect.getNullColumnString());
@@ -283,7 +283,7 @@ public class MDMTable extends Table {
         return results.iterator();
     }
 
-    private String covertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
+    private String convertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
         String defaultSQL = StringUtils.EMPTY;
         if (StringUtils.isNotBlank(defaultValue) && isDefaultValueNeeded(sqlType)) {
             defaultSQL = " DEFAULT " + defaultValue;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.engine.spi.Mapping;
@@ -27,10 +28,102 @@ import org.hibernate.mapping.UniqueKey;
 import org.hibernate.tool.hbm2ddl.ColumnMetadata;
 import org.hibernate.tool.hbm2ddl.TableMetadata;
 
-@SuppressWarnings("nls")
+@SuppressWarnings({"nls", "rawtypes", "deprecation", "serial"})
 public class MDMTable extends Table {
 
     private static final Logger LOGGER = Logger.getLogger(MDMTable.class);
+
+    public String sqlCreateString(Dialect dialect, Mapping p, String defaultCatalog, String defaultSchema) {
+        StringBuilder buf = new StringBuilder( hasPrimaryKey() ? dialect.getCreateTableString() : dialect.getCreateMultisetTableString() )
+                .append( ' ' )
+                .append( getQualifiedName( dialect, defaultCatalog, defaultSchema ) )
+                .append( " (" );
+
+        boolean identityColumn = getIdentifierValue() != null && getIdentifierValue().isIdentityColumn( p.getIdentifierGeneratorFactory(), dialect );
+
+        // Try to find out the name of the primary key to create it as identity if the IdentityGenerator is used
+        String pkname = null;
+        if ( hasPrimaryKey() && identityColumn ) {
+            pkname = ( (Column) getPrimaryKey().getColumnIterator().next() ).getQuotedName( dialect );
+        }
+
+        Iterator iter = getColumnIterator();
+        while ( iter.hasNext() ) {
+            Column col = (Column) iter.next();
+
+            buf.append( col.getQuotedName( dialect ) )
+                    .append( ' ' );
+
+            if ( identityColumn && col.getQuotedName( dialect ).equals( pkname ) ) {
+                // to support dialects that have their own identity data type
+                if ( dialect.hasDataTypeInIdentityColumn() ) {
+                    buf.append( col.getSqlType( dialect, p ) );
+                }
+                buf.append( ' ' )
+                        .append( dialect.getIdentityColumnString( col.getSqlTypeCode( p ) ) );
+            } else {
+
+                String sqlType = col.getSqlType(dialect, p);
+                buf.append(sqlType);
+
+                String defaultValue = col.getDefaultValue();
+                if (defaultValue != null) {
+                    if (sqlType.equals("longtext") && (dialect instanceof MySQLDialect)) {
+                    } else {
+                        buf.append(" default ").append(defaultValue);
+                    }
+                }
+
+                if (col.isNullable()) {
+                    buf.append(dialect.getNullColumnString());
+                } else {
+                    buf.append(" not null");
+                }
+
+            }
+
+            if (col.isUnique()) {
+                String keyName = Constraint.generateName("UK_", this, col);
+                UniqueKey uk = getOrCreateUniqueKey(keyName);
+                uk.addColumn(col);
+                buf.append(dialect.getUniqueDelegate().getColumnDefinitionUniquenessFragment(col));
+            }
+
+            if (col.hasCheckConstraint() && dialect.supportsColumnCheck()) {
+                buf.append(" check (").append(col.getCheckConstraint()).append(")");
+            }
+
+            String columnComment = col.getComment();
+            if (columnComment != null) {
+                buf.append(dialect.getColumnComment(columnComment));
+            }
+
+            if (iter.hasNext()) {
+                buf.append(", ");
+            }
+
+        }
+        if (hasPrimaryKey()) {
+            buf.append(", ").append(getPrimaryKey().sqlConstraintString(dialect));
+        }
+
+        buf.append(dialect.getUniqueDelegate().getTableCreationUniqueConstraintsFragment(this));
+
+        if (dialect.supportsTableCheck()) {
+            Iterator chiter = getCheckConstraintsIterator();
+            while (chiter.hasNext()) {
+                buf.append(", check (").append(chiter.next()).append(')');
+            }
+        }
+
+        buf.append(')');
+
+        if (getComment() != null) {
+            buf.append(dialect.getTableComment(getComment()));
+        }
+
+        return buf.append(dialect.getTableTypeString()).toString();
+    }
 
     @Override
     public Iterator sqlAlterStrings(Dialect dialect, Mapping p, TableMetadata tableInfo, String defaultCatalog,

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -268,8 +268,7 @@ public class MDMTable extends Table {
                     }
                     alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);
                 } else {
-                    if (LONGTEXT.equals(sqlType) && (dialect instanceof MySQLDialect)) {
-                    } else {
+                    if(!LONGTEXT.equals(sqlType) || !(dialect instanceof MySQLDialect)) {
                         alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
                     }
                 }
@@ -287,10 +286,11 @@ public class MDMTable extends Table {
     private StringBuffer covertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
         StringBuffer sb = new StringBuffer();
         if (StringUtils.isNotBlank(defaultValue)) {
-            if (LONGTEXT.equals(sqlType) && (dialect instanceof MySQLDialect)) {
-            } else {
-                sb.append(" DEFAULT ").append(defaultValue);
-            }
+            if (StringUtils.isNotBlank(defaultValue) ) {
+                if(!LONGTEXT.equals(sqlType) || !(dialect instanceof MySQLDialect)) {
+                       sb.append(" DEFAULT ").append(defaultValue);
+                 }
+           }
         }
         return sb;
     }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -45,6 +45,7 @@ public class MDMTable extends Table {
 
     private static final Logger LOGGER = Logger.getLogger(MDMTable.class);
 
+    @Override
     public String sqlCreateString(Dialect dialect, Mapping p, String defaultCatalog, String defaultSchema) {
         StringBuilder buf = new StringBuilder(hasPrimaryKey() ? dialect.getCreateTableString()
                 : dialect.getCreateMultisetTableString()).append(' ')
@@ -253,7 +254,7 @@ public class MDMTable extends Table {
                     }
                     alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);
                 } else {
-                    if (sqlType.equals("longtext") && (dialect instanceof MySQLDialect)) {
+                    if ("longtext".equals(sqlType) && (dialect instanceof MySQLDialect)) {
                     } else {
                         alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
                     }
@@ -272,7 +273,7 @@ public class MDMTable extends Table {
     private StringBuffer covertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
         StringBuffer sb = new StringBuffer();
         if (StringUtils.isNotBlank(defaultValue)) {
-            if (sqlType.equals("longtext") && (dialect instanceof MySQLDialect)) {
+            if ("longtext".equals(sqlType) && (dialect instanceof MySQLDialect)) {
             } else {
                 sb.append(" default ").append(defaultValue);
             }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -129,7 +129,11 @@ public class MDMTable extends Table {
             buf.append(dialect.getTableComment(getComment()));
         }
 
-        return buf.append(dialect.getTableTypeString()).toString();
+        String createSQL = buf.append(dialect.getTableTypeString()).toString();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(createSQL);
+        }
+        return createSQL;
     }
 
     @Override
@@ -181,6 +185,9 @@ public class MDMTable extends Table {
 
                 alter.append(dialect.getAddColumnSuffixString());
 
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(alter.toString());
+                }
                 results.add(alter.toString());
             } else if (MDMTableUtils.isAlterColumnField(column, columnInfo, dialect)) {
                 StringBuilder alter = new StringBuilder(root.toString());
@@ -224,7 +231,9 @@ public class MDMTable extends Table {
 
                 alter.append(dialect.getAddColumnSuffixString());
 
-                LOGGER.debug(alter.toString());
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(alter.toString());
+                }
                 results.add(alter.toString());
             } else if (StringUtils.isNotBlank(defaultValue)) {
                 StringBuilder alter = new StringBuilder(root.toString());
@@ -241,7 +250,11 @@ public class MDMTable extends Table {
                                 + "where a.id=object_id('" + tableName + "') and b.name='" + columnName + '\'';
                         ResultSet rs = statement.executeQuery(sql);
                         while (rs.next()) {
-                            results.add("alter table Test drop constraint " + rs.getString(1));
+                            String alterDropConstraintSQL = "alter table Test drop constraint " + rs.getString(1);
+                            results.add(alterDropConstraintSQL);
+                            if (LOGGER.isDebugEnabled()) {
+                                LOGGER.debug(alterDropConstraintSQL);
+                            }
                         }
 
                     } catch (SQLException e) {
@@ -264,7 +277,9 @@ public class MDMTable extends Table {
                 }
                 alter.append(dialect.getAddColumnSuffixString());
 
-                LOGGER.debug(alter.toString());
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(alter.toString());
+                }
                 results.add(alter.toString());
             }
 

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -10,10 +10,17 @@
 
 package com.amalto.core.storage.hibernate.mapping;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
@@ -28,8 +35,13 @@ import org.hibernate.mapping.UniqueKey;
 import org.hibernate.tool.hbm2ddl.ColumnMetadata;
 import org.hibernate.tool.hbm2ddl.TableMetadata;
 
+import com.amalto.core.storage.datasource.RDBMSDataSource;
+import com.amalto.core.storage.hibernate.OracleCustomDialect;
+
 @SuppressWarnings({"nls", "rawtypes", "deprecation", "serial"})
 public class MDMTable extends Table {
+
+    protected RDBMSDataSource dataSource;
 
     private static final Logger LOGGER = Logger.getLogger(MDMTable.class);
 
@@ -67,7 +79,7 @@ public class MDMTable extends Table {
                 buf.append(sqlType);
 
                 String defaultValue = col.getDefaultValue();
-                if (defaultValue != null) {
+                if (StringUtils.isNotBlank(defaultValue)) {
                     if (sqlType.equals("longtext") && (dialect instanceof MySQLDialect)) {
                     } else {
                         buf.append(" default ").append(defaultValue);
@@ -90,7 +102,7 @@ public class MDMTable extends Table {
             }
 
             if (col.hasCheckConstraint() && dialect.supportsColumnCheck()) {
-                buf.append(" check (").append(col.getCheckConstraint()).append(")");
+                buf.append(" check (").append(col.getCheckConstraint()).append(')');
             }
 
             String columnComment = col.getComment();
@@ -129,8 +141,8 @@ public class MDMTable extends Table {
     public Iterator sqlAlterStrings(Dialect dialect, Mapping p, TableMetadata tableInfo, String defaultCatalog,
             String defaultSchema) throws HibernateException {
 
-        StringBuilder root = new StringBuilder("alter table ").append(getQualifiedName(dialect, defaultCatalog, defaultSchema))
-                .append(' ');
+        String tableName = getQualifiedName(dialect, defaultCatalog, defaultSchema);
+        StringBuilder root = new StringBuilder("alter table ").append(tableName).append(' ');
 
         Iterator iter = getColumnIterator();
         List results = new ArrayList();
@@ -140,14 +152,19 @@ public class MDMTable extends Table {
 
             ColumnMetadata columnInfo = tableInfo.getColumnMetadata(column.getName());
 
+            String sqlType = column.getSqlType(dialect, p);
+            String defaultValue = column.getDefaultValue();
+            String columnName = column.getQuotedName(dialect);
             if (columnInfo == null) {
                 // the column doesnt exist at all.
                 StringBuilder alter = new StringBuilder(root.toString()).append(dialect.getAddColumnString()).append(' ')
-                        .append(column.getQuotedName(dialect)).append(' ').append(column.getSqlType(dialect, p));
+                        .append(columnName).append(' ').append(sqlType);
 
-                String defaultValue = column.getDefaultValue();
-                if (defaultValue != null) {
-                    alter.append(" default ").append(defaultValue);
+                if (StringUtils.isNotBlank(defaultValue)) {
+                    if (sqlType.equals("longtext") && (dialect instanceof MySQLDialect)) {
+                    } else {
+                        alter.append(" default ").append(defaultValue);
+                    }
                 }
 
                 if (column.isNullable()) {
@@ -164,7 +181,7 @@ public class MDMTable extends Table {
                 }
 
                 if (column.hasCheckConstraint() && dialect.supportsColumnCheck()) {
-                    alter.append(" check(").append(column.getCheckConstraint()).append(")");
+                    alter.append(" check(").append(column.getCheckConstraint()).append(')');
                 }
 
                 String columnComment = column.getComment();
@@ -179,27 +196,29 @@ public class MDMTable extends Table {
                 StringBuilder alter = new StringBuilder(root.toString());
 
                 if (dialect instanceof SQLServerDialect || dialect instanceof PostgreSQLDialect) {
-                    alter.append(" ").append("alter COLUMN").append(" ");
+                    alter.append(" ALTER COLUMN ");
                 } else {
-                    alter.append(" ").append("modify").append(" ");
+                    alter.append(" MODIFY ");
                 }
-                alter.append(" ").append(column.getQuotedName(dialect)).append(" ");
+                alter.append(' ').append(columnName).append(' ');
 
                 if (dialect instanceof PostgreSQLDialect) {
-                    alter.append("TYPE").append(" ");
+                    alter.append("TYPE ");
                 }
 
-                alter.append(column.getSqlType(dialect, p));
+                alter.append(sqlType);
 
-                String defaultValue = column.getDefaultValue();
-                if (defaultValue != null) {
-                    alter.append(" default ").append(defaultValue);
+                if (StringUtils.isNotBlank(defaultValue)) {
+                    if (sqlType.equals("longtext") && (dialect instanceof MySQLDialect)) {
+                    } else {
+                        alter.append(" default ").append(defaultValue);
+                    }
                 }
 
                 if (column.isNullable()) {
                     alter.append(dialect.getNullColumnString());
                 } else {
-                    alter.append(" not null");
+                    alter.append(" not null ");
                 }
 
                 if (column.isUnique()) {
@@ -210,7 +229,7 @@ public class MDMTable extends Table {
                 }
 
                 if (column.hasCheckConstraint() && dialect.supportsColumnCheck()) {
-                    alter.append(" check(").append(column.getCheckConstraint()).append(")");
+                    alter.append(" check(").append(column.getCheckConstraint()).append(')');
                 }
 
                 String columnComment = column.getComment();
@@ -222,9 +241,53 @@ public class MDMTable extends Table {
 
                 LOGGER.debug(alter.toString());
                 results.add(alter.toString());
+            } else if (StringUtils.isNotBlank(defaultValue)) {
+                StringBuilder alter = new StringBuilder(root.toString());
+                if (dialect instanceof OracleCustomDialect) {
+                    alter.append(" MODIFY ").append(columnName).append(" DEFAULT ").append(defaultValue);
+                } else if (dialect instanceof SQLServerDialect) {
+                    Connection connection = null;
+                    Statement statement = null;
+                    try {
+                        Properties properties = dataSource.getAdvancedPropertiesIncludeUserInfo();
+                        connection = DriverManager.getConnection(dataSource.getConnectionURL(), properties);
+                        statement = connection.createStatement();
+                        String sql = "select c.name from sysconstraints a inner join syscolumns b on a.colid=b.colid inner join sysobjects c on a.constid=c.id "
+                                + "where a.id=object_id('" + tableName + "') and b.name='" + columnName + '\'';
+                        ResultSet rs = statement.executeQuery(sql);
+                        while (rs.next()) {
+                            results.add("alter table Test drop constraint " + rs.getString(1));
+                        }
+
+                    } catch (SQLException e) {
+                        LOGGER.debug("Error to fetch SQLServer default value constraint", e);
+                    } finally {
+                        try {
+                            statement.close();
+                            connection.close();
+                        } catch (SQLException e) {
+                            LOGGER.error("Unexpected error on connection close.", e);
+                        }
+                    }
+                    alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);
+                } else {
+                    if (sqlType.equals("longtext") && (dialect instanceof MySQLDialect)) {
+                    } else {
+                        alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
+                    }
+
+                }
+                alter.append(dialect.getAddColumnSuffixString());
+
+                LOGGER.debug(alter.toString());
+                results.add(alter.toString());
             }
 
         }
         return results.iterator();
+    }
+
+    public void setDataSource(RDBMSDataSource dataSource) {
+        this.dataSource = dataSource;
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -38,7 +38,7 @@ import org.hibernate.tool.hbm2ddl.TableMetadata;
 import com.amalto.core.storage.datasource.RDBMSDataSource;
 import com.amalto.core.storage.hibernate.OracleCustomDialect;
 
-@SuppressWarnings({"nls", "rawtypes", "deprecation", "serial"})
+@SuppressWarnings({ "nls", "rawtypes", "deprecation", "serial" })
 public class MDMTable extends Table {
 
     protected RDBMSDataSource dataSource;

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/HibernateStorageUtilsTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/HibernateStorageUtilsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+package com.amalto.core.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.amalto.core.storage.datasource.RDBMSDataSource.DataSourceDialect;
+
+
+public class HibernateStorageUtilsTest {
+
+    @Test
+    public void testConvertedDefaultValue() {
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "\"true\"", "'"));
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "\"true\"", "'"));
+
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "fn:true()", "'"));
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "fn:true()", "'"));
+
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "'true'", "'"));
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "'true'", "'"));
+
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "\"false\"", "'"));
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "\"false\"", "'"));
+
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "'false'", "'"));
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "'false'", "'"));
+
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "fn:false()", "'"));
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "fn:false()", "'"));
+
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.H2, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.POSTGRES, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.SQL_SERVER, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.MYSQL, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.ORACLE_10G, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.DB2, "\"[En:*]\"", "'"));
+
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.H2, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.POSTGRES, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.SQL_SERVER, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.MYSQL, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.ORACLE_10G, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.DB2, "100", "'"));
+    }
+
+    @Test
+    public void testIsBooleanDefaultValue() throws Exception {
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "fn:false()"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "fn:true()"));
+        assertFalse(HibernateStorageUtils.isBooleanDefaultValue("boolean", "1"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "'true'"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "'false'"));
+
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("fn:false()"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("fn:true()"));
+        assertFalse(HibernateStorageUtils.isBooleanDefaultValue("1"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("'true'"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("'false'"));
+    }
+}

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/StoragePrepareTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/StoragePrepareTest.java
@@ -591,6 +591,78 @@ public class StoragePrepareTest extends TestCase {
 
     }
 
+    public void testBooleanDefaultValuePrepare() throws Exception {
+        DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS2", STORAGE_NAME);
+  Storage storage = new HibernateStorage("Test", StorageType.MASTER);
+        storage.init(dataSource);
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(StoragePrepareTest.class.getResourceAsStream("BooleanType.xsd"));
+        storage.prepare(repository, true);
+
+        // test table had been created
+        String[] tables = { "BooleanType"};
+        String[][] columns = {
+                { "", "X_ID", "X_A1", "X_A2", "X_A3", "X_A4", "X_A5", "X_A6", "X_TALEND_TIMESTAMP", "X_TALEND_TASK_ID" }};
+        DataRecordReader<String> factory = new XmlStringDataRecordReader();
+        try {
+            assertDatabaseChange(dataSource, tables, columns, new boolean[] { true });
+        } catch (SQLException e) {
+            assertNull(e);
+        }
+
+        ComplexTypeMetadata booleanType = repository.getComplexType("BooleanType");//$NON-NLS-1$
+
+        // test data had been added
+        List<DataRecord> records = new ArrayList<DataRecord>();
+        records.add(factory.read(repository, booleanType,
+                "<BooleanType><Id>123</Id><a2>true</a2><a6>false</a6></BooleanType>")); // $NON-NLS-1$
+
+        try {
+            storage.begin();
+            storage.update(records);
+            storage.commit();
+        } catch (Exception e) {
+            fail("Faield to insert data");
+        } finally {
+            storage.end();
+        }
+
+        // test query data
+        UserQueryBuilder qb = from(booleanType);
+        qb.getSelect().getPaging().setLimit(10);
+        storage.begin();
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(1, results.getCount());
+            for (DataRecord result : results) {
+                assertEquals("123", result.get("Id"));//$NON-NLS-1$ //$NON-NLS-2$
+                assertEquals(true, result.get("a1"));//$NON-NLS-1$ //$NON-NLS-2$
+                assertEquals(true, result.get("a2"));//$NON-NLS-1$ //$NON-NLS-2$
+                assertEquals(null, result.get("a3"));//$NON-NLS-1$ //$NON-NLS-2$
+                assertEquals(true, result.get("a4"));//$NON-NLS-1$ //$NON-NLS-2$
+                assertEquals(null, result.get("a5"));//$NON-NLS-1$ //$NON-NLS-2$
+                assertEquals(false, result.get("a6"));//$NON-NLS-1$ //$NON-NLS-2$
+            }
+
+        } finally {
+            results.close();
+        }
+        storage.end();
+
+        // delte data
+        try {
+            storage.begin();
+            {
+                qb = from(booleanType);
+                storage.delete(qb.getSelect());
+            }
+            storage.commit();
+        } finally {
+            storage.end();
+        }
+
+    }
+
     private void assertDatabaseChange(DataSourceDefinition dataSource, String[] tables, String[][] columns, boolean[] exists)
             throws SQLException {
         DataSource master = dataSource.getMaster();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/StoragePrepareTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/StoragePrepareTest.java
@@ -593,7 +593,7 @@ public class StoragePrepareTest extends TestCase {
 
     public void testBooleanDefaultValuePrepare() throws Exception {
         DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS2", STORAGE_NAME);
-  Storage storage = new HibernateStorage("Test", StorageType.MASTER);
+        Storage storage = new HibernateStorage("Test", StorageType.MASTER);
         storage.init(dataSource);
         MetadataRepository repository = new MetadataRepository();
         repository.load(StoragePrepareTest.class.getResourceAsStream("BooleanType.xsd"));
@@ -638,7 +638,7 @@ public class StoragePrepareTest extends TestCase {
                 assertEquals("123", result.get("Id"));//$NON-NLS-1$ //$NON-NLS-2$
                 assertEquals(true, result.get("a1"));//$NON-NLS-1$ //$NON-NLS-2$
                 assertEquals(true, result.get("a2"));//$NON-NLS-1$ //$NON-NLS-2$
-                assertEquals(null, result.get("a3"));//$NON-NLS-1$ //$NON-NLS-2$
+                assertEquals(false, result.get("a3"));//$NON-NLS-1$ //$NON-NLS-2$
                 assertEquals(true, result.get("a4"));//$NON-NLS-1$ //$NON-NLS-2$
                 assertEquals(null, result.get("a5"));//$NON-NLS-1$ //$NON-NLS-2$
                 assertEquals(false, result.get("a6"));//$NON-NLS-1$ //$NON-NLS-2$

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/BooleanType.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/BooleanType.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:element name="BooleanType">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a1" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">fn:true()</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a2" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">"false"</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a3" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">'false'</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a4" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Default_Value_Rule">"true"</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a5" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Default_Value_Rule">1</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a6" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Default_Value_Rule">'true'</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="BooleanType">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-12515

**What is the current behavior?** (You should also link to an open issue here)
1. have no set the default value of boolean type for MySQL and DB2 
2. defalut value existed in MySQL for longtext field


**What is the new behavior?**
1. set default value of boolean type for MySQL and DB2 
2. remove default value for longtext field in MySQL when generate create script.
3. add the set default value scripter when modify it.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
