### PR TITLE
TMDM-13276 [Impact Analysis] ElementType change (length) not reflected in PostgreSQL database tables

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorageDataAnaylzer.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorageDataAnaylzer.java
@@ -59,8 +59,8 @@ public class HibernateStorageDataAnaylzer extends HibernateStorageImpactAnalyzer
                 }
 
                 RDBMSDataSource.DataSourceDialect dialect = ((RDBMSDataSource) storage.getDataSource()).getDialectName();
-                if ((HibernateStorageUtils.isDB2(dialect)
-                        || HibernateStorageUtils.isOracle(dialect) && element instanceof SimpleTypeFieldMetadata)) {
+                if ((HibernateStorageUtils.isDB2(dialect) || HibernateStorageUtils.isOracle(dialect))
+                        && element instanceof SimpleTypeFieldMetadata) {
                     String fieldType = MetadataUtils.getSuperConcreteType(((FieldMetadata) element).getType()).getName();
                     if (fieldType.equals("string")) {
                         Object oldLengthObj = CommonUtil.getSuperTypeMaxLength(previous.getType(), previous.getType());

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorageDataAnaylzer.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorageDataAnaylzer.java
@@ -59,7 +59,7 @@ public class HibernateStorageDataAnaylzer extends HibernateStorageImpactAnalyzer
 
                 if (current.isMandatory() && !previous.isMandatory() && !(element instanceof ContainedTypeFieldMetadata)) {
                     int count = fetchFieldCountOfNull(previous.getContainingType().getEntity(), previous);
-                    modifyAction.addData(ModifyChange.HAS_NULL_VALUE, count > 0);
+                    modifyAction.addData(Change.HAS_NULL_VALUE, count > 0);
                 }
 
                 int currentLengthInt = Integer.parseInt((currentLength == null ? STRING_DEFAULT_LENGTH : (String) currentLength));
@@ -71,7 +71,7 @@ public class HibernateStorageDataAnaylzer extends HibernateStorageImpactAnalyzer
 
                     if ((HibernateStorageUtils.isDB2(dialect) || HibernateStorageUtils.isOracle(dialect))
                             && currentLengthInt > dialect.getTextLimit()) {
-                        modifyAction.addData(ModifyChange.CHANGE_TO_CLOB, true);
+                        modifyAction.addData(Change.CHANGE_TO_CLOB, true);
                     }
                 }
             }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMDenormalizedTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMDenormalizedTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMDenormalizedTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMDenormalizedTable.java
@@ -55,6 +55,10 @@ public class MDMDenormalizedTable extends DenormalizedTable {
         while (iter.hasNext()) {
             Column column = (Column) iter.next();
 
+            if (column.getSqlTypeCode() == null) {
+                column.setSqlTypeCode(column.getSqlTypeCode(p));
+            }
+
             ColumnMetadata columnInfo = tableInfo.getColumnMetadata(column.getName());
 
             if (columnInfo == null) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -207,7 +207,11 @@ public class MDMTable extends Table {
                 if (column.isNullable()) {
                     alter.append(dialect.getNullColumnString());
                 } else {
-                    alter.append(" not null ");
+                    if (dialect instanceof PostgreSQLDialect) {
+                        alter.append(", alter column ").append(columnName).append(" set not null ");
+                    } else {
+                        alter.append(" not null ");
+                    }
                 }
 
                 // add the UK str

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -29,6 +29,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
+import org.hibernate.dialect.OracleDialect;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Constraint;
@@ -205,10 +206,16 @@ public class MDMTable extends Table {
                 alter.append(convertDefaultValue(dialect, sqlType, defaultValue));
 
                 if (column.isNullable()) {
-                    alter.append(dialect.getNullColumnString());
+                    if (dialect instanceof OracleDialect) {
+                        alter.append(" check( ").append(columnName).append(" is not null )");
+                    } else {
+                        alter.append(dialect.getNullColumnString());
+                    }
                 } else {
                     if (dialect instanceof PostgreSQLDialect) {
                         alter.append(", alter column ").append(columnName).append(" set not null ");
+                    } else if (dialect instanceof OracleDialect) {
+                        alter.append(" check( ").append(columnName).append(" is not null )");
                     } else {
                         alter.append(" not null ");
                     }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -29,7 +29,7 @@ import org.hibernate.dialect.H2Dialect;
 import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
-import org.hibernate.dialect.OracleDialect;
+import org.hibernate.dialect.Oracle8iDialect;
 import org.hibernate.engine.spi.Mapping;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.Constraint;
@@ -206,15 +206,15 @@ public class MDMTable extends Table {
                 alter.append(convertDefaultValue(dialect, sqlType, defaultValue));
 
                 if (column.isNullable()) {
-                    if (dialect instanceof OracleDialect) {
-                        alter.append(" check( ").append(columnName).append(" is not null )");
+                    if (dialect instanceof Oracle8iDialect) {
+                        alter.append(" check( ").append(columnName).append(" is null )");
                     } else {
                         alter.append(dialect.getNullColumnString());
                     }
                 } else {
                     if (dialect instanceof PostgreSQLDialect) {
                         alter.append(", alter column ").append(columnName).append(" set not null ");
-                    } else if (dialect instanceof OracleDialect) {
+                    } else if (dialect instanceof Oracle8iDialect) {
                         alter.append(" check( ").append(columnName).append(" is not null )");
                     } else {
                         alter.append(" not null ");

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -282,14 +282,13 @@ public class MDMTable extends Table {
     }
 
     private String generateUK(Dialect dialect, Column col) {
-        StringBuilder buf = new StringBuilder();
         if (col.isUnique()) {
             String keyName = Constraint.generateName("UK_", this, col);
             UniqueKey uk = getOrCreateUniqueKey(keyName);
             uk.addColumn(col);
-            buf.append(dialect.getUniqueDelegate().getColumnDefinitionUniquenessFragment(col));
+            return dialect.getUniqueDelegate().getColumnDefinitionUniquenessFragment(col);
         }
-        return buf.toString();
+        return StringUtils.EMPTY;
     }
 
     private String generateAlterDefaultValueConstraintSQL(String tableName, String columnName) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTableUtils.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTableUtils.java
@@ -1,9 +1,9 @@
 /*
  * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
- * 
+ *
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
- * 
+ *
  * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
  * 92150 Suresnes, France
  */
@@ -21,27 +21,23 @@ import java.sql.Types;
 @SuppressWarnings("nls")
 public abstract class MDMTableUtils {
 
-    public static final String NO = "NO";
+    private static final String NO = "NO";
 
     public static boolean isAlterColumnField(Column newColumn, ColumnMetadata oldColumnInfo, Dialect dialect) {
         if (oldColumnInfo == null) {
             return Boolean.FALSE;
         }
-        return isVarcharField(oldColumnInfo, dialect) && isIncreaseVarcharColumnLength(newColumn, oldColumnInfo)
-                || isStringTypeChanged(newColumn, oldColumnInfo, dialect);
+        return isVarcharField(oldColumnInfo, dialect) && isIncreaseVarcharColumnLength(newColumn, oldColumnInfo, dialect)
+                || isVarcharTypeChanged(newColumn, oldColumnInfo, dialect);
     }
 
-    public static boolean isStringTypeChanged(Column newColumn, ColumnMetadata oldColumnInfo, Dialect dialect) {
-        if (dialect instanceof DB2Dialect) {
-            if (oldColumnInfo.getTypeCode() == Types.VARCHAR && newColumn.getSqlTypeCode() == Types.CLOB) {
-                return false;
-            }
-        }
-        return oldColumnInfo.getTypeCode() == Types.VARCHAR && newColumn.getSqlTypeCode() == Types.LONGVARCHAR;
+    private static boolean isVarcharTypeChanged(Column newColumn, ColumnMetadata oldColumnInfo) {
+        return (oldColumnInfo.getTypeCode() == Types.VARCHAR || oldColumnInfo.getTypeCode() == Types.NVARCHAR) && (
+                newColumn.getSqlTypeCode() == Types.LONGVARCHAR || newColumn.getSqlTypeCode() == Types.CLOB);
     }
 
 
-    public static boolean isVarcharField(ColumnMetadata oldColumnInfo, Dialect dialect) {
+    private static boolean isVarcharField(ColumnMetadata oldColumnInfo, Dialect dialect) {
         boolean isVarcharType = oldColumnInfo.getTypeCode() == Types.VARCHAR;
         if (dialect instanceof SQLServerDialect) {
             isVarcharType |= oldColumnInfo.getTypeCode() == Types.NVARCHAR
@@ -50,8 +46,14 @@ public abstract class MDMTableUtils {
         return isVarcharType;
     }
 
-    public static boolean isIncreaseVarcharColumnLength(Column newColumn, ColumnMetadata oldColumnInfo) {
-        return newColumn.getLength() > oldColumnInfo.getColumnSize() && (newColumn.getSqlTypeCode() == oldColumnInfo.getTypeCode());
+    private static boolean isIncreaseVarcharColumnLength(Column newColumn, ColumnMetadata oldColumnInfo, Dialect dialect) {
+        if (dialect instanceof SQLServerDialect) {
+            return newColumn.getLength() > oldColumnInfo.getColumnSize() && (oldColumnInfo.getTypeCode() == Types.NVARCHAR
+                    || oldColumnInfo.getTypeCode() == Types.VARCHAR) && (newColumn.getSqlTypeCode() == Types.NVARCHAR
+                    || newColumn.getSqlTypeCode() == Types.VARCHAR);
+        }
+        return newColumn.getLength() > oldColumnInfo.getColumnSize() && (newColumn.getSqlTypeCode() == oldColumnInfo
+                .getTypeCode());
     }
 
     public static boolean isChangedToOptional(Column newColumn, ColumnMetadata oldColumnInfo) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTableUtils.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTableUtils.java
@@ -28,7 +28,7 @@ public abstract class MDMTableUtils {
             return Boolean.FALSE;
         }
         return isVarcharField(oldColumnInfo, dialect) && isIncreaseVarcharColumnLength(newColumn, oldColumnInfo, dialect)
-                || isVarcharTypeChanged(newColumn, oldColumnInfo, dialect);
+                || isVarcharTypeChanged(newColumn, oldColumnInfo);
     }
 
     private static boolean isVarcharTypeChanged(Column newColumn, ColumnMetadata oldColumnInfo) {

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema9_4.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/schema9_4.xsd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+  ~ 92150 Suresnes, France
+  -->
+
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:simpleType name="MyStr">
+        <xsd:restriction base="xsd:string">
+            <xsd:maxLength value="2000" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:element name="MyStr">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string" />
+                <xsd:element maxOccurs="1" minOccurs="0" name="MyStr" type="MyStr" />
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="MyStr">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/compare1_1.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/compare1_1.xsd
@@ -1,0 +1,15 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
+    <xsd:element name="Test">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Test">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/compare1_2.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/compare1_2.xsd
@@ -1,0 +1,20 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
+    <xsd:element name="Test">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="STRING_5000"/>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Test">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="STRING_5000">
+        <xsd:restriction base="xsd:string">
+            <xsd:length value="5000"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13276

**What is the current behavior?** (You should also link to an open issue here)
1. Enlarge the String field length, greater than 255, H2, MySQL, PostgreSQL, DB2, after redeploy, column type doesn't modify in the database.


**What is the new behavior?**
1. if enlarge the string field length greater than 255, H2, MySQL, PostgreSQL, after redeploy, column type changed to text from varchar.
2. DB2: DB2 doesn't support changed the type from varchar to clob.
from: https://www.ibm.com/support/knowledgecenter/en/SSEPGG_11.1.0/com.ibm.db2.luw.sql.ref.doc/doc/r0000888.html
> A non-LOB column cannot be altered to a LOB data type (SQLSTATE 42837).
So, for DB2, don't deal with this case, maintain the same with before.



**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
