### PR TITLE
TMDM-6252 When creating a new record, use the submitted id even if it is auto generated in model

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/MyProduct.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/MyProduct.xsd
@@ -1,0 +1,91 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+	<xsd:simpleType name="AUTO_INCREMENT">
+		<xsd:restriction base="xsd:string" />
+	</xsd:simpleType>
+	<xsd:simpleType name="UUID">
+		<xsd:restriction base="xsd:string" />
+	</xsd:simpleType>
+	<xsd:element name="PeopleGroupSize">
+		<xsd:annotation>
+			<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all>
+				<xsd:element name="Id" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element maxOccurs="1" minOccurs="1" name="Name"
+					type="xsd:string">
+					<xsd:annotation>
+
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element maxOccurs="1" minOccurs="1"
+					name="Description" type="xsd:string">
+					<xsd:annotation>
+
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:all>
+		</xsd:complexType>
+		<xsd:unique name="PeopleGroupSize">
+			<xsd:selector xpath="." />
+			<xsd:field xpath="Id" />
+		</xsd:unique>
+	</xsd:element>
+	<xsd:element name="AutoIDEntity">
+		<xsd:annotation>
+			<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all>
+				<xsd:element maxOccurs="1" minOccurs="1" name="Id"
+					type="AUTO_INCREMENT">
+					<xsd:annotation>
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element maxOccurs="1" minOccurs="1" name="Name"
+					type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:all>
+		</xsd:complexType>
+		<xsd:unique name="AutoIDEntity">
+			<xsd:selector xpath="." />
+			<xsd:field xpath="Id" />
+		</xsd:unique>
+	</xsd:element>
+	<xsd:element name="UUIDEntity">
+		<xsd:annotation>
+			<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+		</xsd:annotation>
+		<xsd:complexType>
+			<xsd:all>
+				<xsd:element maxOccurs="1" minOccurs="1" name="Id"
+					type="UUID">
+					<xsd:annotation>
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element maxOccurs="1" minOccurs="1" name="Name"
+					type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+			</xsd:all>
+		</xsd:complexType>
+		<xsd:unique name="UUIDEntity">
+			<xsd:selector xpath="." />
+			<xsd:field xpath="Id" />
+		</xsd:unique>
+	</xsd:element>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/MyProduct_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/MyProduct_original.xml
@@ -1,0 +1,34 @@
+<!-- ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com ~ ~ This source 
+	code is available under agreement available at ~ %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt 
+	~ ~ You should have received a copy of the agreement ~ along with this program; 
+	if not, write to Talend SA ~ 9 rue Pages 92150 Suresnes, France -->
+<MyProduct xmlns:tmdm="http://www.talend.com/mdm">
+	<PeopleGroupSize>
+		<Id>id1</Id>
+		<Name>Product Name1</Name>
+		<Description>desc1</Description>
+	</PeopleGroupSize>
+	<PeopleGroupSize>
+		<Name>Product Name2</Name>
+		<Description>desc2</Description>
+	</PeopleGroupSize>
+	<AutoIDEntity>
+		<Id>1</Id>
+		<Name>name1</Name>
+	</AutoIDEntity>
+	<AutoIDEntity>
+		<Id></Id>
+		<Name>name2</Name>
+	</AutoIDEntity>
+	<AutoIDEntity>
+		<Name>name3</Name>
+	</AutoIDEntity>
+	<UUIDEntity>
+		<Id>1</Id>
+		<Name>name1</Name>
+	</UUIDEntity>
+	<UUIDEntity>
+		<Id></Id>
+		<Name>name2</Name>
+	</UUIDEntity>
+</MyProduct>

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/CreateWithProvidedIdActions.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/CreateWithProvidedIdActions.java
@@ -14,6 +14,7 @@ import java.util.Date;
 
 import org.apache.commons.lang.StringUtils;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
+import org.talend.mdm.commmon.util.core.EUUIDCustomType;
 
 import com.amalto.core.history.MutableDocument;
 import com.amalto.core.history.accessor.Accessor;
@@ -31,11 +32,26 @@ public class CreateWithProvidedIdActions extends CreateActions {
     protected void handleField(FieldMetadata field, boolean doCreate, String currentPath, UserAction userAction) {
         if (field.isKey()) {
             Accessor accessor = document.createAccessor(currentPath);
-            if (accessor.exist()) {
+            if (accessor.exist() && isValidField(field, accessor)) {
                 actions.add(new FieldUpdateAction(date, source, userName, currentPath, StringUtils.EMPTY, accessor.get(), field, userAction));
                 return;
             }
         }
         super.handleField(field, doCreate, currentPath, userAction);
+    }
+
+    private boolean isValidField(FieldMetadata keyField, Accessor accessor) {
+        if (isServerProvidedValue(keyField.getType().getName())) {
+            String value = accessor.get();
+            if (StringUtils.isBlank(value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isServerProvidedValue(String keyFieldTypeName) {
+        return EUUIDCustomType.UUID.getName().equalsIgnoreCase(keyFieldTypeName)
+                || EUUIDCustomType.AUTO_INCREMENT.getName().equalsIgnoreCase(keyFieldTypeName);
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/GenerateActions.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/GenerateActions.java
@@ -182,7 +182,7 @@ class GenerateActions implements DocumentSaver {
                 if (action instanceof FieldUpdateAction) {
                     FieldUpdateAction fieldUpdateAction = (FieldUpdateAction) action;
                     FieldMetadata field = fieldUpdateAction.getField();
-                    if (field.isKey()) {
+                    if (field.isKey() && keyActions.containsKey(field)) {
                         mergedActions.add(keyActions.get(field));
                     } else {
                         mergedActions.add(action);

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/ID.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/ID.java
@@ -12,6 +12,7 @@
 package com.amalto.core.save.context;
 
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -50,12 +51,14 @@ class ID implements DocumentSaver {
         String dataModelName = context.getDataModelName();
         MutableDocument userDocument = context.getUserDocument();
         String typeName = type.getName();
+        boolean isAutomaticId = false;
         for (FieldMetadata keyField : keyFields) {
             String keyFieldTypeName = keyField.getType().getName();
             Accessor userAccessor = userDocument.createAccessor(keyField.getName());
             // Get ids.
             String currentIdValue;
             if (isServerProvidedValue(keyFieldTypeName)) {
+                isAutomaticId = true;
                 if (userAccessor.exist()) { // Ignore cases where id is not there (will usually mean this is a creation).
                     String value = userAccessor.get();
                     if (!value.trim().isEmpty()) {
@@ -80,13 +83,18 @@ class ID implements DocumentSaver {
             }
         }
         // now has an id, so load database document
-        String[] xmlDocumentId = ids.toArray(new String[ids.size()]);
-        if (xmlDocumentId.length > 0 && database.exist(dataCluster, dataModelName, typeName, xmlDocumentId)) {
+        String[] xmlDocumentIds = ids.toArray(new String[ids.size()]);
+        EnumSet<UserAction> createTypeSet = EnumSet.of(UserAction.AUTO, UserAction.AUTO_STRICT, UserAction.CREATE, UserAction.CREATE_STRICT, UserAction.REPLACE);
+        boolean isExistRecord = database.exist(dataCluster, dataModelName, typeName, xmlDocumentIds);
+        if (xmlDocumentIds.length > 0 && isExistRecord) {
             if (context.getUserAction() == UserAction.AUTO || context.getUserAction() == UserAction.AUTO_STRICT) {
                 context.setUserAction(UserAction.UPDATE);
             }
-            context.setId(xmlDocumentId);
-            context.setDatabaseDocument(database.get(dataCluster, dataModelName, typeName, xmlDocumentId));
+            context.setId(xmlDocumentIds);
+            context.setDatabaseDocument(database.get(dataCluster, dataModelName, typeName, xmlDocumentIds));
+        } else if (isAutomaticId && xmlDocumentIds.length > 0 && keyFields.size() == xmlDocumentIds.length && !isExistRecord && createTypeSet.contains(context.getUserAction())) {
+            context.setUserAction(UserAction.CREATE_STRICT);
+            context.setDatabaseDocument(new DOMDocument(SaverContextFactory.DOCUMENT_BUILDER.newDocument(), type, dataCluster, context.getDataModelName()));
         } else {
             // Throw an exception if trying to update a document that does not exist.
             switch (context.getUserAction()) {
@@ -99,7 +107,7 @@ class ID implements DocumentSaver {
                 case UPDATE:
                 case PARTIAL_UPDATE:
                     StringBuilder builder = new StringBuilder();
-                    for (String idElement : xmlDocumentId) {
+                    for (String idElement : xmlDocumentIds) {
                         builder.append('[').append(idElement).append(']');
                     }
                     throw new IllegalStateException("Can not update document '" + type.getName() + "' with id '" + builder.toString() + "' because it does not exist.");


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

Using auto generated PK when create record instead of submitted Id.

**What is the new behavior?**

Prefer to use submitted Id when create a new record.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
