### PR TITLE
TMDM-11900 Avoid duplicate key in Update_Report tables

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
@@ -84,23 +84,16 @@ public class StandardPersistenceExtension implements PersistenceExtension {
         }
         try {
             Class.forName(dataSource.getDriverClassName());
-            Connection connection = DriverManager.getConnection(dataSource.getConnectionURL(), dataSource.getUserName(), dataSource.getPassword());
-            try {
-                Statement statement = connection.createStatement();
-                try {
-                    ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = upper('x_update_report')"); //$NON-NLS-1$
-                    if (resultSet.next()) {
-                        return resultSet.getInt(1) == 1;
-                    } else {
-                        return false;
-                    }
-                } catch (SQLException e) {
-                    LOGGER.warn("Exception occurred during checking the query table exists.", e);//$NON-NLS-1$
-                } finally {
-                    statement.close();
+            try (Connection connection = DriverManager.getConnection(dataSource.getConnectionURL(), dataSource.getUserName(), dataSource.getPassword());
+                 Statement statement = connection.createStatement()) {
+                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = upper('x_update_report')"); //$NON-NLS-1$
+                if (resultSet.next()) {
+                    return resultSet.getInt(1) == 1;
+                } else {
+                    return false;
                 }
-            } finally {
-                connection.close();
+            } catch (SQLException e) {
+                LOGGER.error("Exception occurred during checking the query table exists.", e);//$NON-NLS-1$
             }
             return false;
         } catch (Exception e) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
@@ -70,7 +70,7 @@ public class StandardPersistenceExtension implements PersistenceExtension {
         Storage simpleStorage = (Storage) UpdateReportStorageProxy.newInstance(new Class[] { Storage.class }, dataSource);
         StorageInitializer initializer = new JDBCStorageInitializer();
 
-        return initializer.isInitialized(simpleStorage) && isTableExisted(simpleStorage);
+        return initializer.isInitialized(simpleStorage) && isUpdateReportExisted(simpleStorage);
     }
 
     /**
@@ -78,7 +78,7 @@ public class StandardPersistenceExtension implements PersistenceExtension {
      * @param storage
      * @return
      */
-    private boolean isTableExisted(Storage storage) {
+    private boolean isUpdateReportExisted(Storage storage) {
         if (!HibernateStorageUtils.isOracle(dataSource.getDialectName())) {
             return true;
         }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
@@ -86,7 +86,7 @@ public class StandardPersistenceExtension implements PersistenceExtension {
             Class.forName(dataSource.getDriverClassName());
             try (Connection connection = DriverManager.getConnection(dataSource.getConnectionURL(), dataSource.getUserName(),
                     dataSource.getPassword()); Statement statement = connection.createStatement()) {
-                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = upper('x_update_report')"); //$NON-NLS-1$
+                ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = 'X_UPDATE_REPORT'"); //$NON-NLS-1$
                 if (resultSet.next()) {
                     return resultSet.getInt(1) == 1;
                 } else {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
@@ -78,14 +78,14 @@ public class StandardPersistenceExtension implements PersistenceExtension {
      * @param storage
      * @return
      */
-    public boolean isTableExisted(Storage storage) {
+    private boolean isTableExisted(Storage storage) {
         if (!HibernateStorageUtils.isOracle(dataSource.getDialectName())) {
             return true;
         }
         try {
             Class.forName(dataSource.getDriverClassName());
-            try (Connection connection = DriverManager.getConnection(dataSource.getConnectionURL(), dataSource.getUserName(), dataSource.getPassword());
-                 Statement statement = connection.createStatement()) {
+            try (Connection connection = DriverManager.getConnection(dataSource.getConnectionURL(), dataSource.getUserName(),
+                    dataSource.getPassword()); Statement statement = connection.createStatement()) {
                 ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = upper('x_update_report')"); //$NON-NLS-1$
                 if (resultSet.next()) {
                     return resultSet.getInt(1) == 1;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/StandardPersistenceExtension.java
@@ -45,8 +45,6 @@ public class StandardPersistenceExtension implements PersistenceExtension {
 
     private static final String INIT_DB_RESOURCE_PATH = "/com/amalto/core/initdb/extensiondata/datamodel/UpdateReport"; //$NON-NLS-1$
 
-    private static final String TABLE_NAME = "x_update_report";//$NON-NLS-1$
-
     private RDBMSDataSource dataSource;
 
     @Override
@@ -72,7 +70,7 @@ public class StandardPersistenceExtension implements PersistenceExtension {
         Storage simpleStorage = (Storage) UpdateReportStorageProxy.newInstance(new Class[] { Storage.class }, dataSource);
         StorageInitializer initializer = new JDBCStorageInitializer();
 
-        return initializer.isInitialized(simpleStorage) && isExistsTable(simpleStorage);
+        return initializer.isInitialized(simpleStorage) && isTableExisted(simpleStorage);
     }
 
     /**
@@ -80,7 +78,7 @@ public class StandardPersistenceExtension implements PersistenceExtension {
      * @param storage
      * @return
      */
-    public boolean isExistsTable(Storage storage) {
+    public boolean isTableExisted(Storage storage) {
         if (!HibernateStorageUtils.isOracle(dataSource.getDialectName())) {
             return true;
         }
@@ -90,14 +88,14 @@ public class StandardPersistenceExtension implements PersistenceExtension {
             try {
                 Statement statement = connection.createStatement();
                 try {
-                    ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = upper('" + TABLE_NAME + "')"); //$NON-NLS-1$ $NON-NLS-2$
+                    ResultSet resultSet = statement.executeQuery("SELECT COUNT(*) FROM user_tables WHERE table_name = upper('x_update_report')"); //$NON-NLS-1$
                     if (resultSet.next()) {
                         return resultSet.getInt(1) == 1;
                     } else {
                         return false;
                     }
                 } catch (SQLException e) {
-                    LOGGER.warn("Exception occurred during checking the query table exists.", e);
+                    LOGGER.warn("Exception occurred during checking the query table exists.", e);//$NON-NLS-1$
                 } finally {
                     statement.close();
                 }
@@ -106,7 +104,7 @@ public class StandardPersistenceExtension implements PersistenceExtension {
             }
             return false;
         } catch (Exception e) {
-            throw new RuntimeException("Exception occurred during processing querying of Oracle database", e);
+            throw new RuntimeException("Exception occurred during processing querying of Oracle database", e);//$NON-NLS-1$
         }
     }
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-11900
**What is the current behavior?** (You should also link to an open issue here)
When MDM server to connect to a empty Oracle DB in Cluster mode, that cause a UpdateReport table doesn't exist exception. 

**What is the new behavior?**
Add a checking operation before using the UpdateReport table to identify if it exists or not for Oracle DB.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
