### PR TITLE
TMDM-12624 Issue with date field defined as a primary key

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/AbstractQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/AbstractQueryHandler.java
@@ -203,12 +203,12 @@ abstract class AbstractQueryHandler extends VisitorAdapter<StorageResults> {
 
         @Override
         public Object visit(DateConstant constant) {
-            return constant.getValueObject();
+            return StorageMetadataUtils.convert(constant);
         }
 
         @Override
         public Object visit(DateTimeConstant constant) {
-            return constant.getValueObject();
+            return StorageMetadataUtils.convert(constant);
         }
 
         @Override
@@ -223,7 +223,7 @@ abstract class AbstractQueryHandler extends VisitorAdapter<StorageResults> {
 
         @Override
         public Object visit(TimeConstant constant) {
-            return constant.getValueObject();
+            return StorageMetadataUtils.convert(constant);
         }
 
         @Override

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
@@ -61,6 +61,8 @@ public class StorageTestCase extends TestCase {
     protected static final ComplexTypeMetadata type;
 
     protected static final ComplexTypeMetadata person;
+    
+    protected static final ComplexTypeMetadata dateKey;
 
     protected static final ComplexTypeMetadata customer;
 
@@ -177,6 +179,7 @@ public class StorageTestCase extends TestCase {
 
         type = repository.getComplexType("TypeA");
         person = repository.getComplexType("Person");
+        dateKey = repository.getComplexType("DateKey");
         customer = repository.getComplexType("Customer");
         address = repository.getComplexType("Address");
         country = repository.getComplexType("Country");

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -73,6 +73,20 @@
 		</xsd:unique>
 	</xsd:element>
 
+    <xsd:element name="DateKey">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="id" type="xsd:string" />
+                <xsd:element name="day" type="xsd:date" />
+                <xsd:element name="name" type="xsd:string" />
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="DateKey">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="day" />
+        </xsd:unique>
+    </xsd:element>
+
 	<xsd:complexType name="Address">
 		<xsd:sequence>
 			<xsd:element name="Street" type="xsd:string" />

--- a/org.talend.mdm.core/src/com/amalto/core/storage/StorageMetadataUtils.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/StorageMetadataUtils.java
@@ -44,6 +44,7 @@ import org.talend.mdm.commmon.metadata.SimpleTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.TypeMetadata;
 import org.talend.mdm.commmon.metadata.Types;
 
+import com.amalto.core.query.user.ConstantExpression;
 import com.amalto.core.query.user.DateConstant;
 import com.amalto.core.query.user.DateTimeConstant;
 import com.amalto.core.query.user.TimeConstant;
@@ -661,6 +662,19 @@ public class StorageMetadataUtils {
             }
         } else {
             throw new NotImplementedException("No support for type '" + type + "'"); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+    }
+
+    public static Object convert(ConstantExpression<Date> constant) {
+        if (constant.isExpressionList()) {
+            CollectionUtils.transform(constant.getValueList(), new Transformer() {
+                public java.lang.Object transform(java.lang.Object input) {
+                        return new Timestamp(((Date)input).getTime());
+                    }
+                });
+            return constant.getValueList();
+        } else {
+            return new Timestamp(constant.getValue().getTime());
         }
     }
 

--- a/org.talend.mdm.core/test/com/amalto/core/storage/StorageMetadataUtilsTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/StorageMetadataUtilsTest.java
@@ -168,8 +168,6 @@ public class StorageMetadataUtilsTest {
 
         List<Date> listDate = new LinkedList<Date>();
         listDate.add(DATE_FORMAT.parse("2018-10-11")); //$NON-NLS-1$
-        listDate.add(DATE_FORMAT.parse("2018-11-12")); //$NON-NLS-1$
-        listDate.add(DATE_FORMAT.parse("2018-12-13")); //$NON-NLS-1$
 
         dateConstant = new DateConstant(listDate);
         Object dateStamps = StorageMetadataUtils.convert(dateConstant);
@@ -188,8 +186,6 @@ public class StorageMetadataUtilsTest {
 
         List<Date> listDateTime = new LinkedList<Date>();
         listDateTime.add(DATE_TIME_FORMAT.parse("2018-10-11T10:11:12")); //$NON-NLS-1$
-        listDateTime.add(DATE_TIME_FORMAT.parse("2018-11-12T10:11:12")); //$NON-NLS-1$
-        listDateTime.add(DATE_TIME_FORMAT.parse("2018-12-13T10:11:12")); //$NON-NLS-1$
 
         dateTimeConstant = new DateTimeConstant(listDateTime);
         Object dateTimeStamps = StorageMetadataUtils.convert(dateTimeConstant);
@@ -208,8 +204,6 @@ public class StorageMetadataUtilsTest {
 
         List<Date> listTime = new LinkedList<Date>();
         listTime.add(TIME_FORMAT.parse("12:11:16")); //$NON-NLS-1$
-        listTime.add(TIME_FORMAT.parse("12:12:26")); //$NON-NLS-1$
-        listTime.add(TIME_FORMAT.parse("12:13:36")); //$NON-NLS-1$
 
         timeConstant = new TimeConstant(listTime);
         Object timeStamps = StorageMetadataUtils.convert(timeConstant);

--- a/org.talend.mdm.core/test/com/amalto/core/storage/StorageMetadataUtilsTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/StorageMetadataUtilsTest.java
@@ -10,6 +10,14 @@
 package com.amalto.core.storage;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.Assert;
@@ -20,6 +28,9 @@ import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
 import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
 
+import com.amalto.core.query.user.DateConstant;
+import com.amalto.core.query.user.DateTimeConstant;
+import com.amalto.core.query.user.TimeConstant;
 import com.amalto.core.storage.record.DataRecord;
 import com.amalto.core.storage.record.metadata.DataRecordMetadataImpl;
 
@@ -145,5 +156,65 @@ public class StorageMetadataUtilsTest {
                 assertEquals("ab7", idList.get(i)); //$NON-NLS-1$
             }
         }
+    }
+
+    @Test
+    public void testConvertConstantExpressionDate() throws ParseException {
+        DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd"); //$NON-NLS-1$
+
+        DateConstant dateConstant = new DateConstant("2018-10-06"); //$NON-NLS-1$
+        Object dateStamp = StorageMetadataUtils.convert(dateConstant);
+        assertTrue(dateStamp instanceof Timestamp);
+
+        List<Date> listDate = new LinkedList<Date>();
+        listDate.add(DATE_FORMAT.parse("2018-10-11")); //$NON-NLS-1$
+        listDate.add(DATE_FORMAT.parse("2018-11-12")); //$NON-NLS-1$
+        listDate.add(DATE_FORMAT.parse("2018-12-13")); //$NON-NLS-1$
+
+        dateConstant = new DateConstant(listDate);
+        Object dateStamps = StorageMetadataUtils.convert(dateConstant);
+        @SuppressWarnings("unchecked")
+        List<Timestamp> returnDateStamps = (List<Timestamp>)dateStamps;
+        assertTrue(returnDateStamps.get(0) instanceof Timestamp);
+    }
+
+    @Test
+    public void testConvertConstantExpressionDateTime() throws ParseException {
+        DateFormat DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss"); //$NON-NLS-1$
+
+        DateTimeConstant dateTimeConstant = new DateTimeConstant("2018-10-06T10:11:12");//$NON-NLS-1$
+        Object dateTimeStamp = StorageMetadataUtils.convert(dateTimeConstant);
+        assertTrue(dateTimeStamp instanceof Timestamp);
+
+        List<Date> listDateTime = new LinkedList<Date>();
+        listDateTime.add(DATE_TIME_FORMAT.parse("2018-10-11T10:11:12")); //$NON-NLS-1$
+        listDateTime.add(DATE_TIME_FORMAT.parse("2018-11-12T10:11:12")); //$NON-NLS-1$
+        listDateTime.add(DATE_TIME_FORMAT.parse("2018-12-13T10:11:12")); //$NON-NLS-1$
+
+        dateTimeConstant = new DateTimeConstant(listDateTime);
+        Object dateTimeStamps = StorageMetadataUtils.convert(dateTimeConstant);
+        @SuppressWarnings("unchecked")
+        List<Timestamp> returnDateTimeStamps = (List<Timestamp>)dateTimeStamps;
+        assertTrue(returnDateTimeStamps.get(0) instanceof Timestamp);
+    }
+
+    @Test
+    public void testConvertConstantExpressionTime() throws ParseException {
+        DateFormat TIME_FORMAT = new SimpleDateFormat("HH:mm:ss"); //$NON-NLS-1$
+
+        TimeConstant timeConstant = new TimeConstant("12:10:06"); //$NON-NLS-1$
+        Object timeStamp = StorageMetadataUtils.convert(timeConstant);
+        assertTrue(timeStamp instanceof Timestamp);
+
+        List<Date> listTime = new LinkedList<Date>();
+        listTime.add(TIME_FORMAT.parse("12:11:16")); //$NON-NLS-1$
+        listTime.add(TIME_FORMAT.parse("12:12:26")); //$NON-NLS-1$
+        listTime.add(TIME_FORMAT.parse("12:13:36")); //$NON-NLS-1$
+
+        timeConstant = new TimeConstant(listTime);
+        Object timeStamps = StorageMetadataUtils.convert(timeConstant);
+        @SuppressWarnings("unchecked")
+        List<Timestamp> returnTimeStamps = (List<Timestamp>)timeStamps;
+        assertTrue(returnTimeStamps.get(0) instanceof Timestamp);
     }
 }


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

If we used date, dateTime or time type as primary key in Studio data model, then from MDM Web UI, we cannot create or view the record. There will have exception reported from MDM server.

https://jira.talendforge.org/browse/TMDM-12624

**What is the new behavior?**

The fixing will allow date, dateTime and time as primary key, the record can be created or viewed from Web UI.

It added a conversion from Java.util.Date to Java.sql.Timestamp as required.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
