### PR TITLE
TMDM-9993 WebUI should take in account the language set to sort entities against multi-lingual element

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
@@ -62,16 +62,20 @@ public class MultilingualProjection extends SimpleProjection {
         switch (dataSourceDialect) {
         case H2:
         case MYSQL:
-            sql = "SUBSTRING(" + colName + ", LOCATE('[" + language + ":', " + colName + "))";
+            sql = "SUBSTRING(" + colName + ", LOCATE('[" + language + ":', " + colName + ")+4, LOCATE(']', " + colName
+                    + ", LOCATE('[" + language + ":', " + colName + ")) - LOCATE('[" + language + ":', " + colName + ") - 4)";
             break;
         case SQL_SERVER:
-            sql = "SUBSTRING(" + colName + ", CHARINDEX('[" + language + ":', " + colName + "), LEN(" + colName + "))";
+            sql = "SUBSTRING(" + colName + ", CHARINDEX('[" + language + ":', " + colName + ") + 4 , CHARINDEX(']', " + colName
+                    + ", CHARINDEX('[" + language + ":', " + colName + ")) -  CHARINDEX('" + language + ":', " + colName
+                    + ") - 3)";
             break;
         case POSTGRES:
-            sql = "SUBSTRING(" + colName + ", POSITION('[" + language + ":' IN " + colName + "))";
+            sql = "SUBSTRING(" + colName + ", '\\[" + language + ":(.*?)\\]')";
             break;
         case ORACLE_10G:
-            sql = "SUBSTR(" + colName + ", INSTR(" + colName + ", '[" + language + ":'))";
+            sql = "SUBSTR(" + colName + ", INSTR(" + colName + ", '[" + language + ":')+ 4, INSTR(" + colName + ", ']', INSTR("
+                    + colName + ", '[" + language + ":')) - INSTR(" + colName + ", '[" + language + ":') - 4)";
             break;
         case DB2:
         default:

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
@@ -58,6 +58,13 @@ public class MultilingualProjection extends SimpleProjection {
 
         StringBuilder sqlFragment = new StringBuilder();
 
+        /**
+         * generate the sql for the different database, data: [ZH:xxxxx][EN:yyyyy][FR:zzzzz], will get 'xxxxx' for ZH
+         * H2 & MySQL: SUBSTRING(this_.x_name, LOCATE('[ZH:', this_.x_name) + 4, LOCATE(']', this_.x_name, LOCATE('[ZH:', this_.x_name)) - LOCATE('[ZH:', this_.x_name) - 4)
+         * SQL_SERVER: SUBSTRING(this_.x_name, CHARINDEX('[ZH:', this_.x_name) + 4 , CHARINDEX(']', this_.x_name, CHARINDEX('[ZH:', this_.x_name)) -  CHARINDEX('ZH:', this_.x_name) - 3)
+         * POSTGRES: SUBSTRING(this_.x_name, '\[ZH:(.*?)\]')
+         * ORACLE_10G: SUBSTR(this_.x_name, INSTR(this_.x_name, '[ZH:') + 4, INSTR(this_.x_name, ']', INSTR(this_.x_name, '[ZH:')) - INSTR(this_.x_name, '[ZH:') - 4) 
+         */
         String sql = StringUtils.EMPTY;
         switch (dataSourceDialect) {
         case H2:

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MultilingualProjection.java
@@ -62,7 +62,7 @@ public class MultilingualProjection extends SimpleProjection {
         switch (dataSourceDialect) {
         case H2:
         case MYSQL:
-            sql = "SUBSTRING(" + colName + ", LOCATE('[" + language + ":', " + colName + ")+4, LOCATE(']', " + colName
+            sql = "SUBSTRING(" + colName + ", LOCATE('[" + language + ":', " + colName + ") + 4, LOCATE(']', " + colName
                     + ", LOCATE('[" + language + ":', " + colName + ")) - LOCATE('[" + language + ":', " + colName + ") - 4)";
             break;
         case SQL_SERVER:
@@ -74,7 +74,7 @@ public class MultilingualProjection extends SimpleProjection {
             sql = "SUBSTRING(" + colName + ", '\\[" + language + ":(.*?)\\]')";
             break;
         case ORACLE_10G:
-            sql = "SUBSTR(" + colName + ", INSTR(" + colName + ", '[" + language + ":')+ 4, INSTR(" + colName + ", ']', INSTR("
+            sql = "SUBSTR(" + colName + ", INSTR(" + colName + ", '[" + language + ":') + 4, INSTR(" + colName + ", ']', INSTR("
                     + colName + ", '[" + language + ":')) - INSTR(" + colName + ", '[" + language + ":') - 4)";
             break;
         case DB2:


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-9993

**What is the current behavior?** (You should also link to an open issue here)
Record 1: [ZH:xxxx][EN:yyyy][FR:zzzz] substring to :yyyy] for English, but it's wrong to compare 'yyyy]' with 'yyyy'


**What is the new behavior?**
What we are going to fix just only one point
Let's say we get a filed with value of 
Record 1: [ZH:xxxx][EN:yyyy][FR:zzzz]
Record 2: [ZH:aaaa][EN:bbbb][FR:cccc]

When using ZH, the values to sort is: xxxx and aaaa
When using EN, the values to sort is: yyyy and bbbb
When using FR, the values to sort is: zzzz and cccc

generate the sql for the different database, data: [ZH:xxxxx][EN:yyyyy][FR:zzzzz], will get 'xxxxx' for ZH
**H2 & MySQL**: 
```SUBSTRING(this_.x_name, LOCATE('[ZH:', this_.x_name) + 4, LOCATE(']', this_.x_name, LOCATE('[ZH:', this_.x_name)) - LOCATE('[ZH:', this_.x_name) - 4)```
**SQL_SERVER**: 
```SUBSTRING(this_.x_name, CHARINDEX('[ZH:', this_.x_name) + 4 , CHARINDEX(']', this_.x_name, CHARINDEX('[ZH:', this_.x_name)) -  CHARINDEX('ZH:', this_.x_name) - 3)```
 **POSTGRES**: 
```SUBSTRING(this_.x_name, '\[ZH:(.*?)\]')```
**ORACLE_10G**: 
```SUBSTR(this_.x_name, INSTR(this_.x_name, '[ZH:') + 4, INSTR(this_.x_name, ']', INSTR(this_.x_name, '[ZH:')) - INSTR(this_.x_name, '[ZH:') - 4) ```

**function SUBSTR(str, beginIndex, lentgh)**
parameter beginIndex is the begin postion
length: how many words will be get.

sql:
```LOCATE(']', this_.x_name, LOCATE('[ZH:', this_.x_name)) - LOCATE('[ZH:', this_.x_name) - 4```
eg, the original **[EN:Talend Dog T-Shirt][ZH:中国]**, 
the Chinese words length = ']' index - '[ZH:' index - length('[ZH:')


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
