### PR TITLE
TMDM-12990 [REST API] Support logical delete on Delete Record Query API

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/server/DefaultItem.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/DefaultItem.java
@@ -262,7 +262,7 @@ public class DefaultItem implements Item {
             throw new RuntimeException("Cannot delete instance '" + itemPOJOPK.getUniqueID() + "' (concept name: " + conceptName + ") due to FK integrity constraints.");
         }
         try {
-            return ItemPOJO.drop(itemPOJOPK, partPath);
+            return ItemPOJO.drop(itemPOJOPK, partPath, false);
         } catch (XtentisException e) {
             throw (e);
         } catch (Exception e) {


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)



**What is the new behavior?**
Add parameter 'createItemsTrashOnly' for drop method.
If createItemsTrashOnly is true, the method will put the dropped records into Recycle bin and won't delete the source record by id. 
The source record will be deleted by query, it should be more efficient than deleting by id.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
