### PR TITLE
TMDM-13202 FK : render in main tab in MetadataRepository

### DIFF
--- a/org.talend.mdm.core/test/com/amalto/core/metadata/MetadataRepositoryTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/metadata/MetadataRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -788,5 +788,25 @@ public class MetadataRepositoryTest extends TestCase {
 
         assertEquals("X_ANONYMOUS0", entityType.getField("aa-non-anonymous/bb-anonymous").getType().getName());
         assertEquals("X_ANONYMOUS1", entityType.getField("do").getType().getName());
+    }
+
+    public void test36_RenderInMainTab() throws Exception {
+        MetadataRepository repository = new MetadataRepository();
+        InputStream stream = getClass().getResourceAsStream("SortType_05.xsd");
+        repository.load(stream);
+
+        //1 set the X_ForeignKey_NotSep value
+        ComplexTypeMetadata component = repository.getComplexType("Component");
+        ReferenceFieldMetadata defaultAirbag = (ReferenceFieldMetadata) component.getField("DefaultAirbag_Fk");
+        ReferenceFieldMetadata associatedComponent = (ReferenceFieldMetadata) component.getField("AssociatedComponent_Fk");
+
+        assertTrue(defaultAirbag.isFKMainRender());
+        assertFalse(associatedComponent.isFKMainRender());
+
+        //2. no set X_ForeignKey_NotSep, default is false
+        ComplexTypeMetadata finishedProduct = repository.getComplexType("FinishedProduct");
+        ReferenceFieldMetadata compositionFk = (ReferenceFieldMetadata) finishedProduct.getField("Composition_Fk");
+
+        assertFalse(compositionFk.isFKMainRender());
     }
 }


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13202

**What is the current behavior?** (You should also link to an open issue here)
ReferenceFieldMetadata have no property about isFKMainRender, which defined in studio "X_ForeignKey_NotSep"


**What is the new behavior?**
add property isFKMainRender in ReferenceFieldMetadata, the default value is false.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
