### PR TITLE
TMDM-13111 [MQL] "not" operator doesn't work as expected with "or/and"

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -6044,4 +6044,80 @@ public class StorageQueryTest extends StorageTestCase {
         }
     }
 
+    public void testNotConditionWithMultiSubCondition() throws Exception {
+        //Case 1 with query condition : NOT (A AND B) = NOT A OR NOT B
+        UserQueryBuilder qb = UserQueryBuilder.from(product);
+        qb.where(not(and(eq(product.getField("Name"), "Product name"), eq(product.getField("Name"), "Renault car"))));
+        StorageResults results = storage.fetch(qb.getSelect());
+        assertEquals(3, results.getCount());
+
+        //Case 2 with query condition : NOT (A OR B) = NOT A AND NOT B
+        qb = UserQueryBuilder.from(product);
+        qb.where(not(or(eq(product.getField("Name"), "Product name"), eq(product.getField("Name"), "Renault car"))));
+        results = storage.fetch(qb.getSelect());
+        assertEquals(1, results.getCount());
+        results.forEach((DataRecord record) -> assertEquals(record.get(product.getField("Id")), "3"));
+
+        //Case 3 with query condition : NOT ((A OR B) AND C) = NOT A AND NOT B OR NOT C
+        qb = UserQueryBuilder.from(product);
+        qb.where(not(and(or(eq(product.getField("Name"), "Product name"), eq(product.getField("Name"), "Renault car")),
+                eq(product.getField("Id"), "1"))));
+        results = storage.fetch(qb.getSelect());
+        assertEquals(2, results.getCount());
+        int[] idx = { 1 };
+        results.forEach((DataRecord record) -> {
+            if (idx[0]++ == 1) {
+                assertEquals(record.get(product.getField("Id")), "2");
+                assertEquals(record.get(product.getField("Name")), "Renault car");
+            } else {
+                assertEquals(record.get(product.getField("Id")), "3");
+                assertEquals(record.get(product.getField("Name")), "Product evan");
+            }
+        });
+
+        //Case 4 with query condition : NOT ((A AND B) OR C) = (NOT A OR NOT B) AND NOT C
+        qb = UserQueryBuilder.from(product);
+        qb.where(not(and(or(eq(product.getField("Name"), "Product name"), eq(product.getField("Name"), "Renault car")),
+                eq(product.getField("Id"), "2"))));
+        results = storage.fetch(qb.getSelect());
+        assertEquals(2, results.getCount());
+        idx[0] = 1;
+        results.forEach((DataRecord record) -> {
+            if (idx[0]++ == 1) {
+                assertEquals(record.get(product.getField("Id")), "1");
+                assertEquals(record.get(product.getField("Name")), "Product name");
+            } else {
+                assertEquals(record.get(product.getField("Id")), "3");
+                assertEquals(record.get(product.getField("Name")), "Product evan");
+            }
+        });
+
+        //Case 5 with query condition : NOT ((A OR B) AND (C OR D)) = (NOT A AND NOT B) OR (NOT C AND NOT D)
+        qb = UserQueryBuilder.from(product);
+        qb.where(not(and(or(eq(product.getField("Name"), "Product name"), eq(product.getField("Id"), "1")),
+                or(eq(product.getField("Features/Sizes/Size"), "Small"), eq(product.getField("Price"), "10")))));
+        results = storage.fetch(qb.getSelect());
+        assertEquals(2, results.getCount());
+        idx[0] = 1;
+        results.forEach((DataRecord record) -> {
+            if (idx[0]++ == 1) {
+                assertEquals(record.get(product.getField("Id")), "2");
+                assertEquals(record.get(product.getField("Name")), "Renault car");
+            } else {
+                assertEquals(record.get(product.getField("Id")), "3");
+                assertEquals(record.get(product.getField("Name")), "Product evan");
+            }
+        });
+
+        //Case 6 with query condition : NOT ((A AND B) AND (C OR D)) = NOT A OR NOT B OR (NOT C AND NOT D)
+        qb = UserQueryBuilder.from(product);
+        qb.where(not(or(or(eq(product.getField("Name"), "Product name"), eq(product.getField("Id"), "1")),
+                and(eq(product.getField("Name"), "Product evan"), eq(product.getField("Price"), "11")))));
+        results = storage.fetch(qb.getSelect());
+        assertEquals(1, results.getCount());
+        results.forEach((DataRecord record) -> {
+                assertEquals(record.get(product.getField("Id")), "2");
+                assertEquals(record.get(product.getField("Name")), "Renault car");
+        });
+    }
 }

--- a/org.talend.mdm.query/src/com/amalto/core/query/user/UnaryLogicOperator.java
+++ b/org.talend.mdm.query/src/com/amalto/core/query/user/UnaryLogicOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -69,7 +69,15 @@ public class UnaryLogicOperator implements Condition {
 
                 @Override
                 public Condition visit(BinaryLogicOperator condition) {
-                    return new BinaryLogicOperator(condition.getLeft().accept(this), condition.getPredicate(), condition.getRight().accept(this));
+                    Predicate predicate = condition.getPredicate();
+                    //not(conditionA OR conditionB) = (not conditionA) AND (not conditionB)
+                    //not(conditionA AND conditionB) = (not conditionA) OR (not conditionB)
+                    if (predicate == Predicate.OR) {
+                        predicate = Predicate.AND;
+                    } else if (predicate == Predicate.AND) {
+                        predicate = Predicate.OR;
+                    }
+                    return new BinaryLogicOperator(condition.getLeft().accept(this), predicate, condition.getRight().accept(this));
                 }
             });
         } else {


### PR DESCRIPTION
TMDM-13111 [MQL] "not" operator doesn't work as expected with "or/and"
**What is the current behavior?** (You should also link to an open issue here)
If user want to get expected query results by the following query condition:
```
{
	"select": {
		"from": ["Store"],
		"where": {
			"not": {
				"and": [{
					"eq": [{
						"field": "Store/Address"
					},
					{
						"value": "add1"
					}]
				},
				{
					"eq": [{
						"field": "Store/Address"
					},
					{
						"value": "add2"
					}]
				}]
			}
		}
	}
}
```
Actually, it generate below query condition:
`where (not (this_.x_address=?) and not (this_.x_address=?))`
**What is the new behavior?**
Below is the expected query condition returned by new code section:
`where (not (this_.x_address=?) or not (this_.x_address=?))`

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
