### PR TITLE
TMDM-12517 [DB2] Failed when redeploy modified DM

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/services/SystemModels.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/services/SystemModels.java
@@ -19,7 +19,6 @@ import io.swagger.annotations.ApiParam;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,7 +35,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -51,7 +49,6 @@ import org.talend.mdm.commmon.metadata.compare.Compare;
 import org.talend.mdm.commmon.metadata.compare.ImpactAnalyzer;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.xml.sax.InputSource;
 
 import com.amalto.commons.core.datamodel.synchronization.DMUpdateEvent;
 import com.amalto.commons.core.datamodel.synchronization.DataModelChangeNotifier;
@@ -71,6 +68,7 @@ import com.amalto.core.storage.record.DataRecord;
 import com.amalto.core.storage.record.DataRecordReader;
 import com.amalto.core.storage.record.XmlDOMDataRecordReader;
 import com.amalto.core.util.LocalUser;
+import com.amalto.core.util.Util;
 import com.amalto.core.util.XtentisException;
 
 
@@ -230,9 +228,7 @@ public class SystemModels {
                 // Marshal
                 StringWriter sw = new StringWriter();
                 MarshallingFactory.getInstance().getMarshaller(updatedDataModelPOJO.getClass()).marshal(updatedDataModelPOJO, sw);
-                DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = DocumentBuilderFactory.newInstance();
-                InputSource source = new InputSource(new StringReader(sw.toString()));
-                Document document = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder().parse(source);
+                Document document = Util.parse(sw.toString());
                 DataRecordReader<Element> reader = new XmlDOMDataRecordReader();
                 DataRecord record = reader.read(newRepository, dataModelType, document.getDocumentElement());
                 record.set(dataModelType.getField("schema"), content); //$NON-NLS-1$

--- a/org.talend.mdm.core/src/com/amalto/core/storage/services/SystemModels.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/services/SystemModels.java
@@ -63,6 +63,7 @@ import com.amalto.core.storage.StorageResults;
 import com.amalto.core.storage.StorageType;
 import com.amalto.core.storage.record.DataRecord;
 import com.amalto.core.util.LocalUser;
+import com.amalto.core.util.Util;
 import com.amalto.core.util.XtentisException;
 
 
@@ -211,26 +212,15 @@ public class SystemModels {
         // Update the system storage with the new data model (if there was any change).
         Compare.DiffResults diffResults = Compare.compare(previousRepository, newRepository);
         if (!diffResults.getActions().isEmpty()) {
-            UserQueryBuilder qb = from(dataModelType).where(eq(dataModelType.getField("name"), modelName)); //$NON-NLS-1$
-            systemStorage.begin();
+            DataModelPOJO updatedDataModelPOJO = new DataModelPOJO(modelName);
+            updatedDataModelPOJO.setDescription(oldDataModel.getDescription());
+            updatedDataModelPOJO.setDigest(oldDataModel.getDigest());
+            updatedDataModelPOJO.setName(oldDataModel.getName());
+            updatedDataModelPOJO.setSchema(content);
             try {
-                StorageResults results = systemStorage.fetch(qb.getSelect());
-                Iterator<DataRecord> iterator = results.iterator();
-                if (iterator.hasNext()) {
-                    // Updates the data model in system db
-                    DataRecord model = iterator.next();
-                    model.set(dataModelType.getField("schema"), content); //$NON-NLS-1$
-                    if (iterator.hasNext()) {
-                        throw new IllegalStateException("Found multiple data models for '" + modelName + "'."); //$NON-NLS-1$ //$NON-NLS-2$
-                    }
-                    systemStorage.update(model);
-                }
-                systemStorage.commit();
-                reloadDataModel(modelName);
+                Util.getDataModelCtrlLocal().putDataModel(updatedDataModelPOJO);
                 // Add audit log
-                DataModelPOJO newdataModelPOJO = new DataModelPOJO(modelName);
-                newdataModelPOJO.setSchema(content);
-                MDMAuditLogger.dataModelModified(user, oldDataModel, newdataModelPOJO, true);
+                MDMAuditLogger.dataModelModified(user, oldDataModel, updatedDataModelPOJO, true);
             } catch (Exception e) {
                 systemStorage.rollback();
                 MDMAuditLogger.dataModelModificationFailed(user, modelName, e);


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-12517

**What is the current behavior?** (You should also link to an open issue here)
Failed when redeploy modified DM for DB2, because table of data_model_pojo, the field x_schema is clob, if fetch data, will throw the exception: the error includes SQLCODE "-270", SQLSTATE "42997" and message tokens "63".. SQLCODE=-727, SQLSTATE=56098, DRIVER=4.16.53


**What is the new behavior?**
Use function DataModel.putDataModel to update the content of schema.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
