### PR TITLE
TMDM-11846 [REST API] Full implementation of partial update as in SOAP API / tMDMOutput

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -1865,7 +1865,7 @@ public class DocumentSaveTest extends TestCase {
 
         SaverSession session = SaverSession.newSession(source);
         InputStream partialUpdateContent = new ByteArrayInputStream((
-                "<Product><Id>11</Id><Features><Colors><Color>Light Pink</Color></Colors></Features></Product>\n")
+                "<Product><Id>11</Id><Features><Colors><Color>Light Blue</Color></Colors></Features></Product>\n")
                 .getBytes("UTF-8"));
         DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
                 partialUpdateContent, true, false, "/Product/Features/Colors", "/Color", 1, true, false);
@@ -1875,7 +1875,36 @@ public class DocumentSaveTest extends TestCase {
         session.end(committer);
 
         assertTrue(committer.hasSaved());
-        assertEquals("Light Pink", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[1]"));
+        assertEquals("Light Blue", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[1]"));
+        assertEquals("White", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[2]"));
+        assertEquals("Light Blue", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[3]"));
+        assertEquals("Khaki", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[4]"));
+    }
+
+    public void testProductPartialUpdateWithIndexOutOfRange() throws Exception {
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("DStar", repository);
+
+        TestSaverSource source = new TestSaverSource(repository, true, "test11_original.xml", "metadata1.xsd");
+        source.setUserName("admin");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream partialUpdateContent = new ByteArrayInputStream((
+                "<Product><Id>11</Id><Features><Colors><Color>Light Blue</Color></Colors></Features></Product>\n")
+                .getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
+                partialUpdateContent, true, false, "/Product/Features/Colors", "/Color", 10000, true, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        assertEquals("White", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[1]"));
+        assertEquals("Light Blue", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[2]"));
+        assertEquals("Khaki", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[3]"));
+        assertEquals("Light Blue", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[4]"));
     }
 
     public void testProductPartialUpdateDeleteTrue() throws Exception {
@@ -1900,7 +1929,7 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("", evaluate(committer.getCommittedElement(), "/Person/Kids"));
     }
 
-    public void testProductPartialUpdateOverwriteAndDeleteFalse() throws Exception {
+    public void testProductPartialUpdateOverwriteFalse() throws Exception {
         MetadataRepository repository = new MetadataRepository();
         repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));
         MockMetadataRepositoryAdmin.INSTANCE.register("DStar", repository);
@@ -1910,7 +1939,7 @@ public class DocumentSaveTest extends TestCase {
 
         SaverSession session = SaverSession.newSession(source);
         InputStream partialUpdateContent = new ByteArrayInputStream((
-                "<Product><Id>1221</Id><Features><Colors><Color>Light Pink</Color></Colors></Features></Product>\n")
+                "<Product><Id>1221</Id><Features><Colors><Color>Light Blue</Color></Colors></Features></Product>\n")
                 .getBytes("UTF-8"));
         DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
                 partialUpdateContent, true, false, "/Product/Features/Colors", "/Color", 1, false, false);
@@ -1920,7 +1949,10 @@ public class DocumentSaveTest extends TestCase {
         session.end(committer);
 
         assertTrue(committer.hasSaved());
-        assertEquals("Light Pink", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[1]"));
+        assertEquals("Light Blue", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[1]"));
+        assertEquals("White", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[2]"));
+        assertEquals("Light Blue", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[3]"));
+        assertEquals("Khaki", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[4]"));
     }
 
     public void testProductPartialUpdate2() throws Exception {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -1855,6 +1855,74 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("Khaki", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[4]"));
     }
 
+    public void testProductPartialUpdateOverwriteTrue() throws Exception {
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("DStar", repository);
+
+        TestSaverSource source = new TestSaverSource(repository, true, "test11_original.xml", "metadata1.xsd");
+        source.setUserName("admin");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream partialUpdateContent = new ByteArrayInputStream((
+                "<Product><Id>11</Id><Features><Colors><Color>Light Pink</Color></Colors></Features></Product>\n")
+                .getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
+                partialUpdateContent, true, false, "/Product/Features/Colors", "/Color", 1, true, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        assertEquals("Light Pink", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[1]"));
+    }
+
+    public void testProductPartialUpdateDeleteTrue() throws Exception {
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("PartialDelete.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("DStar", repository);
+
+        TestSaverSource source = new TestSaverSource(repository, true, "PartialDelete_original_2.xml", "PartialDelete.xsd");
+        source.setUserName("admin");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream partialUpdateContent = new ByteArrayInputStream((
+                "<Person><Id>1</Id><Kids><Kid><Name>k1</Name></Kid></Kids></Person>")
+                .getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
+                partialUpdateContent, true, false, "/Person/Kids/Kid", "/Name", 1, false, true);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+        assertTrue(committer.hasSaved());
+        assertEquals("", evaluate(committer.getCommittedElement(), "/Person/Kids"));
+    }
+
+    public void testProductPartialUpdateOverwriteAndDeleteFalse() throws Exception {
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("DStar", repository);
+
+        TestSaverSource source = new TestSaverSource(repository, true, "test11_original.xml", "metadata1.xsd");
+        source.setUserName("admin");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream partialUpdateContent = new ByteArrayInputStream((
+                "<Product><Id>1221</Id><Features><Colors><Color>Light Pink</Color></Colors></Features></Product>\n")
+                .getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().createPartialUpdate("MDM", "DStar", "Source",
+                partialUpdateContent, true, false, "/Product/Features/Colors", "/Color", 1, false, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        assertEquals("Light Pink", evaluate(committer.getCommittedElement(), "/Product/Features/Colors/Color[1]"));
+    }
+
     public void testProductPartialUpdate2() throws Exception {
         MetadataRepository repository = new MetadataRepository();
         repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));

--- a/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/server/service/JournalDBService.java
+++ b/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/server/service/JournalDBService.java
@@ -61,7 +61,7 @@ public class JournalDBService {
 
     private static final String RIGHT_BRACKET = "]";
 
-    private static final String SPRIT = "/";
+    private static final String SLASH = "/";
 
     private static final Logger LOG = Logger.getLogger(JournalDBService.class);
 
@@ -341,9 +341,9 @@ public class JournalDBService {
         for (String item : pathArray) {
             pathList.add(item);
         }
-        getChagneNodePath(StringUtils.EMPTY, pathList, result);
-        for(int i = 0 ; i < result.size() ; i++){
-            result.set(i, SPRIT + modelEntityName + SPRIT + result.get(i));
+        getChangeNodePath(StringUtils.EMPTY, pathList, result);
+        for (int i = 0 ; i < result.size() ; i++) {
+            result.set(i, SLASH + modelEntityName + SLASH + result.get(i));
         }
         return result;
     }
@@ -358,7 +358,7 @@ public class JournalDBService {
         return result;
     }
 
-    private void getChagneNodePath(String prePath, List<String> pathList, List<String> result) {
+    private void getChangeNodePath(String prePath, List<String> pathList, List<String> result) {
         for (int i = 0; i < pathList.size(); i++) {
             String path = pathList.get(i);
 
@@ -369,6 +369,9 @@ public class JournalDBService {
                 result.add(path);
                 break;
             }
+            if (StringUtils.isNoneEmpty(path) && StringUtils.isNoneEmpty(prePath) && path.equalsIgnoreCase(prePath)) {
+                continue;
+            }
 
             String newpath = StringUtils.EMPTY; 
             if (prePath.equals(StringUtils.EMPTY)) { 
@@ -377,14 +380,14 @@ public class JournalDBService {
                 newpath = path.substring(prePath.length() + 1);
             }
 
-            if (newpath.endsWith(LEFT_BRACKET) && !newpath.contains(SPRIT)) {
+            if (newpath.endsWith(LEFT_BRACKET) && !newpath.contains(SLASH)) {
                 result.add(path);
-            } else if (!newpath.contains(LEFT_BRACKET) && !newpath.contains(SPRIT)) {
+            } else if (!newpath.contains(LEFT_BRACKET) && !newpath.contains(SLASH)) {
                 result.add(path);
-            } else if (newpath.contains(LEFT_BRACKET) || newpath.contains(SPRIT)) {
+            } else if (newpath.contains(LEFT_BRACKET) || newpath.contains(SLASH)) {
                 String firstStr = StringUtils.EMPTY;
-                if (newpath.contains(SPRIT)) {
-                    firstStr = newpath.substring(0, newpath.indexOf(SPRIT));
+                if (newpath.contains(SLASH)) {
+                    firstStr = newpath.substring(0, newpath.indexOf(SLASH));
                 } else {
                     firstStr = newpath;
                 }
@@ -394,19 +397,18 @@ public class JournalDBService {
                     for (int j = 1; j <= firstStrNum; j++) {
                         String newStr = firstStr.substring(0, firstStr.indexOf(LEFT_BRACKET)) + LEFT_BRACKET + j + RIGHT_BRACKET;
                         if (i < pathList.size() - 1) {
-                            List<String> containsList = getContainsList(prePath.equals(StringUtils.EMPTY) ? newStr : prePath + SPRIT + newStr,
+                            List<String> containsList = getContainsList(prePath.equals(StringUtils.EMPTY) ? newStr : prePath + SLASH + newStr,
                                     pathList);
-                            getChagneNodePath(prePath.equals(StringUtils.EMPTY) ? newStr : prePath + SPRIT + newStr, containsList, result);
+                            getChangeNodePath(prePath.equals(StringUtils.EMPTY) ? newStr : prePath + SLASH + newStr, containsList, result);
                         }
                     }
                 } else {
-                    List<String> containsList = getContainsList(prePath.equals(StringUtils.EMPTY) ? firstStr : prePath + SPRIT + firstStr,
+                    List<String> containsList = getContainsList(prePath.equals(StringUtils.EMPTY) ? firstStr : prePath + SLASH + firstStr,
                             pathList);
-                    getChagneNodePath(prePath.equals(StringUtils.EMPTY) ? firstStr : prePath + SPRIT + firstStr, containsList, result);
+                    getChangeNodePath(prePath.equals(StringUtils.EMPTY) ? firstStr : prePath + SLASH + firstStr, containsList, result);
                 }
             }
         }
-
     }
 
     private String checkNull(String str) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-11846

**What is the current behavior?** (You should also link to an open issue here)

Current REST API for partial update cannot accept parameters: pivot, key, position and delete, which are available in SOAP API and tMDMOutput.

**What is the new behavior?**

With this feature, the parameters pivot, key, position and delete are accepted from REST API of partial update, and the behavior for the added parameters would be same as tMDMOutput, the previous behavior wouldn't be changed.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
