### PR TITLE
TMDM-12749 [REST API] Support JSON input for Create/Update Record APIs(wip)

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement
+ * along with this program; if not, write to Talend SA
+ * 9 rue Pages 92150 Suresnes, France
+ */
+
+package com.amalto.core.storage.record;
+
+import com.amalto.core.metadata.ClassRepository;
+import com.amalto.core.storage.StorageMetadataUtils;
+import com.amalto.core.storage.record.metadata.DataRecordMetadata;
+import com.amalto.core.storage.record.metadata.DataRecordMetadataImpl;
+import com.amalto.core.storage.record.metadata.UnsupportedDataRecordMetadata;
+
+import org.apache.commons.lang.StringUtils;
+import org.talend.mdm.commmon.metadata.*;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
+
+    private static final String JSON_REF = "$ref"; //$NON-NLS-1$
+    
+    private static JsonElement rootElement = null;
+
+    public DataRecordJSONReader() {
+    }
+
+    public DataRecord read(MetadataRepository repository, ComplexTypeMetadata type, JsonElement element) {
+        DataRecordMetadata metadata = new DataRecordMetadataImpl();
+        DataRecord dataRecord = new DataRecord(type, metadata);
+        rootElement = (JsonElement) element.getAsJsonObject().get(type.getName());
+        _read(repository, dataRecord, type, rootElement);
+        // Process fields that are links to other field values.
+        ComplexTypeMetadata dataRecordType = dataRecord.getType();
+        Collection<FieldMetadata> fields = dataRecordType.getFields();
+        for (FieldMetadata field : fields) {
+            if (field.getData(ClassRepository.LINK) != null) {
+                dataRecord.set(field, dataRecord.get(field.<String>getData(ClassRepository.LINK)));
+            }
+        }
+        return dataRecord;
+    }
+
+    private void _read(MetadataRepository repository, DataRecord dataRecord, ComplexTypeMetadata type, JsonElement element) {
+        JsonObject root = element.getAsJsonObject();
+        for (Iterator<Entry<String, JsonElement>> iterator = root.entrySet().iterator(); iterator.hasNext(); ) {
+            Entry<String, JsonElement> entry = iterator.next();
+            String tagName = entry.getKey();
+            JsonElement currentChild = entry.getValue();
+            String refType = "";
+            if (tagName.equalsIgnoreCase(JSON_REF)) {
+                refType = _resolveJSONRef(currentChild);
+                for (Entry<String, JsonElement> refEntry : ((JsonObject)rootElement.getAsJsonObject().get(refType)).entrySet()) {
+                    root.addProperty(refEntry.getKey(), refEntry.getValue().getAsString());
+                }
+                iterator.remove();
+            }
+            if (currentChild instanceof JsonObject) {
+                JsonObject child = currentChild.getAsJsonObject();
+                if (!type.hasField(tagName)) {
+                    continue;
+                }
+                FieldMetadata field = type.getField(tagName);
+                if (field.getType() instanceof ContainedComplexTypeMetadata) {
+                    ComplexTypeMetadata containedType = (ComplexTypeMetadata) field.getType();
+                    for (ComplexTypeMetadata subType : containedType.getSubTypes()) {
+                        if (subType.getName().equals(refType)) {
+                            containedType = subType;
+                            break;
+                        }
+                    }
+                    DataRecord containedRecord = new DataRecord(containedType, UnsupportedDataRecordMetadata.INSTANCE);
+                    dataRecord.set(field, containedRecord);
+                    _read(repository, containedRecord, containedType, child);
+                } else {
+                    _read(repository, dataRecord, type, child);
+                }
+            } else if (currentChild instanceof JsonPrimitive) {
+                _readJsonPrimitive(repository, dataRecord, type, (JsonPrimitive)currentChild, tagName);
+            } else if (currentChild instanceof JsonArray) {
+                int size = ((JsonArray) currentChild).size();
+                for (int i=0; i<size; i++) {
+                    JsonElement childObject = ((JsonArray) currentChild).get(i);
+                    if (childObject instanceof JsonPrimitive) {
+                        _readJsonPrimitive(repository, dataRecord, type, (JsonPrimitive)childObject, tagName);
+                    } else if(childObject instanceof JsonObject) {
+                        _read(repository, dataRecord, type, childObject);
+                    }
+                }
+            }
+        }
+    }
+
+    /*   The xsi:type in XML:
+    *    <Person><PersonId>33</PersonId><Name>person-name-322aa3</Name><Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="USAddress"><zip>10221</zip><Line1>usa-new</Line1></Address></Person>
+    * 
+    *    The expected JSON input:
+    *    {
+    *        "Person": {
+    *            "PersonId": "33",
+    *            "Name": "person-name-322aa3",
+    *            "Address": {
+    *                "zip": "102221",
+    *                "$ref": "#/USAddress"
+    *            },
+    *            "USAddress": {  "Line1": "usa-new" }
+    *                
+    *        }
+    *    }
+    *    
+    *    The resolved JSON output:
+    *    {
+    *        "Person": {
+    *            "PersonId": "33",
+    *            "Name": "person-name-322aa3",
+    *            "Address": {
+    *                "zip": "102221",
+    *                "Line1": "usa-new"
+    *            }   
+    *        }
+    *    }
+    *
+    */
+    private String _resolveJSONRef(JsonElement refChild) {
+        if (refChild != null && !refChild.isJsonNull()) {
+            if (refChild.isJsonPrimitive()) {
+                String refType = refChild.getAsString();
+                refType = StringUtils.substringAfterLast(refType, "/"); //$NON-NLS-1$
+                return refType;
+            }
+        }
+        return ""; //$NON-NLS-1$
+    }
+
+    private void _readJsonPrimitive(MetadataRepository repository, DataRecord dataRecord, ComplexTypeMetadata type, JsonPrimitive currentChild, String tagName) {
+        StringBuilder builder = new StringBuilder();
+        String nodeValue = currentChild.getAsString();
+        if (nodeValue != null) {
+            builder.append(nodeValue.trim());
+        }
+        String textContent = builder.toString();
+        if (!textContent.isEmpty()) {
+            if (type.hasField(tagName)) {
+                FieldMetadata field = type.getField(tagName);
+                if (field instanceof ReferenceFieldMetadata) {
+                    ComplexTypeMetadata actualType = ((ReferenceFieldMetadata) field).getReferencedType();
+                    dataRecord.set(field, StorageMetadataUtils.convert(textContent, field, actualType));
+                } else {
+                    dataRecord.set(field, StorageMetadataUtils.convert(textContent, field, type));
+                }
+            }
+        }
+    }
+}

--- a/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONReaderTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONReaderTestCase.java
@@ -1,0 +1,344 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+
+package com.amalto.core.storage.record;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.ContainedComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
+import org.talend.mdm.commmon.metadata.FieldMetadata;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+public class DataRecordJSONReaderTestCase extends DataRecordDataWriterTestCase {
+
+    private DataRecordJSONReader reader;
+
+    private DataRecordXmlWriter writer;
+
+    @Before
+    public void setup() throws Exception {
+        super.setup();
+        writer = new DataRecordXmlWriter();
+        writer.setSecurityDelegator(delegate);
+        reader = new DataRecordJSONReader();
+        repository.load(this.getClass().getResourceAsStream("metadata.xsd"));
+    }
+
+    @Test
+    public void testComplexType() throws Exception {
+        DataRecord record = createDataRecord(repository.getComplexType("SimpleProduct"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", "Name");
+        setDataRecordField(record, "Description", "Desc");
+        setDataRecordField(record, "Availability", Boolean.FALSE);
+
+        String inputJson = "{\"SimpleProduct\": {\"Id\": \"12345\",\"Name\": \"Name\",\"Description\": \"Desc\",\"Availability\": \"false\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "SimpleProduct");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithArray() throws Exception {
+        DataRecord record = createDataRecord(repository.getComplexType("WithArray"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Repeat", "ABC");
+        setDataRecordField(record, "Repeat", "DEF");
+
+        String inputJson = "{\"WithArray\": {\"Id\": \"12345\",\"Repeat\": \"ABC\",\"Repeat\": \"DEF\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithArray");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithArrayContainsNull() throws Exception {
+        DataRecord record = createDataRecord(repository.getComplexType("WithArray"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Repeat", "ABC");
+        setDataRecordField(record, "Repeat", null);
+
+        String inputJson = "{\"WithArray\": {\"Id\": \"12345\",\"Repeat\": \"ABC\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithArray");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithEmptyArray() throws Exception {
+        DataRecord record = createDataRecord(repository.getComplexType("WithArray"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Repeat", new ArrayList<String>());
+
+        String inputJson = "{\"WithArray\": {\"Id\": \"12345\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithArray");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeContainsNull() throws Exception {
+        DataRecord record = createDataRecord(repository.getComplexType("SimpleProduct"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", null);
+        setDataRecordField(record, "Description", "Desc");
+        setDataRecordField(record, "Availability", null);
+
+        String inputJson = "{\"SimpleProduct\": {\"Id\": \"12345\",\"Description\": \"Desc\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "SimpleProduct");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithReferencedField() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("Customer");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", "Name");
+
+        FieldMetadata field = type.getField("Address");
+
+        DataRecord referenced = createDataRecord(((ContainedComplexTypeMetadata) field.getType()).getContainedType());
+        setDataRecordField(referenced, "Id", "AddressId");
+        setDataRecordField(referenced, "Street", "AddressStreet");
+        setDataRecordField(referenced, "City", "AddressCity");
+
+        setDataRecordField(record, "Address", referenced);
+
+        String inputJson = "{\"Customer\": {\"Id\": \"12345\",\"Name\": \"Name\",\"Address\": {\"Id\": \"AddressId\",\"City\": \"AddressCity\",\"Street\": \"AddressStreet\"}}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "Customer");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithReferencedFieldContainsNull() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("Customer");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", null);
+
+        FieldMetadata field = type.getField("Address");
+
+        DataRecord referenced = createDataRecord(((ContainedComplexTypeMetadata) field.getType()).getContainedType());
+        setDataRecordField(referenced, "Id", "AddressId");
+        setDataRecordField(referenced, "Street", "AddressStreet");
+        setDataRecordField(referenced, "City", null);
+
+        setDataRecordField(record, "Address", referenced);
+        String inputJson = "{\"Customer\": {\"Id\": \"12345\",\"Address\": {\"Id\": \"AddressId\",\"Street\": \"AddressStreet\"}}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "Customer");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithEmptyReferencedFieldContainsNull() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("Customer");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", null);
+
+        FieldMetadata field = type.getField("Address");
+
+        DataRecord referenced = createDataRecord(((ContainedComplexTypeMetadata) field.getType()).getContainedType());
+
+        setDataRecordField(record, "Address", referenced);
+
+        String inputJson = "{\"Customer\": {\"Id\": \"12345\",\"Address\": \"\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "Customer");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithContainedField() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("WithContained");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "ABCD");
+
+        FieldMetadata field = type.getField("Contained");
+        Assert.assertTrue(field instanceof ContainedTypeFieldMetadata);
+        ContainedTypeFieldMetadata containedField = (ContainedTypeFieldMetadata) field;
+        ContainedComplexTypeMetadata tm = (ContainedComplexTypeMetadata) containedField.getType();
+
+        DataRecord contained = createDataRecord(tm);
+        setDataRecordField(contained, "ContainedId", "CID");
+        setDataRecordField(contained, "ContainedName", "CName");
+
+        setDataRecordField(record, "Contained", contained);
+
+        String inputJson = "{\"WithContained\": {\"Id\": \"ABCD\",\"Contained\": {\"ContainedId\": \"CID\", \"ContainedName\": \"CName\"}}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithContained");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testContainedTypeContainsNull() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("WithContained");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "ABCD");
+
+        FieldMetadata field = type.getField("Contained");
+        Assert.assertTrue(field instanceof ContainedTypeFieldMetadata);
+        ContainedTypeFieldMetadata containedField = (ContainedTypeFieldMetadata) field;
+        ContainedComplexTypeMetadata tm = (ContainedComplexTypeMetadata) containedField.getType();
+
+        DataRecord contained = createDataRecord(tm);
+        setDataRecordField(contained, "ContainedId", "CID");
+        setDataRecordField(contained, "ContainedName", null);
+
+        setDataRecordField(record, "Contained", contained);
+
+        String inputJson = "{\"WithContained\": {\"Id\": \"ABCD\",\"Contained\": {\"ContainedId\": \"CID\"}}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithContained");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithNullContainedField() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("WithContained");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "ABCD");
+
+        FieldMetadata field = type.getField("Contained");
+        Assert.assertTrue(field instanceof ContainedTypeFieldMetadata);
+        ContainedTypeFieldMetadata containedField = (ContainedTypeFieldMetadata) field;
+        ContainedComplexTypeMetadata tm = (ContainedComplexTypeMetadata) containedField.getType();
+
+        DataRecord contained = createDataRecord(tm);
+
+        setDataRecordField(record, "Contained", contained);
+
+        String inputJson = "{\"WithContained\":{\"Id\": \"ABCD\",\"Contained\": \"\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithContained");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithMultiContainedField() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("WithMultiContained");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "ABCD");
+        FieldMetadata field = type.getField("Contained");
+        Assert.assertTrue(field instanceof ContainedTypeFieldMetadata);
+        ContainedTypeFieldMetadata containedField = (ContainedTypeFieldMetadata) field;
+        ContainedComplexTypeMetadata tm = (ContainedComplexTypeMetadata) containedField.getType();
+        List<DataRecord> list = new ArrayList<DataRecord>();
+        DataRecord contained1 = createDataRecord(tm);
+        setDataRecordField(contained1, "ContainedId", "CID1");
+        setDataRecordField(contained1, "ContainedName", "CName1");
+        list.add(contained1);
+
+        DataRecord contained2 = createDataRecord(tm);
+        setDataRecordField(contained2, "ContainedId", "CID2");
+        setDataRecordField(contained2, "ContainedName", "CName2");
+        list.add(contained2);
+
+        setDataRecordField(record, "Contained", list);
+
+        String inputJson = "{\"WithMultiContained\":{\"Id\": \"ABCD\",\"Contained\": [{\"ContainedId\": \"CID1\",\"ContainedName\": \"CName1\"},{\"ContainedId\": \"CID2\",\"ContainedName\": \"CName2\"}]}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithMultiContained");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithEmptyMultiContainedField() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("WithMultiContained");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "ABCD");
+        FieldMetadata field = type.getField("Contained");
+        Assert.assertTrue(field instanceof ContainedTypeFieldMetadata);
+        ContainedTypeFieldMetadata containedField = (ContainedTypeFieldMetadata) field;
+        ContainedComplexTypeMetadata tm = (ContainedComplexTypeMetadata) containedField.getType();
+        setDataRecordField(record, "Contained", new ArrayList<DataRecord>());
+
+        String inputJson = "{\"WithMultiContained\":{\"Id\":\"ABCD\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithMultiContained");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithEnumContainsNull() throws Exception {
+        DataRecord record = createDataRecord(repository.getComplexType("WithEnum"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Color", "White");
+        setDataRecordField(record, "Color", null);
+
+        String inputJson = "{\"WithEnum\":{\"Id\":\"12345\",\"Color\":\"White\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithEnum");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testComplexTypeWithEnum() throws Exception {
+        DataRecord record = createDataRecord(repository.getComplexType("WithEnum"));
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Color", "White");
+
+        String inputJson = "{\"WithEnum\":{\"Id\":\"12345\",\"Color\":\"White\"}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "WithEnum");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    @Test
+    public void testTypeWithComplexTypeOfReference() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("Customer");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", "Name");
+
+        FieldMetadata field = type.getField("Address");
+
+        DataRecord referenced = createDataRecord(((ContainedComplexTypeMetadata) field.getType()).getContainedType());
+        setDataRecordField(referenced, "Id", "AddressId");
+        setDataRecordField(referenced, "Street", "AddressStreet");
+        setDataRecordField(referenced, "City", "AddressCity");
+
+        setDataRecordField(record, "Address", referenced);
+
+        String inputJson = "{\"Customer\":{\"Id\":\"12345\",\"Name\": \"Name\",\"Address\": {\"Id\": \"AddressId\",\"Street\": \"AddressStreet\",\"City\": \"AddressCity\"}}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "Customer");
+        Assert.assertEquals(record, resultRecord);
+    }
+
+    /*
+    "Customer": {
+        "Id": "33",
+        "$ref": "#/NameField",
+        "NameField": {  "Name": "New_Name" }
+        }
+    }
+    */
+    @Test
+    public void testTypeWithJSONReference() throws Exception {
+        ComplexTypeMetadata type = repository.getComplexType("Customer");
+        DataRecord record = createDataRecord(type);
+        setDataRecordField(record, "Id", "12345");
+        setDataRecordField(record, "Name", "New_Name");
+
+        String inputJson = "{\"Customer\":{\"Id\":\"12345\",\"$ref\": \"#/NameField\",\"NameField\": {  \"Name\": \"New_Name\" }}}";
+        DataRecord resultRecord = toDataRecord(inputJson, "Customer");
+
+        Assert.assertEquals(record.get("Name"), resultRecord.get("Name"));
+    }
+
+    private DataRecord toDataRecord(String strJson, String storageName) throws Exception {
+        JsonParser parser = new JsonParser();
+        JsonElement root = parser.parse(strJson);
+        ComplexTypeMetadata complexTypeMetadata = repository.getComplexType(storageName);
+        DataRecord record = reader.read(repository, complexTypeMetadata, root);
+        return record;
+    }
+}


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

This is a new feature.
https://jira.talendforge.org/browse/TMDM-12749

**What is the new behavior?**

On the resources:

POST /data/{containerName}   Create Record API
PUT  /data/{containerName}   Update Record API

The content-type supported is application/xml.

To have multiple possibilities and facilitates the integration on proxy side, the goal is to extend the actual API to support the input of JSON (Content-type:application/json)

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
