### PR TITLE
TMDM-13275 Success query on record id unexistant

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/SecurityQueryCleaner.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/SecurityQueryCleaner.java
@@ -40,7 +40,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(Range range) {
         if (!range.getExpression().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return range;
         }
@@ -106,7 +106,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(IndexedField indexedField) {
         if (delegator.hide(indexedField.getFieldMetadata())) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return indexedField;
         }
@@ -115,7 +115,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(Isa isa) {
         if(!isa.getExpression().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return isa;
         }
@@ -124,7 +124,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(NotIsEmpty notIsEmpty) {
         if (!notIsEmpty.getField().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return notIsEmpty;
         }
@@ -133,7 +133,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(NotIsNull notIsNull) {
         if (!notIsNull.getField().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return notIsNull;
         }
@@ -142,7 +142,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(IsEmpty isEmpty) {
         if (!isEmpty.getField().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return isEmpty;
         }
@@ -151,7 +151,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(IsNull isNull) {
         if (!isNull.getField().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return isNull;
         }
@@ -159,12 +159,9 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
 
     @Override
     public Expression visit(BinaryLogicOperator condition) {
-        if (!condition.getLeft().accept(checker) && !condition.getRight().accept(checker)) {
-            return UserQueryHelper.TRUE;
-        } else if (!condition.getLeft().accept(checker)) {
-            return new BinaryLogicOperator(UserQueryHelper.TRUE, condition.getPredicate(), condition.getRight());
-        } else if (!condition.getRight().accept(checker)) {
-            return new BinaryLogicOperator(condition.getLeft(), condition.getPredicate(), UserQueryHelper.TRUE);
+        // TMDM-13275 If user has no access to one query condition field, return empty list.
+        if (!condition.getLeft().accept(checker) || !condition.getRight().accept(checker)) {
+            return UserQueryHelper.FALSE;
         } else {
             return condition;
         }
@@ -173,7 +170,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(UnaryLogicOperator condition) {
         if (!condition.getCondition().accept(checker)) {
-            return new UnaryLogicOperator(UserQueryHelper.TRUE, condition.getPredicate());
+            return new UnaryLogicOperator(UserQueryHelper.FALSE, condition.getPredicate());
         } else {
             return condition;
         }
@@ -182,7 +179,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(Compare condition) {
         if (!condition.getLeft().accept(checker) || !condition.getRight().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return condition;
         }
@@ -202,7 +199,7 @@ class SecurityQueryCleaner extends VisitorAdapter<Expression> {
     @Override
     public Expression visit(FieldFullText fullText) {
         if (!fullText.getField().accept(checker)) {
-            return UserQueryHelper.TRUE;
+            return UserQueryHelper.FALSE;
         } else {
             return fullText;
         }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13275
**What is the current behavior?** (You should also link to an open issue here)
When search with field user has no access with api, the condition will be ignored, will return the list without filtered by the field.


**What is the new behavior?**
Search with field user has no access,  always return empty list.
If there is and/or condition with two fields and user has no access to only one field, still return empty list.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
