### PR TITLE
TMDM-12877 [Impact analysis] Modify Product/Features from 1-1 to 0-1 redeploy DM failed.

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorageDataAnaylzer.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorageDataAnaylzer.java
@@ -52,7 +52,7 @@ public class HibernateStorageDataAnaylzer extends HibernateStorageImpactAnalyzer
                 FieldMetadata previous = (FieldMetadata) modifyAction.getPrevious();
                 FieldMetadata current = (FieldMetadata) modifyAction.getCurrent();
 
-                if (current.isMandatory() && !previous.isMandatory()) {
+                if (current.isMandatory() && !previous.isMandatory() && !(element instanceof ContainedTypeFieldMetadata)) {
                     int count = fetchFieldCountOfNull(previous.getContainingType().getEntity(), previous);
                     modifyAction.setHasNullValue(count > 0);
                 }
@@ -107,11 +107,16 @@ public class HibernateStorageDataAnaylzer extends HibernateStorageImpactAnalyzer
     private int fetchFieldCountByUserQuery(UserQueryBuilder qb) {
         int count = 0;
         storage.begin();
-        StorageResults results = storage.fetch(qb.getSelect());
+        StorageResults results = null;
         try {
+            results = storage.fetch(qb.getSelect());
             count = results.getCount();
+        } catch (Exception e) {
+            LOGGER.error("Failed to fetch count of field.", e); //$NON-NLS-1$
         } finally {
-            results.close();
+            if (results != null) {
+                results.close();
+            }
             storage.commit();
         }
         return count;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -170,10 +170,16 @@ public class LiquibaseSchemaAdapter  {
         List<AbstractChange> changeActionList = new ArrayList<AbstractChange>();
         for (ModifyChange modifyAction : diffResults.getModifyChanges()) {
             MetadataVisitable element = modifyAction.getElement();
-            if (!isContainedComplexFieldTypeMetadata((FieldMetadata) element)
-                    || isSimpleTypeFieldMetadata((FieldMetadata) element) || isContainedComplexType((FieldMetadata) element)) {
+            if ((!isContainedComplexFieldTypeMetadata((FieldMetadata) element)
+                    || isSimpleTypeFieldMetadata((FieldMetadata) element)
+                    || isContainedComplexType((FieldMetadata) element))
+                    && !isContainedTypeFieldMetadata((FieldMetadata) element)) {
                 FieldMetadata previous = (FieldMetadata) modifyAction.getPrevious();
                 FieldMetadata current = (FieldMetadata) modifyAction.getCurrent();
+
+                if (MetadataUtils.isAnonymousType(current.getContainingType())) {
+                    continue;
+                }
 
                 String defaultValueRule = current.getData(MetadataRepository.DEFAULT_VALUE_RULE);
                 defaultValueRule = HibernateStorageUtils.convertedDefaultValue(current.getType().getName(),
@@ -482,6 +488,10 @@ public class LiquibaseSchemaAdapter  {
     protected boolean isContainedComplexType(FieldMetadata fieldMetadata) {
         return (fieldMetadata.getContainingType() instanceof ComplexTypeMetadata)
                 && (fieldMetadata.getType() instanceof ContainedComplexTypeMetadata);
+    }
+
+    protected  boolean isContainedTypeFieldMetadata(FieldMetadata fieldMetadata){
+        return fieldMetadata instanceof ContainedTypeFieldMetadata;
     }
 
     protected boolean isBooleanType(String columnDataType) {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
@@ -2335,6 +2335,89 @@ public class StorageAdaptTest extends TestCase {
         storage.commit();
     }
 
+    public void test22_ModifyContainedFieldType() throws Exception {
+        /*
+         * Test                                                                    Test
+         *   |__id (SimpleField) (1-1)                                               |__id (SimpleField) (1-1)
+         *   |__Name (SimpleField) (0-1)                                             |__Name (SimpleField) (0-1)
+         *   |__Feature (ContainedFieldType) (1-1)                                   |__Feature (ContainedFieldType) (0-1)
+         *        |__Colors (ContainedFieldType) (0-1)                                    |__Colors (ContainedFieldType) (0-1)
+         *            |__Color(SimpleField) (1-1)                                               |__Color(SimpleField) (1-1)
+         *        |__Sizes (ContainedFieldType) (1-1)              =======>               |__Sizes (ContainedFieldType) (1-1)
+         *            |__Size(SimpleField) (1-1)                                                |__Size(SimpleField) (1-1)
+         *   |__Stores (ContainedFieldType) (1-1)                                    |__Stores (ContainedFieldType) (0-1)
+         *        |__Store(Foreign Key)(0-many)                                           |__Store(Foreign Key)(0-many)
+         *   |__Nodes (ContainedFieldType) (1-1)                                     |__Nodes (ContainedFieldType) (0-1)
+         *        |__subelement (SimpleField) (1-1)                                       |__subelement (SimpleField) (0-1)
+         */
+        setMDMRootURL();
+
+        DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
+        Storage storage = new HibernateStorage("Test", StorageType.MASTER);
+        storage.init(dataSource);
+        String[] tables = { "TEST" };
+        String[][] columns = { { "", "X_ID", "X_NAME", "X_FEATURES_X_TALEND_ID", "X_STORES_X_TALEND_ID", "X_NODES_X_TALEND_ID", "X_TALEND_TIMESTAMP", "X_TALEND_TASK_ID" } };
+        int[][] isNullable = { { 0, 0, 1, 0, 0, 0, 0, 1 }};
+        MetadataRepository repository1 = new MetadataRepository();
+        repository1.load(StorageAdaptTest.class.getResourceAsStream("schema22_1.xsd"));
+        storage.prepare(repository1, true);
+        try {
+            assertColumnNullAble(dataSource, tables, columns, isNullable);
+        } catch (SQLException e) {
+            assertNull(e);
+        }
+
+        MetadataRepository repository2 = new MetadataRepository();
+        repository2.load(StorageAdaptTest.class.getResourceAsStream("schema22_2.xsd"));
+        try {
+            storage.adapt(repository2, false);
+        } catch (Exception e2) {
+            assertNull(e2);
+        }
+
+        isNullable[0][3] = 1;
+        isNullable[0][4] = 1;
+        isNullable[0][5] = 1;
+        try {
+            assertColumnNullAble(dataSource, tables, columns, isNullable);
+        } catch (SQLException e) {
+            assertNull(e);
+        }
+    }
+
+    public void test22_ModifyContainedFieldType_For_Color_Field() throws Exception {
+        /*
+         * Test                                                                    Test
+         *   |__id (SimpleField) (1-1)                                               |__id (SimpleField) (1-1)
+         *   |__Name (SimpleField) (0-1)                                             |__Name (SimpleField) (0-1)
+         *   |__Feature (ContainedFieldType) (1-1)                                   |__Feature (ContainedFieldType) (1-1)
+         *        |__Colors (ContainedFieldType) (0-1)                                    |__Colors (ContainedFieldType) (0-1)
+         *            |__Color(SimpleField) (1-1)                                               |__Color(SimpleField) (0-1)
+         *        |__Sizes (ContainedFieldType) (1-1)              =======>               |__Sizes (ContainedFieldType) (1-1)
+         *            |__Size(SimpleField) (1-1)                                                |__Size(SimpleField) (0-1)
+         *   |__Stores (ContainedFieldType) (1-1)                                    |__Stores (ContainedFieldType) (1-1)
+         *        |__Store(Foreign Key)(0-many)                                           |__Store(Foreign Key)(0-many)
+         *   |__Nodes (ContainedFieldType) (1-1)                                     |__Nodes (ContainedFieldType) (1-1)
+         *        |__subelement (SimpleField) (1-1)                                       |__subelement (SimpleField) (0-1)
+         */
+        setMDMRootURL();
+
+        DataSourceDefinition dataSource = ServerContext.INSTANCE.get().getDefinition("H2-DS3", STORAGE_NAME);
+        Storage storage = new HibernateStorage("Test", StorageType.MASTER);
+        storage.init(dataSource);
+        MetadataRepository repository1 = new MetadataRepository();
+        repository1.load(StorageAdaptTest.class.getResourceAsStream("schema22_3.xsd"));
+        storage.prepare(repository1, true);
+
+        MetadataRepository repository2 = new MetadataRepository();
+        repository2.load(StorageAdaptTest.class.getResourceAsStream("schema22_4.xsd"));
+        try {
+            storage.adapt(repository2, false);
+        } catch (Exception e2) {
+            assertNull(e2);
+        }
+    }
+
     private void assertColumnLengthChange(DataSourceDefinition dataSource, String tables, String columns, int expectedLength)
             throws SQLException {
         DataSource master = dataSource.getMaster();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
@@ -170,14 +170,9 @@ public class LiquibaseSchemaAdapterTest {
 
         List<AbstractChange> changeList = adapter.analyzeModifyChange(diffResults);
 
-        assertEquals(3, changeList.size());
+        assertEquals(1, changeList.size());
         assertEquals("liquibase.change.core.DropNotNullConstraintChange", changeList.get(0).getClass().getName());
-        assertEquals("liquibase.change.core.DropNotNullConstraintChange", changeList.get(1).getClass().getName());
-        assertEquals("liquibase.change.core.DropNotNullConstraintChange", changeList.get(2).getClass().getName());
-
-        assertEquals("x_bb_x_talend_id", ((DropNotNullConstraintChange) changeList.get(0)).getColumnName());
-        assertEquals("x_ee", ((DropNotNullConstraintChange) changeList.get(1)).getColumnName());
-        assertEquals("x_uu_x_talend_id", ((DropNotNullConstraintChange) changeList.get(2)).getColumnName());
+        assertEquals("x_ee", ((DropNotNullConstraintChange) changeList.get(0)).getColumnName());
     }
 
     @Test

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_1.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_1.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Test">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="1" name="Features">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Colors">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="1" name="Color" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Sizes">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="1" name="Size" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Stores">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Store" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_ForeignKey">Store/Id</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKeyInfo">Store/Address</xsd:appinfo>
+                                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Nodes" type="Node">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Test">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="Store">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Lat" type="xsd:double" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Long" type="xsd:double" />
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Store">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="Node">
+        <xsd:all>
+            <xsd:element name="subelement" type="xsd:string" />
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_2.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_2.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Test">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Features">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Colors">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="1" name="Color" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Sizes">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="1" name="Size" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Stores">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Store" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_ForeignKey">Store/Id</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKeyInfo">Store/Address</xsd:appinfo>
+                                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Nodes" type="Node">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Test">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="Store">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Lat" type="xsd:double" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Long" type="xsd:double" />
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Store">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="Node">
+        <xsd:all>
+            <xsd:element name="subelement" type="xsd:string" />
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_3.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_3.xsd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:element name="Product">
+        <xsd:complexType>
+            <xsd:all maxOccurs="1" minOccurs="1">
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"></xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Name" type="xsd:string"></xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Features">
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="1" name="Sizes">
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="1" name="Size" type="Size"></xsd:element>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Colors">
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="1" name="Color" type="Color"></xsd:element>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Product">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="Size">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Small" />
+            <xsd:enumeration value="Medium" />
+            <xsd:enumeration value="Large" />
+            <xsd:enumeration value="X-Large" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Color">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="White" />
+            <xsd:enumeration value="Light Blue" />
+            <xsd:enumeration value="Light Pink" />
+            <xsd:enumeration value="Lemon" />
+            <xsd:enumeration value="Khaki" />
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_4.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema22_4.xsd
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+  ~ 92150 Suresnes, France
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Test">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Features">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Colors">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="0" name="Color" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Sizes">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="1" minOccurs="0" name="Size" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Stores">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Store" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_ForeignKey">Store/Id</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKeyInfo">Store/Address</xsd:appinfo>
+                                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Nodes" type="Node">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Test">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="Store">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Lat" type="xsd:double" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Long" type="xsd:double" />
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Store">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="Node">
+        <xsd:all>
+            <xsd:element name="subelement" type="xsd:string" />
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>

--- a/org.talend.mdm.core/test/com/amalto/core/metadata/compare/CompareTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/metadata/compare/CompareTest.java
@@ -1561,6 +1561,72 @@ public class CompareTest extends TestCase {
         assertEquals(1, sort.get(ImpactAnalyzer.Impact.LOW).size());
     }
 
+    public void test34_ModifyContainedFieldType_From_11_TO_01() throws Exception {
+        /*
+         * Test                                                                    Test
+         *   |__id (SimpleField) (1-1)                                               |__id (SimpleField) (1-1)
+         *   |__Name (SimpleField) (0-1)                                             |__Name (SimpleField) (0-1)
+         *   |__Feature (ContainedFieldType) (1-1)                                   |__Feature (ContainedFieldType) (0-1)
+         *        |__Colors (ContainedFieldType) (0-1)                                    |__Colors (ContainedFieldType) (0-1)
+         *            |__Color(SimpleField) (1-1)                                               |__Color(SimpleField) (1-1)
+         *        |__Sizes (ContainedFieldType) (1-1)              =======>               |__Sizes (ContainedFieldType) (1-1)
+         *            |__Size(SimpleField) (1-1)                                                |__Size(SimpleField) (1-1)
+         *   |__Stores (ContainedFieldType) (1-1)                                    |__Stores (ContainedFieldType) (0-1)
+         *        |__Store(Foreign Key)(0-many)                                           |__Store(Foreign Key)(0-many)
+         *   |__Nodes (ContainedFieldType) (1-1)                                     |__Nodes (ContainedFieldType) (0-1)
+         *        |__subelement (SimpleField) (1-1)                                       |__subelement (SimpleField) (0-1)
+         */
+        MetadataRepository original = new MetadataRepository();
+        original.load(CompareTest.class.getResourceAsStream("schema34_1.xsd")); //$NON-NLS-1$
+        original = original.copy();
+        MetadataRepository updated2 = new MetadataRepository();
+        updated2.load(CompareTest.class.getResourceAsStream("schema34_2.xsd")); //$NON-NLS-1$
+        Compare.DiffResults diffResults = Compare.compare(original, updated2);
+        assertEquals(3, diffResults.getActions().size());
+        assertEquals(3, diffResults.getModifyChanges().size());
+        assertEquals(0, diffResults.getRemoveChanges().size());
+        assertEquals(0, diffResults.getAddChanges().size());
+
+        ImpactAnalyzer analyzer = new HibernateStorageImpactAnalyzer();
+        Map<ImpactAnalyzer.Impact, List<Change>> sort = analyzer.analyzeImpacts(diffResults);
+        assertEquals(0, sort.get(ImpactAnalyzer.Impact.HIGH).size());
+        assertEquals(0, sort.get(ImpactAnalyzer.Impact.MEDIUM).size());
+        assertEquals(3, sort.get(ImpactAnalyzer.Impact.LOW).size());
+    }
+
+    public void test34_ModifyContainedFieldType_From_01_TO_11() throws Exception {
+        /*
+         * Test                                                                    Test
+         *   |__id (SimpleField) (1-1)                                               |__id (SimpleField) (1-1)
+         *   |__Name (SimpleField) (0-1)                                             |__Name (SimpleField) (0-1)
+         *   |__Feature (ContainedFieldType) (0-1)                                   |__Feature (ContainedFieldType) (1-1)
+         *        |__Colors (ContainedFieldType) (0-1)                                    |__Colors (ContainedFieldType) (0-1)
+         *            |__Color(SimpleField) (1-1)                                               |__Color(SimpleField) (1-1)
+         *        |__Sizes (ContainedFieldType) (1-1)              =======>               |__Sizes (ContainedFieldType) (1-1)
+         *             |__Size(SimpleField) (1-1)                                               |__Size(SimpleField) (1-1)
+         *   |__Stores (ContainedFieldType) (0-1)                                    |__Stores (ContainedFieldType) (1-1)
+         *        |__Store(Foreign Key)(0-many)                                           |__Store(Foreign Key)(0-many)
+         *   |__Nodes (ContainedFieldType) (0-1)                                     |__Nodes (ContainedFieldType) (1-1)
+         *        |__subelement (SimpleField) (1-1)                                       |__subelement (SimpleField) (0-1)
+         */
+        MetadataRepository original = new MetadataRepository();
+        original.load(CompareTest.class.getResourceAsStream("schema34_2.xsd")); //$NON-NLS-1$
+        original = original.copy();
+        MetadataRepository updated2 = new MetadataRepository();
+        updated2.load(CompareTest.class.getResourceAsStream("schema34_1.xsd")); //$NON-NLS-1$
+        Compare.DiffResults diffResults = Compare.compare(original, updated2);
+        assertEquals(3, diffResults.getActions().size());
+        assertEquals(3, diffResults.getModifyChanges().size());
+        assertEquals(0, diffResults.getRemoveChanges().size());
+        assertEquals(0, diffResults.getAddChanges().size());
+
+        ImpactAnalyzer analyzer = new HibernateStorageImpactAnalyzer();
+        Map<ImpactAnalyzer.Impact, List<Change>> sort = analyzer.analyzeImpacts(diffResults);
+        assertEquals(3, sort.get(ImpactAnalyzer.Impact.HIGH).size());
+        assertEquals(0, sort.get(ImpactAnalyzer.Impact.MEDIUM).size());
+        assertEquals(0, sort.get(ImpactAnalyzer.Impact.LOW).size());
+    }
+
     @SuppressWarnings("rawtypes")
     private ClassRepository buildRepository() {
         ClassRepository repository = new ClassRepository();

--- a/org.talend.mdm.core/test/com/amalto/core/metadata/compare/schema34_1.xsd
+++ b/org.talend.mdm.core/test/com/amalto/core/metadata/compare/schema34_1.xsd
@@ -1,0 +1,83 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Test">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Features">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Colors">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="unbounded" name="Color" type="xsd:string"/>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Sizes">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="unbounded" name="Size" type="xsd:string"/>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Stores">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Store" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_ForeignKey">Store/Id</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKeyInfo">Store/Address</xsd:appinfo>
+                                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Nodes" type="Node">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Test">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="Store">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Lat" type="xsd:double"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Long" type="xsd:double"/>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Store">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="Node">
+        <xsd:all>
+            <xsd:element name="subelement" type="xsd:string"/>
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>

--- a/org.talend.mdm.core/test/com/amalto/core/metadata/compare/schema34_2.xsd
+++ b/org.talend.mdm.core/test/com/amalto/core/metadata/compare/schema34_2.xsd
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+  ~ 92150 Suresnes, France
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Test">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Features">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Colors">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="unbounded" name="Color" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Sizes">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="unbounded" name="Size" type="xsd:string" />
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Stores">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Store" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_ForeignKey">Store/Id</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKeyInfo">Store/Address</xsd:appinfo>
+                                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Nodes" type="Node">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_AutoExpand">false</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Test">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="Store">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Lat" type="xsd:double" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="Long" type="xsd:double" />
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Store">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="Node">
+        <xsd:all>
+            <xsd:element name="subelement" type="xsd:string" />
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-12877

**What is the current behavior?** (You should also link to an open issue here)
Modify **ContainedTypeFieldMetadata** type field, which like **Features** field or **Stores** field in Product data model, have 2 issues:

1. Failed to move this field from 1-1 to 0-1:
    Reason: sometimes liquibase to execute changeLog, but this field is not existed.
2. Failed to move this field from 0-1 to 1-1:
    Reason: failed to fetch count existed in database of this field, because it is not existed.
3. Failed to move Product/Feature/Colors/Color or Product/Feature/Size/Size from 1-1 to 0-1.
     Reason: liquibase get the wrong table name and column name, so it's failed when liquibase execute.

**Why Not Existed:**
Because it is a **ContainedTypeFieldMetadata** type, it depends on the DM and database, for example Product data model:
In Product Table, have no column for **Features** , but have two table: **product_x_features_colors_color** and **product_x_features_sizes_size**, these two table's key is product table's key: like below:
```

mysql> select * from product;
+------+-----------+--------+---------------+----------------+---------+---------------+---------------+--------------------+------------------+
| x_id | x_picture | x_name | x_description | x_availability | x_price | x_family_x_id | x_onlinestore | x_talend_timestamp | x_talend_task_id |
+------+-----------+--------+---------------+----------------+---------+---------------+---------------+--------------------+------------------+
| 1    | NULL      | name   | description   | NULL           |    1.20 | NULL          | NULL          |      1544434182360 | NULL             |
| 20   | NULL      | name   | description   | NULL           |    1.20 | NULL          | NULL          |      1544434294410 | NULL             |
+------+-----------+--------+---------------+----------------+---------+---------------+---------------+--------------------+------------------+
2 rows in set (0.00 sec)

mysql> select * from product_x_features_colors_color;
+------+------------+-----+
| x_id | value      | pos |
+------+------------+-----+
| 1    | Light Blue |   0 |
| 20   | Light Blue |   0 |
+------+------------+-----+
2 rows in set (0.00 sec)

mysql> select * from product_x_features_sizes_size;
+------+-------+-----+
| x_id | value | pos |
+------+-------+-----+
| 1    | Small |   0 |
| 20   | Small |   0 |
+------+-------+-----+
2 rows in set (0.00 sec)
```
However, for ORACLE database, it existed the column '_X_FEATURES_X_TALEND'_.
Have other case, the column is existed in main table.


**What is the new behavior?**
For above two issues, the solution are below:
No.1: 
    Can not add the Change into the ChangeSet(which used Liquibase), use Hibernate tools to update  if the column existed (oracle contains the columns 'X_FEATURES_X_TALEND_ID' for feature)
No.2:
   Avoid to fetch the number existed in database, because when moved 0-1 to 1-1, it must high, whatever existed data.
No.3:
   Modified to use hibernate tool to updated the not-null properties

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
