### PR TITLE
TMDM-12687 [REST API] JSON response doesn't respect case sensitivity properly

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
@@ -17,11 +17,16 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import com.amalto.core.storage.SecuredStorage;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONWriter;
-import org.talend.mdm.commmon.metadata.*;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
+import org.talend.mdm.commmon.metadata.DefaultMetadataVisitor;
+import org.talend.mdm.commmon.metadata.EnumerationFieldMetadata;
+import org.talend.mdm.commmon.metadata.FieldMetadata;
+import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
+import org.talend.mdm.commmon.metadata.SimpleTypeFieldMetadata;
 
+import com.amalto.core.storage.SecuredStorage;
 import com.amalto.core.storage.StorageMetadataUtils;
 
 /**
@@ -30,7 +35,14 @@ import com.amalto.core.storage.StorageMetadataUtils;
  */
 public class DataRecordJSONWriter implements DataRecordWriter {
 
+    // Write attribute name use Camel-Case or LowerCase format
+    private boolean isCamelCase = false;
+
     private SecuredStorage.UserDelegator delegator = SecuredStorage.UNSECURED;
+
+    public DataRecordJSONWriter(boolean isCamelCase) {
+        this.isCamelCase = isCamelCase;
+    }
 
     private void writeRecord(final DataRecord record, final JSONWriter writer) throws JSONException {
         writer.object();
@@ -45,12 +57,12 @@ public class DataRecordJSONWriter implements DataRecordWriter {
                             }
                             try {
                                 if (!field.isMany()) {
-                                    writer.key(field.getName().toLowerCase()).value(
+                                    writer.key(generateAttributeName(field.getName())).value(
                                             StorageMetadataUtils.toString(record.get(field), false));
                                 } else {
                                     List<Object> values = (List<Object>) record.get(field);
                                     if (values != null) {
-                                        writer.key(field.getName().toLowerCase()).array();
+                                        writer.key(generateAttributeName(field.getName())).array();
                                         for (Object value : values) {
                                             writer.value(StorageMetadataUtils.toString(value, false));
                                         }
@@ -79,7 +91,7 @@ public class DataRecordJSONWriter implements DataRecordWriter {
                                 return null;
                             }
                             try {
-                                writer.key(containedField.getName().toLowerCase());
+                                writer.key(generateAttributeName(containedField.getName()));
                                 if (!containedField.isMany()) {
                                     writeRecord((DataRecord) record.get(containedField), writer);
                                 } else {
@@ -121,7 +133,7 @@ public class DataRecordJSONWriter implements DataRecordWriter {
     public void write(DataRecord record, Writer writer) throws IOException {
         JSONWriter jsonWriter = new JSONWriter(writer);
         try {
-            jsonWriter.object().key(record.getType().getName().toLowerCase());
+            jsonWriter.object().key(generateAttributeName(record.getType().getName()));
             {
                 if (!delegator.hide(record.getType())) {
                     writeRecord(record, jsonWriter);
@@ -140,5 +152,9 @@ public class DataRecordJSONWriter implements DataRecordWriter {
             throw new IllegalArgumentException("Delegator cannot be null.");
         }
         this.delegator = delegator;
+    }
+
+    private String generateAttributeName(String name) {
+        return isCamelCase ? name : name.toLowerCase();
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
@@ -35,7 +35,7 @@ import com.amalto.core.storage.StorageMetadataUtils;
  */
 public class DataRecordJSONWriter implements DataRecordWriter {
 
-    // Write attribute name use low case if ignoreCase is true
+    // Controls attribute name to be low case or raw value defined in schema, default: true, low case
     private boolean ignoreCase = true;
 
     private SecuredStorage.UserDelegator delegator = SecuredStorage.UNSECURED;

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
@@ -35,7 +35,7 @@ import com.amalto.core.storage.StorageMetadataUtils;
  */
 public class DataRecordJSONWriter implements DataRecordWriter {
 
-    // Controls attribute name to be low case or raw value defined in schema, default: true, low case
+    // Controls attribute name to be lowcase or raw value defined in schema, default: true, lowcase
     private boolean ignoreCase = true;
 
     private SecuredStorage.UserDelegator delegator = SecuredStorage.UNSECURED;
@@ -57,12 +57,12 @@ public class DataRecordJSONWriter implements DataRecordWriter {
                             }
                             try {
                                 if (!field.isMany()) {
-                                    writer.key(generateAttributeName(field.getName())).value(
+                                    writer.key(getFieldName(field.getName())).value(
                                             StorageMetadataUtils.toString(record.get(field), false));
                                 } else {
                                     List<Object> values = (List<Object>) record.get(field);
                                     if (values != null) {
-                                        writer.key(generateAttributeName(field.getName())).array();
+                                        writer.key(getFieldName(field.getName())).array();
                                         for (Object value : values) {
                                             writer.value(StorageMetadataUtils.toString(value, false));
                                         }
@@ -91,7 +91,7 @@ public class DataRecordJSONWriter implements DataRecordWriter {
                                 return null;
                             }
                             try {
-                                writer.key(generateAttributeName(containedField.getName()));
+                                writer.key(getFieldName(containedField.getName()));
                                 if (!containedField.isMany()) {
                                     writeRecord((DataRecord) record.get(containedField), writer);
                                 } else {
@@ -133,7 +133,7 @@ public class DataRecordJSONWriter implements DataRecordWriter {
     public void write(DataRecord record, Writer writer) throws IOException {
         JSONWriter jsonWriter = new JSONWriter(writer);
         try {
-            jsonWriter.object().key(generateAttributeName(record.getType().getName()));
+            jsonWriter.object().key(getFieldName(record.getType().getName()));
             {
                 if (!delegator.hide(record.getType())) {
                     writeRecord(record, jsonWriter);
@@ -154,7 +154,7 @@ public class DataRecordJSONWriter implements DataRecordWriter {
         this.delegator = delegator;
     }
 
-    private String generateAttributeName(String name) {
+    private String getFieldName(String name) {
         return ignoreCase ? name.toLowerCase() : name;
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
@@ -35,13 +35,13 @@ import com.amalto.core.storage.StorageMetadataUtils;
  */
 public class DataRecordJSONWriter implements DataRecordWriter {
 
-    // Write attribute name use Camel-Case or LowerCase format
-    private boolean isCamelCase = false;
+    // Write attribute name use low case if ignoreCase is true
+    private boolean ignoreCase = true;
 
     private SecuredStorage.UserDelegator delegator = SecuredStorage.UNSECURED;
 
-    public DataRecordJSONWriter(boolean isCamelCase) {
-        this.isCamelCase = isCamelCase;
+    public DataRecordJSONWriter(boolean ignoreCase) {
+        this.ignoreCase = ignoreCase;
     }
 
     private void writeRecord(final DataRecord record, final JSONWriter writer) throws JSONException {
@@ -155,6 +155,6 @@ public class DataRecordJSONWriter implements DataRecordWriter {
     }
 
     private String generateAttributeName(String name) {
-        return isCamelCase ? name : name.toLowerCase();
+        return ignoreCase ? name.toLowerCase() : name;
     }
 }

--- a/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONWriterTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONWriterTestCase.java
@@ -29,7 +29,7 @@ public class DataRecordJSONWriterTestCase extends DataRecordDataWriterTestCase {
     @Before
     public void setup() throws Exception {
         super.setup();
-        writer = new DataRecordJSONWriter();
+        writer = new DataRecordJSONWriter(true);
         writer.setSecurityDelegator(delegate);
         repository.load(this.getClass().getResourceAsStream("metadata.xsd"));
     }

--- a/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONWriterTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONWriterTestCase.java
@@ -179,6 +179,22 @@ public class DataRecordJSONWriterTestCase extends DataRecordDataWriterTestCase {
                 + "[]}}", result);
     }
     
+    @Test
+    public void testIgnoreCase() throws Exception {
+        // Test IgnoreCase is false,attribute name to be raw value defined in schema
+        // Attribute name to be lower case when IgnoreCase is true, refer to Test case 'testSimpleComplexType'
+        writer = new DataRecordJSONWriter(false);
+        DataRecord record = createDataRecord(repository.getComplexType("SimpleProduct"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", "Name");
+        setDataRecordField(record, "Description", "Desc");
+        setDataRecordField(record, "Availability", Boolean.FALSE);
+        String result = toJSON(record);
+        Assert.assertEquals(
+                "{\"SimpleProduct\":{\"Id\":\"12345\",\"Name\":\"Name\",\"Description\":\"Desc\",\"Availability\":\"false\"}}",
+                result);
+    }
+
     private String toJSON(DataRecord record) throws Exception {
         Writer w = new StringWriter();
         writer.write(record, w);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-12687
**What is the current behavior?** (You should also link to an open issue here)
Attribute name of response json is in low case.


**What is the new behavior?**
Add a parameter 'ignoreCase', and default value is true.
Attribute name of response json is in low case if parameter 'ignoreCase' is true.
Return original attribute name(defined in studio) if parameter 'ignoreCase' is false.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
