### PR TITLE
TMDM-13063 Wrong order computation when importing records to server

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ReferenceEntityBridge.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ReferenceEntityBridge.java
@@ -26,10 +26,10 @@ import com.amalto.core.storage.record.StorageConstants;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.lucene.document.Document;
+import org.hibernate.ObjectNotFoundException;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 
-import com.amalto.core.storage.Storage;
 import com.amalto.core.storage.hibernate.MultiLingualIndexedBridge.MultilingualIndexHandler;
 
 /**
@@ -145,8 +145,16 @@ public class ReferenceEntityBridge implements TwoWayFieldBridge {
                 if (value == null) {
                     break;
                 }
-                IndexHandler handler = getHandler(field, value);
-                handler.handle(name, value, field, document, luceneOptions);
+                try {
+                    if (value != null && value.toString() != null) {
+                        IndexHandler handler = getHandler(field, value);
+                        handler.handle(name, value, field, document, luceneOptions);
+                    }
+                } catch (ObjectNotFoundException e) {
+                    LOGGER.debug("Filed '" + field.getName() + "' is not persistent");
+                    ((Wrapper) dataObject).set(field.getName(), null);
+                    break;
+                }
             }
         }
     }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ReferenceEntityBridge.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ReferenceEntityBridge.java
@@ -145,13 +145,25 @@ public class ReferenceEntityBridge implements TwoWayFieldBridge {
                 if (value == null) {
                     break;
                 }
+
+               /* For the entity as bellow:
+                * A
+                * |__Id (SimpleField)
+                * |__B (ContainedField)
+                *    |__C (ComplexField)
+                *       |__D (Reference)
+                * Use '<A><Id>1</Id><B><C><D>[1]</D></C></B></A>' to save, but D(1) doesn't exist.
+                * Generente lucence index for D(1) will fail, so need to set it to null for now.
+                */
                 try {
                     if (value != null && value.toString() != null) {
                         IndexHandler handler = getHandler(field, value);
                         handler.handle(name, value, field, document, luceneOptions);
                     }
                 } catch (ObjectNotFoundException e) {
-                    LOGGER.debug("Filed '" + field.getName() + "' is not persistent");
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Filed '" + field.getName() + "' doesn't exist yet.", e);
+                    }
                     ((Wrapper) dataObject).set(field.getName(), null);
                     break;
                 }


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13063

**What is the current behavior?** (You should also link to an open issue here)
have one error when creating lucence index for one reference field which is not persistent on the database.


**What is the new behavior?**
if the reference field data can't persistent on database, can't generate lucence index.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
