### PR TITLE
TMDM-12908 Talend MDM timeout cannot be increased with IAM enabled

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -122,6 +122,8 @@ public class Util extends XmlUtil {
 
     public static final String ROOT_LOCATION_URL_KEY = "mdm.root.url";
 
+    public static final String WEB_SESSION_TIMEOUT_IN_SECONDS = "mdm.web.session.timeout";
+
     private static final String USER_PROPERTY_PREFIX = "${user_context";
 
     private static final ScriptEngineManager SCRIPT_FACTORY = new ScriptEngineManager();

--- a/org.talend.mdm.webapp.general/pom.xml
+++ b/org.talend.mdm.webapp.general/pom.xml
@@ -30,6 +30,17 @@
         <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-dev</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>

--- a/org.talend.mdm.webapp.general/pom.xml
+++ b/org.talend.mdm.webapp.general/pom.xml
@@ -38,11 +38,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>

--- a/org.talend.mdm.webapp.general/pom.xml
+++ b/org.talend.mdm.webapp.general/pom.xml
@@ -28,14 +28,12 @@
             <artifactId>powermock-api-mockito</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-dev</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.servlet</groupId>
-                    <artifactId>javax.servlet-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>

--- a/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
+++ b/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
+++ b/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
@@ -75,10 +75,10 @@ public class MDMContextListener implements ServletContextListener {
     private int getSessionTimeoutInSeconds(ServletContext servletContext) {
         int webSessionTimeoutInSeconds;
         try {
-            webSessionTimeoutInSeconds = servletContext.getSessionTimeout()*60;
+            webSessionTimeoutInSeconds = servletContext.getSessionTimeout() * 60;
         } catch (Exception e) {
             LOGGER.warn("Failed to retrieve session timeout, using default value of 30 mins.", e); //$NON-NLS-1$
-            webSessionTimeoutInSeconds = 30*60;
+            webSessionTimeoutInSeconds = 30 * 60;
         }
         return webSessionTimeoutInSeconds;
     }

--- a/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
+++ b/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
@@ -12,6 +12,7 @@ package org.talend.mdm.webapp.general.server.servlet;
 import static com.amalto.core.util.Util.ROOT_LOCATION_KEY;
 import static com.amalto.core.util.Util.ROOT_LOCATION_PARAM;
 import static com.amalto.core.util.Util.ROOT_LOCATION_URL_KEY;
+import static com.amalto.core.util.Util.WEB_SESSION_TIMEOUT_IN_SECONDS;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -22,14 +23,21 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import org.apache.log4j.Logger;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.util.ServletContextPropertyUtils;
 
 public class MDMContextListener implements ServletContextListener {
 
+    private static final Logger LOGGER = Logger.getLogger(MDMContextListener.class);
+
     @Override
     public void contextInitialized(ServletContextEvent event) {
         ServletContext servletContext = event.getServletContext();
+
+        int webSessionTimeoutInSeconds = getSessionTimeoutInSeconds(servletContext);
+        System.setProperty(WEB_SESSION_TIMEOUT_IN_SECONDS, webSessionTimeoutInSeconds + ""); //$NON-NLS-1$
+
         String location = servletContext.getInitParameter(ROOT_LOCATION_PARAM);
         String resolvedLocation = ServletContextPropertyUtils.resolvePlaceholders(location, servletContext);
         servletContext.log("Initializing MDM root folder from [" + resolvedLocation + "]"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -64,4 +72,14 @@ public class MDMContextListener implements ServletContextListener {
         System.getProperties().remove(ROOT_LOCATION_URL_KEY);
     }
 
+    private int getSessionTimeoutInSeconds(ServletContext servletContext) {
+        int webSessionTimeoutInSeconds;
+        try {
+            webSessionTimeoutInSeconds = servletContext.getSessionTimeout()*60;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to retrieve session timeout, using default value of 30 mins.", e); //$NON-NLS-1$
+            webSessionTimeoutInSeconds = 30*60;
+        }
+        return webSessionTimeoutInSeconds;
+    }
 }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-12908
**What is the current behavior?** 

With IAM enabled, customer needs a longer session timeout for MDM, such as 8 hours, but MDM session cannot exceed 30 minutes whatever the value is set in the MDM web.xml such below

```
mdm\apache-tomcat\webapps\talendmdm\WEB-INF\web.xml

<session-config>
   <session-timeout>60</session-timeout>
</session-config>
```
**What is the new behavior?**

With IAM enabled, MDM session timeout will use the custom value defined in web.xml

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
