### PR TITLE
TMDM-13187 [REST API] Support JSON input for Update Partial Record APIs

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
@@ -21,9 +21,11 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.*;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 import java.util.Map.Entry;
 
@@ -37,6 +39,12 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     private static final Logger LOGGER = Logger.getLogger(DataRecordJSONReader.class);
 
     private final String JSON_REF = "$ref"; //$NON-NLS-1$
+
+    private final String MDM_TYPE = "-tmdm:type"; //$NON-NLS-1$
+
+    private final String MDM_NAMESPACE = "-xmlns:tmdm"; //$NON-NLS-1$
+
+    private final String REERENCE_VALUE = "#text"; //$NON-NLS-1$
 
     private JsonElement rootElement = null;
 
@@ -66,7 +74,10 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     }
 
     /*   The xsi:type in XML:
-    *    <Person><PersonId>33</PersonId><Name>person-name-322aa3</Name><Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="USAddress"><zip>10221</zip><Line1>usa-new</Line1></Address></Person>
+    *    <Person><PersonId>33</PersonId><Name>person-name-322aa3</Name>
+    *       <Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="USAddress">
+    *       <zip>10221</zip><Line1>usa-new</Line1></Address>
+    *    </Person>
     * 
     *    The expected JSON input:
     *    {
@@ -81,7 +92,7 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     *        }
     *    }
     */
-    private String getReferenceValue(String typeName) {
+    private String getContainedValue(String typeName) {
         try {
             if (null == rootElement.getAsJsonObject().get(typeName)) {
                 return StringUtils.EMPTY;
@@ -99,7 +110,7 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
                 }
             }
         } catch (Exception e) {
-            LOGGER.warn("Failed to get JSON reference value.", e); //$NON-NLS-1$
+            LOGGER.warn("Failed to get JSON contained value.", e); //$NON-NLS-1$
             return StringUtils.EMPTY;
         }
         return StringUtils.EMPTY;
@@ -157,16 +168,16 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     }
 
     private void throwNotOwnedField(String tagName) {
-        throw new IllegalArgumentException("Entity '" + entityName + "' doesn't own field '" + tagName + "'."); //$NON-NLS-1$
+        throw new IllegalArgumentException("Entity '" + entityName + "' doesn't own field '" + tagName + "'."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
     }
 
     private void readJsonObject(MetadataRepository repository, DataRecord dataRecord, ComplexTypeMetadata type, JsonObject currentChild, String tagName) {
         FieldMetadata field = type.getField(tagName);
-        String referenceValue = getReferenceValue(tagName);
+        String containedValue = getContainedValue(tagName);
         if (field.getType() instanceof ContainedComplexTypeMetadata) {
             ComplexTypeMetadata containedType = (ComplexTypeMetadata) field.getType();
             for (ComplexTypeMetadata subType : containedType.getSubTypes()) {
-                if (StringUtils.isNotEmpty(referenceValue) && subType.getName().equals(referenceValue)) {
+                if (StringUtils.isNotEmpty(containedValue) && subType.getName().equals(containedValue)) {
                     containedType = subType;
                     break;
                 }
@@ -174,13 +185,80 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
             DataRecord containedRecord = new DataRecord(containedType, UnsupportedDataRecordMetadata.INSTANCE);
             dataRecord.set(field, containedRecord);
             readElement(repository, containedRecord, containedType, currentChild);
+        } else if (field instanceof ReferenceFieldMetadata) {
+            ComplexTypeMetadata actualType = ((ReferenceFieldMetadata) field).getReferencedType();
+            String referencedType = null;
+            String referenceValue = null;
+            List<String> referencedTypeAndValue = getReferencedTypeAndValue(tagName);
+            if (null != referencedTypeAndValue) {
+                referencedType = referencedTypeAndValue.get(0);
+                referenceValue = referencedTypeAndValue.get(1);
+                if (!referencedType.isEmpty()) {
+                    actualType = repository.getComplexType(referencedType);
+                }
+            }
+            if (actualType == null) {
+                throw new IllegalArgumentException("Type '" + referencedType + "' does not exist."); //$NON-NLS-1$ //$NON-NLS-2$
+            }
+            dataRecord.set(field, StorageMetadataUtils.convert(referenceValue, field, actualType));
         } else {
             readElement(repository, dataRecord, type, currentChild);
         }
     }
 
+    /*   The mdm:type in XML:
+    *    <PartyProduct><id>PartyProduct1</id><name>PartyProduct1</name>
+    *       <supplier xmlns:tmdm='http://www.talend.com/mdm' tmdm:type='PartyIndividual'>[PartyIndividual1]</supplier>
+    *    </PartyProduct>
+    *    
+    *    The expected JSON input:
+    *    {
+    *        "PartyProduct": {
+    *            "id": "PartyProduct1",
+    *            "name": "PartyProduct1",
+    *            "supplier": {
+    *                "-xmlns:tmdm": "http://www.talend.com/mdm",
+    *                "-tmdm:type": "PartyCompany",
+    *                "#text": "[PartyCompany1]"
+    *            }
+    *        }
+    *    }
+    */
+    private List<String> getReferencedTypeAndValue(String typeName) {
+        try {
+            if (null == rootElement.getAsJsonObject().get(typeName)) {
+                return null;
+            }
+            List<String> referencedTypeAndValue = new ArrayList<>();
+            JsonObject root = rootElement.getAsJsonObject().get(typeName).getAsJsonObject();
+            for (Iterator<Entry<String, JsonElement>> iterator = root.entrySet().iterator(); iterator.hasNext(); ) {
+                Entry<String, JsonElement> entry = iterator.next();
+                String tagName = entry.getKey();
+                JsonElement currentElement = entry.getValue();
+                if (tagName.equalsIgnoreCase(MDM_TYPE)) {
+                    String refType = currentElement.getAsString();
+                    if (StringUtils.isNotEmpty(refType)) {
+                        referencedTypeAndValue.add(refType);
+                    }
+                } else if (tagName.equalsIgnoreCase(REERENCE_VALUE)) {
+                    String refValue = currentElement.getAsString();
+                    if (StringUtils.isNotEmpty(refValue)) {
+                        referencedTypeAndValue.add(refValue);
+                    }
+                }
+            }
+            return referencedTypeAndValue.size() > 0 ? referencedTypeAndValue : null;
+        } catch (Exception e) {
+            LOGGER.warn("Failed to get JSON referenced type and value.", e); //$NON-NLS-1$
+            return null;
+        }
+    }
+    
     private void readJsonPrimitive(MetadataRepository repository, DataRecord dataRecord, ComplexTypeMetadata type, JsonPrimitive currentChild, String tagName) {
-        if (tagName.equalsIgnoreCase(JSON_REF)) {
+        if (tagName.equalsIgnoreCase(JSON_REF) || 
+            tagName.equalsIgnoreCase(MDM_TYPE) ||
+            tagName.equalsIgnoreCase(MDM_NAMESPACE) ||            
+            tagName.equalsIgnoreCase(REERENCE_VALUE)) {
             return;
         }
 

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
@@ -74,9 +74,9 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     }
 
     /**
+     * The xsi:type in XML:
      * <pre>
-     * {@code
-     *  The xsi:type in XML:
+     *    {@code
      *    <Person><PersonId>33</PersonId><Name>person-name-322aa3</Name>
      *        <Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="USAddress">
      *        <zip>10221</zip><Line1>usa-new</Line1></Address>
@@ -94,7 +94,6 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
      *            }
      *        }
      *    }
-     * }   
      * </pre>
      */
     private String getContainedValue(String typeName) {
@@ -138,9 +137,9 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     *    }
     * </pre>
     *    
-    *    As above Json input, the root element is Product, fields Id, Name and Family are JsonPrimitive.
-    *    Field Stores is ComplexTypeMetadata and JsonObject, and filed Store is JsonArray.
-    *    Field Family and each Store are ReferenceFieldMetadata, 
+    * As above Json input, the root element is Product, fields Id, Name and Family are JsonPrimitive.
+    * Field Stores is ComplexTypeMetadata and JsonObject, and filed Store is JsonArray.
+    * Field Family and each Store are ReferenceFieldMetadata, 
     *    
     */
     private void readElement(MetadataRepository repository, DataRecord dataRecord, ComplexTypeMetadata type, JsonElement element) {
@@ -214,9 +213,9 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     }
 
     /**
-     * <pre>
-     * {@code
      *    The mdm:type in XML:
+     * <pre>
+     *     {@code
      *     <PartyProduct><id>PartyProduct1</id><name>PartyProduct1</name>
      *         <supplier xmlns:tmdm='http://www.talend.com/mdm' tmdm:type='PartyIndividual'>[PartyIndividual1]</supplier>
      *     </PartyProduct>
@@ -233,8 +232,8 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
      *            }
      *        }
      *    }
-     * }
      * </pre>
+     * 
      */
     private List<String> getReferencedTypeAndValue(String typeName) {
         try {

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONReader.java
@@ -73,25 +73,30 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
         return dataRecord;
     }
 
-    /*   The xsi:type in XML:
-    *    <Person><PersonId>33</PersonId><Name>person-name-322aa3</Name>
-    *       <Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="USAddress">
-    *       <zip>10221</zip><Line1>usa-new</Line1></Address>
-    *    </Person>
-    * 
-    *    The expected JSON input:
-    *    {
-    *        "Person": {
-    *            "PersonId": "33",
-    *            "Name": "person-name-322aa3",
-    *            "Address": {
-    *                "$ref": "USAddress",
-    *                "zip": "102221",
-    *                "Line1": "usa-new"
-    *            }
-    *        }
-    *    }
-    */
+    /**
+     * <pre>
+     * {@code
+     *  The xsi:type in XML:
+     *    <Person><PersonId>33</PersonId><Name>person-name-322aa3</Name>
+     *        <Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="USAddress">
+     *        <zip>10221</zip><Line1>usa-new</Line1></Address>
+     *    </Person>
+     *
+     *    The expected JSON input:
+     *    {
+     *        "Person": {
+     *            "PersonId": "33",
+     *            "Name": "person-name-322aa3",
+     *            "Address": {
+     *                "$ref": "USAddress",
+     *                "zip": "102221",
+     *                "Line1": "usa-new"
+     *            }
+     *        }
+     *    }
+     * }   
+     * </pre>
+     */
     private String getContainedValue(String typeName) {
         try {
             if (null == rootElement.getAsJsonObject().get(typeName)) {
@@ -116,7 +121,8 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
         return StringUtils.EMPTY;
     }
 
-    /*
+    /**
+    * <pre>
     *    {
     *        "Product": {
     *            "Id": "231035933",
@@ -130,6 +136,7 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
     *            }
     *        }
     *    }
+    * </pre>
     *    
     *    As above Json input, the root element is Product, fields Id, Name and Family are JsonPrimitive.
     *    Field Stores is ComplexTypeMetadata and JsonObject, and filed Store is JsonArray.
@@ -206,24 +213,29 @@ public class DataRecordJSONReader implements DataRecordReader<JsonElement> {
         }
     }
 
-    /*   The mdm:type in XML:
-    *    <PartyProduct><id>PartyProduct1</id><name>PartyProduct1</name>
-    *       <supplier xmlns:tmdm='http://www.talend.com/mdm' tmdm:type='PartyIndividual'>[PartyIndividual1]</supplier>
-    *    </PartyProduct>
-    *    
-    *    The expected JSON input:
-    *    {
-    *        "PartyProduct": {
-    *            "id": "PartyProduct1",
-    *            "name": "PartyProduct1",
-    *            "supplier": {
-    *                "-xmlns:tmdm": "http://www.talend.com/mdm",
-    *                "-tmdm:type": "PartyCompany",
-    *                "#text": "[PartyCompany1]"
-    *            }
-    *        }
-    *    }
-    */
+    /**
+     * <pre>
+     * {@code
+     *    The mdm:type in XML:
+     *     <PartyProduct><id>PartyProduct1</id><name>PartyProduct1</name>
+     *         <supplier xmlns:tmdm='http://www.talend.com/mdm' tmdm:type='PartyIndividual'>[PartyIndividual1]</supplier>
+     *     </PartyProduct>
+     *   
+     *    The expected JSON input:
+     *    {
+     *        "PartyProduct": {
+     *            "id": "PartyProduct1",
+     *            "name": "PartyProduct1",
+     *            "supplier": {
+     *                "-xmlns:tmdm": "http://www.talend.com/mdm",
+     *                "-tmdm:type": "PartyCompany",
+     *                "#text": "[PartyCompany1]"
+     *            }
+     *        }
+     *    }
+     * }
+     * </pre>
+     */
     private List<String> getReferencedTypeAndValue(String typeName) {
         try {
             if (null == rootElement.getAsJsonObject().get(typeName)) {


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)

Current JSON input doesn't support reference type from JSON object which was converted from XML:
```
<PartyProduct><id>bbPartyProduct2</id><name>bbPartyProduct222</name><supplier xmlns:tmdm="http://www.talend.com/mdm" tmdm:type="PartyCompany">[PartyCompany1]</supplier></PartyProduct>
```
```
{
   "PartyProduct": {
     "id": "PartyProduct2",
     "name": "PartyProduct222",
     "supplier": {
       "-xmlns:tmdm": "http://www.talend.com/mdm",
       "-tmdm:type": "PartyCompany",
       "#text": "[PartyCompany1]"
     }
   }
}
```

**What is the new behavior?**

With this code change, above format JSON input is supported.


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
