### PR TITLE
TMDM-11845 [REST API] Partial update should be able to add items to a list of multi-occuring values

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -706,8 +706,7 @@ public class DocumentSaveTest extends TestCase {
                 ("<Agency>\n" + "    <Id>5258f292-5670-473b-bc01-8b63434682f3</Id>\n" + "    <Information>\n"
                         + "        <MoreInfo>http://www.mynewsite.fr</MoreInfo>\n" + "    </Information>\n" + "</Agency>\n")
                         .getBytes("UTF-8"));
-        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
-                partialUpdateContent, true, true, "/Agency/Information/MoreInfo", "", -1, false);
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source", partialUpdateContent, true, true, "/Agency/Information/MoreInfo", "", -1, false);
         DocumentSaver saver = context.createSaver();
         saver.save(session, context);
         MockCommitter committer = new MockCommitter();
@@ -729,9 +728,57 @@ public class DocumentSaveTest extends TestCase {
         InputStream partialUpdateContent = new ByteArrayInputStream(
                 ("<Agency>\n" + "    <Id>5258f292-5670-473b-bc01-8b63434682f3</Id>\n" + "    <Information>\n"
                         + "        <MoreInfo>http://www.mynewsite.fr</MoreInfo>\n" + "    </Information>\n" + "</Agency>\n")
+                .getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source", partialUpdateContent, true, true, "/", "/", -1, true);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        assertEquals("http://www.mynewsite.fr", evaluate(committedElement, "/Agency/Information/MoreInfo[1]"));
+        assertEquals("", evaluate(committedElement, "/Agency/Information/MoreInfo[2]"));
+    }
+
+    public void testPartialUpdateWithOverwriteEqualsFalse() throws Exception {
+        final MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("DStar", repository);
+
+        SaverSource source = new TestSaverSource(repository, true, "test1_1_original.xml", "metadata1.xsd");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream partialUpdateContent = new ByteArrayInputStream(
+                ("<Agency>\n" + "    <Id>5258f292-5670-473b-bc01-8b63434682f4</Id>\n" + "    <Information>\n"
+                        + "        <MoreInfo>http://www.mynewsite.fr</MoreInfo>\n" + "    </Information>\n" + "</Agency>\n")
+                .getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source", partialUpdateContent, true, true, "/", "/", -1, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        assertEquals("www.a.com", evaluate(committedElement, "/Agency/Information/MoreInfo[1]"));
+        assertEquals("www.b.com", evaluate(committedElement, "/Agency/Information/MoreInfo[2]"));
+        assertEquals("http://www.mynewsite.fr", evaluate(committedElement, "/Agency/Information/MoreInfo[3]"));
+    }
+
+    public void testPartialUpdateWithOverwriteEqualsTrue() throws Exception {
+        final MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("DStar", repository);
+
+        SaverSource source = new TestSaverSource(repository, true, "test1_1_original.xml", "metadata1.xsd");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream partialUpdateContent = new ByteArrayInputStream(
+                ("<Agency>\n" + "    <Id>5258f292-5670-473b-bc01-8b63434682f4</Id>\n" + "    <Information>\n"
+                        + "        <MoreInfo>http://www.mynewsite.fr</MoreInfo>\n" + "    </Information>\n" + "</Agency>\n")
                         .getBytes("UTF-8"));
-        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
-                partialUpdateContent, true, true, "/", "/", -1, true);
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source", partialUpdateContent, true, true, "/", "/", -1, true);
         DocumentSaver saver = context.createSaver();
         saver.save(session, context);
         MockCommitter committer = new MockCommitter();

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test1_1_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test1_1_original.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~ %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement
+  ~ along with this program; if not, write to Talend SA
+  ~ 9 rue Pages 92150 Suresnes, France
+  -->
+
+<ii>
+    <c>Agency</c>
+    <n>Agency</n>
+    <dmn>Product</dmn>
+    <i>5258f292-5670-473b-bc01-8b63434682f4</i>
+    <t>1328544306381</t>
+    <taskId/>
+    <p>
+        <Agency>
+            <Id>5258f292-5670-473b-bc01-8b63434682f4</Id>
+            <Name>Portland</Name>
+            <City>Portland</City>
+            <State>ME</State>
+            <Zip>04102</Zip>
+            <Region>EAST</Region>
+            <Information>
+            	<MoreInfo>www.a.com</MoreInfo>
+            	<MoreInfo>www.b.com</MoreInfo>
+            </Information>
+        </Agency>
+    </p>
+</ii>

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/GenerateActions.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/GenerateActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -64,9 +64,9 @@ class GenerateActions implements DocumentSaver {
         List<Action> actions;
         MetadataRepository metadataRepository = saverSource.getMetadataRepository(context.getDataModelName());
         // Generate field update actions for UUID and AutoIncrement elements.
-        UpdateActionCreator updateActions = new UpdateActionCreator(databaseDocument, userDocument, date, source, userName,
-                context.generateTouchActions(), metadataRepository, context.getDataCluster(), context.getDataModelName(),
-                saverSource, context.getUserAction());
+        UpdateActionCreator updateActions = new UpdateActionCreator(databaseDocument, userDocument, date,
+                context.preserveOldCollectionValues(), source, userName, context.generateTouchActions(), metadataRepository,
+                context.getDataCluster(), context.getDataModelName(), saverSource, context.getUserAction());
         UserAction userAction = context.getUserAction();
         switch (userAction) {
         case CREATE_STRICT:


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

Only be able to overwrite items to a list of multi-occuring values for the current API, our user no way to add new items to the list, while don't lose existing value.
https://jira.talendforge.org/browse/TMDM-11845

**What is the new behavior?**

Add a request parameter to decide if need to add or overwrite.
overwrite: true(default) => there is the default action for backwards compatibility.
overwrite: false => may add new items to the a list of multi-occurring values.
For back-end code, our system had prepared the snippet of code to support the action, so only add new request parameter, it's ok.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
