### PR TITLE
TMDM-12751 Deploy RTE datamodel failed(SQLServer2017)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -1,9 +1,9 @@
 /*
  * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
- * 
+ *
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
- * 
+ *
  * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
  * 92150 Suresnes, France
  */
@@ -61,7 +61,7 @@ public class MDMTable extends Table {
         // Try to find out the name of the primary key to create it as identity if the IdentityGenerator is used
         String pkname = null;
         if (hasPrimaryKey() && identityColumn) {
-            pkname = ((Column) getPrimaryKey().getColumnIterator().next()).getQuotedName(dialect);
+            pkname = getPrimaryKey().getColumnIterator().next().getQuotedName(dialect);
         }
 
         Iterator iter = getColumnIterator();
@@ -239,26 +239,33 @@ public class MDMTable extends Table {
                 results.add(alter.toString());
             } else if (StringUtils.isNotBlank(defaultValue)) {
                 StringBuilder alter = new StringBuilder(root.toString());
+                boolean needAlterDefalutValue = true;
                 if (dialect instanceof OracleCustomDialect) {
                     alter.append(" MODIFY ").append(columnName).append(" DEFAULT ").append(defaultValue);
                 } else if (dialect instanceof SQLServerDialect) {
-                    String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
-                    results.add(alterDropConstraintSQL);
-                    if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug(alterDropConstraintSQL);
+                    String existDefaultValue = getDefaultValueForColumn(tableName, columnName);
+                    if (StringUtils.isNotBlank(existDefaultValue) && existDefaultValue.equals(defaultValue)) {
+                        needAlterDefalutValue = false;
+                    } else {
+                        String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
+                        results.add(alterDropConstraintSQL);
+                        if (LOGGER.isDebugEnabled()) {
+                            LOGGER.debug(alterDropConstraintSQL);
+                        }
+                        alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);
                     }
-                    alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);
                 } else {
                     if (isDefaultValueNeeded(sqlType, dialect)) {
                         alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
                     }
                 }
-                alter.append(dialect.getAddColumnSuffixString());
-
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug(alter.toString());
+                if (needAlterDefalutValue) {
+                    alter.append(dialect.getAddColumnSuffixString());
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(alter.toString());
+                    }
+                    results.add(alter.toString());
                 }
-                results.add(alter.toString());
             } else if (MDMTableUtils.isChangedToOptional(column, columnInfo)) {
                 StringBuilder alter = new StringBuilder(root.toString());
                 if (dialect instanceof PostgreSQLDialect || dialect instanceof DB2Dialect) {
@@ -282,32 +289,65 @@ public class MDMTable extends Table {
     }
 
     private String generateAlterDefaultValueConstraintSQL(String tableName, String columnName) {
+        String alterDropConstraintSQL = StringUtils.EMPTY;
+        try {
+            String sql = "select c.name from sysconstraints a inner join syscolumns b on a.colid=b.colid inner join sysobjects c on a.constid=c.id "
+                    + "where a.id=object_id(?) and b.name=?";
+            List<String> parameters = new ArrayList<>();
+            parameters.add(tableName);
+            parameters.add(columnName);
+            String queryResult = executeSQLForSQLServer(sql, parameters);
+            alterDropConstraintSQL = "alter table " + tableName + " drop constraint " + queryResult;
+        } catch (Exception e) {
+            LOGGER.error("Fetching SQLServer default value constraint failed.", e);
+        }
+        return alterDropConstraintSQL;
+    }
+
+    private String getDefaultValueForColumn(String tableName, String columnName) {
+        String defaultValue = StringUtils.EMPTY;
+        try {
+            String sql = "SELECT CM.text FROM syscolumns C INNER JOIN systypes T ON C.xusertype = T.xusertype "
+                    + "LEFT JOIN sys.extended_properties ETP ON  ETP.major_id = c.id AND ETP.minor_id = C.colid AND ETP.name ='MS_Description' "
+                    + "LEFT join syscomments CM ON C.cdefault=CM.id WHERE C.id = object_id(?) and C.name = ?";
+            List<String> parameters = new ArrayList<>();
+            parameters.add(tableName);
+            parameters.add(columnName);
+            defaultValue = executeSQLForSQLServer(sql, parameters);
+        } catch (Exception e) {
+            LOGGER.error("Fetching SQLServer default value failed.", e);
+        }
+        return defaultValue.replaceAll("\\(", "").replaceAll("\\)", "");
+    }
+
+    private String executeSQLForSQLServer(String sql, List<String> parameters) throws Exception {
         Connection connection = null;
         PreparedStatement statement = null;
-        String alterDropConstraintSQL = StringUtils.EMPTY;
+        String queryValue = StringUtils.EMPTY;
         try {
             Properties properties = dataSource.getAdvancedPropertiesIncludeUserInfo();
             connection = DriverManager.getConnection(dataSource.getConnectionURL(), properties);
-            String sql = "select c.name from sysconstraints a inner join syscolumns b on a.colid=b.colid inner join sysobjects c on a.constid=c.id "
-                    + "where a.id=object_id(?) and b.name=?";
             statement = connection.prepareStatement(sql);
-            statement.setString(1, tableName);
-            statement.setString(2, columnName);
+            for (int i = 0; i < parameters.size(); i++) {
+                statement.setString(i + 1, parameters.get(i));
+            }
             ResultSet rs = statement.executeQuery();
             while (rs.next()) {
-                alterDropConstraintSQL = "alter table " + tableName + " drop constraint " + rs.getString(1);
+                queryValue = rs.getString(1);
             }
-        } catch (SQLException e) {
-            LOGGER.error("Fetching SQLServer default value constraint failed.", e);
         } finally {
             try {
-                statement.close();
-                connection.close();
+                if (statement != null) {
+                    statement.close();
+                }
+                if (connection != null) {
+                    connection.close();
+                }
             } catch (SQLException e) {
                 LOGGER.error("Unexpected error when closing connection.", e);
             }
         }
-        return alterDropConstraintSQL;
+        return queryValue;
     }
 
     private String convertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
@@ -324,6 +364,7 @@ public class MDMTable extends Table {
         }
         return true;
     }
+
 
     public void setDataSource(RDBMSDataSource dataSource) {
         this.dataSource = dataSource;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -291,8 +291,8 @@ public class MDMTable extends Table {
     private String generateAlterDefaultValueConstraintSQL(String tableName, String columnName) {
         String alterDropConstraintSQL = StringUtils.EMPTY;
         try {
-            String sql = "select c.name from sysconstraints a inner join syscolumns b on a.colid=b.colid inner join sysobjects c on a.constid=c.id "
-                    + "where a.id=object_id(?) and b.name=?";
+            String sql = "SELECT c.name FROM sysconstraints a INNER JOIN syscolumns b ON a.colid=b.colid INNER JOIN sysobjects c ON a.constid=c.id "
+                    + "WHERE a.id = object_id (?) AND b.name = ?";
             List<String> parameters = new ArrayList<>();
             parameters.add(tableName);
             parameters.add(columnName);
@@ -309,7 +309,7 @@ public class MDMTable extends Table {
         try {
             String sql = "SELECT CM.text FROM syscolumns C INNER JOIN systypes T ON C.xusertype = T.xusertype "
                     + "LEFT JOIN sys.extended_properties ETP ON  ETP.major_id = c.id AND ETP.minor_id = C.colid AND ETP.name ='MS_Description' "
-                    + "LEFT join syscomments CM ON C.cdefault=CM.id WHERE C.id = object_id(?) and C.name = ?";
+                    + "LEFT join syscomments CM ON C.cdefault=CM.id WHERE C.id = object_id(?) AND C.name = ?";
             List<String> parameters = new ArrayList<>();
             parameters.add(tableName);
             parameters.add(columnName);

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -243,8 +243,8 @@ public class MDMTable extends Table {
                 if (dialect instanceof OracleCustomDialect) {
                     alter.append(" MODIFY ").append(columnName).append(" DEFAULT ").append(defaultValue);
                 } else if (dialect instanceof SQLServerDialect) {
-                    String existDefaultValue = getDefaultValueForColumn(tableName, columnName);
-                    if (StringUtils.isNotBlank(existDefaultValue) && existDefaultValue.equals(defaultValue)) {
+                    String existedDefaultValue = getDefaultValueForColumn(tableName, columnName);
+                    if (StringUtils.isNotBlank(existedDefaultValue) && existedDefaultValue.equals(defaultValue)) {
                         needAlterDefalutValue = false;
                     } else {
                         String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
@@ -323,7 +323,7 @@ public class MDMTable extends Table {
     private String executeSQLForSQLServer(String sql, List<String> parameters) throws Exception {
         Connection connection = null;
         PreparedStatement statement = null;
-        String queryValue = StringUtils.EMPTY;
+        String result = StringUtils.EMPTY;
         try {
             Properties properties = dataSource.getAdvancedPropertiesIncludeUserInfo();
             connection = DriverManager.getConnection(dataSource.getConnectionURL(), properties);
@@ -333,7 +333,7 @@ public class MDMTable extends Table {
             }
             ResultSet rs = statement.executeQuery();
             while (rs.next()) {
-                queryValue = rs.getString(1);
+                result = rs.getString(1);
             }
         } finally {
             try {
@@ -347,7 +347,7 @@ public class MDMTable extends Table {
                 LOGGER.error("Unexpected error when closing connection.", e);
             }
         }
-        return queryValue;
+        return result;
     }
 
     private String convertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
@@ -364,7 +364,6 @@ public class MDMTable extends Table {
         }
         return true;
     }
-
 
     public void setDataSource(RDBMSDataSource dataSource) {
         this.dataSource = dataSource;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -248,7 +248,7 @@ public class MDMTable extends Table {
                         needAlterDefalutValue = false;
                     } else {
                         String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
-                        if(StringUtils.isNotBlank(alterDropConstraintSQL)) {
+                        if (StringUtils.isNotBlank(alterDropConstraintSQL)) {
                             results.add(alterDropConstraintSQL);
                         }
                         if (LOGGER.isDebugEnabled()) {
@@ -299,10 +299,9 @@ public class MDMTable extends Table {
             parameters.add(tableName);
             parameters.add(columnName);
             String queryResult = executeSQLForSQLServer(sql, parameters);
-            if(StringUtils.isNotEmpty(queryResult)){
+            if (StringUtils.isNotBlank(queryResult)) {
                 alterDropConstraintSQL = "alter table " + tableName + " drop constraint " + queryResult;
             }
-
         } catch (Exception e) {
             LOGGER.error("Fetching SQLServer default value constraint failed.", e);
         }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -248,7 +248,9 @@ public class MDMTable extends Table {
                         needAlterDefalutValue = false;
                     } else {
                         String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
-                        results.add(alterDropConstraintSQL);
+                        if(StringUtils.isNotBlank(alterDropConstraintSQL)) {
+                            results.add(alterDropConstraintSQL);
+                        }
                         if (LOGGER.isDebugEnabled()) {
                             LOGGER.debug(alterDropConstraintSQL);
                         }
@@ -297,7 +299,10 @@ public class MDMTable extends Table {
             parameters.add(tableName);
             parameters.add(columnName);
             String queryResult = executeSQLForSQLServer(sql, parameters);
-            alterDropConstraintSQL = "alter table " + tableName + " drop constraint " + queryResult;
+            if(StringUtils.isNotEmpty(queryResult)){
+                alterDropConstraintSQL = "alter table " + tableName + " drop constraint " + queryResult;
+            }
+
         } catch (Exception e) {
             LOGGER.error("Fetching SQLServer default value constraint failed.", e);
         }
@@ -307,7 +312,7 @@ public class MDMTable extends Table {
     private String getDefaultValueForColumn(String tableName, String columnName) {
         String defaultValue = StringUtils.EMPTY;
         try {
-            String sql = "SELECT CM.text FROM syscolumns C INNER JOIN systypes T ON C.xusertype = T.xusertype "
+            String sql = "SELECT ISNULL(CM.text,'')  FROM syscolumns C INNER JOIN systypes T ON C.xusertype = T.xusertype "
                     + "LEFT JOIN sys.extended_properties ETP ON  ETP.major_id = c.id AND ETP.minor_id = C.colid AND ETP.name ='MS_Description' "
                     + "LEFT join syscomments CM ON C.cdefault=CM.id WHERE C.id = object_id(?) AND C.name = ?";
             List<String> parameters = new ArrayList<>();

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -61,7 +61,7 @@ public class MDMTable extends Table {
         // Try to find out the name of the primary key to create it as identity if the IdentityGenerator is used
         String pkname = null;
         if (hasPrimaryKey() && identityColumn) {
-            pkname = getPrimaryKey().getColumnIterator().next().getQuotedName(dialect);
+            pkname = ((Column) getPrimaryKey().getColumnIterator().next()).getQuotedName(dialect);
         }
 
         Iterator iter = getColumnIterator();

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -239,13 +239,13 @@ public class MDMTable extends Table {
                 results.add(alter.toString());
             } else if (StringUtils.isNotBlank(defaultValue)) {
                 StringBuilder alter = new StringBuilder(root.toString());
-                boolean needAlterDefultValue = true;
+                boolean needAlterDefaultValue = true;
                 if (dialect instanceof OracleCustomDialect) {
                     alter.append(" MODIFY ").append(columnName).append(" DEFAULT ").append(defaultValue);
                 } else if (dialect instanceof SQLServerDialect) {
                     String existedDefaultValue = getDefaultValueForColumn(tableName, columnName);
                     if (StringUtils.isNotBlank(existedDefaultValue) && existedDefaultValue.equals(defaultValue)) {
-                        needAlterDefultValue = false;
+                        needAlterDefaultValue = false;
                     } else {
                         String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
                         if (StringUtils.isNotBlank(alterDropConstraintSQL)) {
@@ -261,7 +261,7 @@ public class MDMTable extends Table {
                         alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
                     }
                 }
-                if (needAlterDefultValue) {
+                if (needAlterDefaultValue) {
                     alter.append(dialect.getAddColumnSuffixString());
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(alter.toString());

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -239,13 +239,13 @@ public class MDMTable extends Table {
                 results.add(alter.toString());
             } else if (StringUtils.isNotBlank(defaultValue)) {
                 StringBuilder alter = new StringBuilder(root.toString());
-                boolean needAlterDefalutValue = true;
+                boolean needAlterDefultValue = true;
                 if (dialect instanceof OracleCustomDialect) {
                     alter.append(" MODIFY ").append(columnName).append(" DEFAULT ").append(defaultValue);
                 } else if (dialect instanceof SQLServerDialect) {
                     String existedDefaultValue = getDefaultValueForColumn(tableName, columnName);
                     if (StringUtils.isNotBlank(existedDefaultValue) && existedDefaultValue.equals(defaultValue)) {
-                        needAlterDefalutValue = false;
+                        needAlterDefultValue = false;
                     } else {
                         String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
                         if (StringUtils.isNotBlank(alterDropConstraintSQL)) {
@@ -261,7 +261,7 @@ public class MDMTable extends Table {
                         alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
                     }
                 }
-                if (needAlterDefalutValue) {
+                if (needAlterDefultValue) {
                     alter.append(dialect.getAddColumnSuffixString());
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(alter.toString());


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-12751
**What is the current behavior?** (You should also link to an open issue here)
For SQL Server, if column exist default value, when execute below sql script
```
 alter table Eda ADD DEFAULT 60 FOR x_delaineutralisationeda
```
Will throw Exception

> Could not prepare database schema: Column already has a DEFAULT bound to it.


**What is the new behavior?**
For SQL Server, the whole logic for alter default value is below: 
1. new default value defined in schema
- if old default value exists and same with new, do nothing.
- if old default value exists and different with new, drop the old constraint + execute alter sql. 
- if old default value doesn't exist, execute alter sql. 
2.  no default value defined in schema
- do nothing.

This PR add logic to check if new default value exist in schema, and compare with old value in DB.

Use Below SQL script to query column default value:
```
SELECT ISNULL(CM.text,'') FROM syscolumns C INNER JOIN systypes T ON C.xusertype = T.xusertype 
LEFT JOIN sys.extended_properties ETP ON  ETP.major_id = c.id AND ETP.minor_id = C.colid AND ETP.name ='MS_Description' 
LEFT join syscomments CM ON C.cdefault=CM.id WHERE C.id = object_id(?) AND C.name = ?
```
the first parameter is table name, second parameter is column name.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
