### PR TITLE
TMDM-11845 [REST API] Partial update should be able to add items to a list of multi-occuring values

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -739,6 +739,16 @@ public class DocumentSaveTest extends TestCase {
         Element committedElement = committer.getCommittedElement();
         assertEquals("http://www.mynewsite.fr", evaluate(committedElement, "/Agency/Information/MoreInfo[1]"));
         assertEquals("", evaluate(committedElement, "/Agency/Information/MoreInfo[2]"));
+
+        MutableDocument updateReportDocument = context.getUpdateReportDocument();
+        assertNotNull(updateReportDocument);
+        Document doc = updateReportDocument.asDOM();
+        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
+        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
+        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
+        assertEquals("Information/MoreInfo[1]", path);
+        assertEquals("", oldValue);
+        assertEquals("http://www.mynewsite.fr", newValue);
     }
 
     public void testPartialUpdateWithOverwriteEqualsFalse() throws Exception {
@@ -751,7 +761,9 @@ public class DocumentSaveTest extends TestCase {
         SaverSession session = SaverSession.newSession(source);
         InputStream partialUpdateContent = new ByteArrayInputStream(
                 ("<Agency>\n" + "    <Id>5258f292-5670-473b-bc01-8b63434682f4</Id>\n" + "    <Information>\n"
-                        + "        <MoreInfo>http://www.mynewsite.fr</MoreInfo>\n" + "    </Information>\n" + "</Agency>\n")
+                        + "        <MoreInfo>http://www.mynewsite.fr</MoreInfo>\n"
+                        + "        <MoreInfo>http://www.mynewsite.com</MoreInfo>\n"
+                        + "    </Information>\n" + "</Agency>\n")
                 .getBytes("UTF-8"));
         DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source", partialUpdateContent, true, true, "/", "/", -1, false);
         DocumentSaver saver = context.createSaver();
@@ -763,7 +775,25 @@ public class DocumentSaveTest extends TestCase {
         Element committedElement = committer.getCommittedElement();
         assertEquals("www.a.com", evaluate(committedElement, "/Agency/Information/MoreInfo[1]"));
         assertEquals("www.b.com", evaluate(committedElement, "/Agency/Information/MoreInfo[2]"));
-        assertEquals("http://www.mynewsite.fr", evaluate(committedElement, "/Agency/Information/MoreInfo[3]"));
+        assertEquals("http://www.mynewsite.com", evaluate(committedElement, "/Agency/Information/MoreInfo[3]"));
+        assertEquals("http://www.mynewsite.fr", evaluate(committedElement, "/Agency/Information/MoreInfo[4]"));
+
+        MutableDocument updateReportDocument = context.getUpdateReportDocument();
+        assertNotNull(updateReportDocument);
+        Document doc = updateReportDocument.asDOM();
+        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
+        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
+        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
+        assertEquals("Information/MoreInfo[3]", path);
+        assertEquals("", oldValue);
+        assertEquals("http://www.mynewsite.com", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
+        assertEquals("Information/MoreInfo[4]", path);
+        assertEquals("", oldValue);
+        assertEquals("http://www.mynewsite.fr", newValue);
     }
 
     public void testPartialUpdateWithOverwriteEqualsTrue() throws Exception {

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -322,6 +322,11 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
             if (newAccessor.exist()) { // new accessor exist
                 if (newAccessor.get() != null && !newAccessor.get().isEmpty()) { // Empty accessor means no op to ensure legacy behavior
                     generateNoOp(lastMatchPath);
+                    if (comparedField.isMany() && preserveCollectionOldValues) {
+                        int insertIndex = Integer.parseInt(StringUtils.substringBetween(path, "[", "]")) //$NON-NLS-1$ //$NON-NLS-2$ 
+                                + originalDocument.createAccessor(StringUtils.substringBeforeLast(path, "[")).size();//$NON-NLS-1$
+                        path = path.replaceAll("\\[\\d+\\]", "[" + insertIndex + "]");//$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                    }
                     actions.add(new FieldUpdateAction(date, source, userName, path, StringUtils.EMPTY, newAccessor.get(), comparedField, userAction));
                     generateNoOp(path);
                 } else if (EUUIDCustomType.AUTO_INCREMENT.getName().equalsIgnoreCase(comparedField.getType().getName())


### PR DESCRIPTION
TMDM-11845 [REST API] Partial update should be able to add items to a list of multi-occurring values**What is the current behavior?** (You should also link to an open issue here)
When user want to preserve old collection value for multi-occurring, and append new items to this collection, both old data and new data have duplicate index in Journal. 


**What is the new behavior?**
If overwrite equals false, that denote user want to add new item to a list of multi-occurring. first of all, getting the old collection size as start of Index, new item will be condition  with the recalculate index.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
