### PR TITLE
TMDM-12666 Error when trying to open a journal record after deletion of an occurence of [0..many]

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/history/accessor/ManyFieldAccessor.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/accessor/ManyFieldAccessor.java
@@ -11,13 +11,22 @@
 
 package com.amalto.core.history.accessor;
 
-import com.amalto.core.history.DOMMutableDocument;
-import com.amalto.core.history.action.FieldUpdateAction;
-
-import org.apache.commons.lang.StringUtils;
-import org.w3c.dom.*;
+import java.util.LinkedList;
+import java.util.List;
 
 import javax.xml.XMLConstants;
+
+import org.apache.commons.lang.StringUtils;
+import org.w3c.dom.Attr;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.Text;
+
+import com.amalto.core.history.DOMMutableDocument;
+import com.amalto.core.history.action.FieldUpdateAction;
 
 /**
  *
@@ -105,10 +114,17 @@ class ManyFieldAccessor implements DOMAccessor {
         Node node = getCollectionItemNode();
         if (node == null) {
             Element parentNode = (Element) parent.getNode();
-            NodeList children = parentNode.getElementsByTagName(fieldName);
-            int currentCollectionSize = children.getLength();
+            List<Node> childList = new LinkedList<>();
+            NodeList childNodeList = parentNode.getChildNodes();
+            for (int i = 0; i < childNodeList.getLength(); i++) {
+                if (fieldName.equals(childNodeList.item(i).getNodeName())) {
+                    childList.add(childNodeList.item(i));
+                }
+            }
+
+            int currentCollectionSize = childList.size();
             if (currentCollectionSize > 0) {
-                Node refNode = children.item(currentCollectionSize - 1).getNextSibling();
+                Node refNode = childList.get(currentCollectionSize - 1).getNextSibling();
                 while (currentCollectionSize <= index) {
                     node = domDocument.createElementNS(domDocument.getNamespaceURI(), fieldName);
                     parentNode.insertBefore(node, refNode);

--- a/org.talend.mdm.core/test/com/amalto/core/history/accessor/ManyFieldAccessorTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/accessor/ManyFieldAccessorTest.java
@@ -20,25 +20,30 @@ import com.amalto.core.save.DOMDocument;
 import com.amalto.core.util.Util;
 
 public class ManyFieldAccessorTest {
-    
+
     @Test
     public void testCreateEmptyChildNode() throws Exception {
         DOMDocument document = getTypeWithNoElementContent();
-
         Accessor accessor = document.createAccessor("/Communications/TypeCommunication[1]"); //$NON-NLS-1$
         accessor.create();
-        
         Assert.assertNotNull(document);
     }
-    
+
     private DOMDocument getTypeWithNoElementContent() throws IOException, SAXException, ParserConfigurationException {
-        String xml = 
-                "<TI_Tiers xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n" +  //$NON-NLS-1$
-        		"   <Id>7</Id>\r\n" +  //$NON-NLS-1$
-        		"   <Communications>\r\n" +  //$NON-NLS-1$
-        		"      <TypeCommunication xsi:type=\"TI_TypeComType\"/>\r\n" +  //$NON-NLS-1$
-        		"   </Communications>\r\n" +   //$NON-NLS-1$
-        		"</TI_Tiers>"; //$NON-NLS-1$
+        String xml = "<TI_Tiers xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><Id>7</Id><Communications><TypeCommunication xsi:type=\"TI_TypeComType\"/></Communications></TI_Tiers>"; //$NON-NLS-1$
+        return new DOMDocument(Util.parse(xml), null, StringUtils.EMPTY, StringUtils.EMPTY);
+    }
+
+    @Test
+    public void testCreateSameNameChildNode() throws Exception {
+        DOMDocument document = getTypeWithSameNameElementContent();
+        Accessor accessor = document.createAccessor("Emails[10]/email"); //$NON-NLS-1$
+        accessor.create();
+        Assert.assertNotNull(document.getLastAccessedNode());
+    }
+
+    private DOMDocument getTypeWithSameNameElementContent() throws IOException, SAXException, ParserConfigurationException {
+        String xml = "<Product><Id>1</Id><Emails><email><email>a@talend.com</email><email>b@talend.com</email></email></Emails></Product>";
         return new DOMDocument(Util.parse(xml), null, StringUtils.EMPTY, StringUtils.EMPTY);
     }
 }


### PR DESCRIPTION
…of an occurence of [0..many]

**What is the current behavior?** (You should also link to an open issue here)

There is NPR when entity has the same property name.

**What is the new behavior?**
Fixed above issue.
The root cause is that there are the same property name in entity hierarchy， so the exception arise when the W3C Document Object Model parse the XML schemal.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
