### PR TITLE
TMDM-13367 : TQL Predicate : isEmpty -> isNull

### DIFF
--- a/org.talend.mdm.query/src/com/amalto/core/query/user/TQLPredicateToMDMPredicate.java
+++ b/org.talend.mdm.query/src/com/amalto/core/query/user/TQLPredicateToMDMPredicate.java
@@ -148,7 +148,8 @@ public class TQLPredicateToMDMPredicate implements IASTVisitor<Condition> {
     @Override
     public Condition visit(FieldIsEmptyExpression fieldIsEmptyExpression) {
         fieldIsEmptyExpression.getField().accept(this);
-        return new IsEmpty(popCurrentExpression());
+        // TMDM-13367 : Workaround : A value not valorised in MDM is null
+        return new IsNull(popCurrentExpression());
     }
 
     @Override

--- a/org.talend.mdm.query/test/org/talend/mdm/query/UserQueryJsonSerializerTest.java
+++ b/org.talend.mdm.query/test/org/talend/mdm/query/UserQueryJsonSerializerTest.java
@@ -10,6 +10,7 @@
 package org.talend.mdm.query;
 
 import com.amalto.core.query.user.Expression;
+import com.amalto.core.query.user.IsNull;
 import com.amalto.core.query.user.Select;
 import com.amalto.core.query.user.TypedExpression;
 import com.amalto.core.query.user.UserQueryBuilder;
@@ -135,6 +136,15 @@ public class UserQueryJsonSerializerTest extends TestCase {
         final UserQueryBuilder userQueryBuilder = UserQueryBuilder.from(type1).where("Type1.value1 contains 'Toto'");
         final Select select = userQueryBuilder.getSelect();
         assertNotNull(select.getCondition());
+        assertRoundTrip(select);
+    }
+
+    public void testConditionIsEmptyTQL() {
+        final ComplexTypeMetadata type1 = repository.getComplexType("Type1");
+        final UserQueryBuilder userQueryBuilder = UserQueryBuilder.from(type1).where("Type1.value1 is empty");
+        final Select select = userQueryBuilder.getSelect();
+        assertNotNull(select.getCondition());
+        assertTrue(select.getCondition() instanceof IsNull);
         assertRoundTrip(select);
     }
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13367

**What is the current behavior?** (You should also link to an open issue here)

The operator isEmpty in TQL was converted into the operator isEmpty in MQL

**What is the new behavior?**

The operator isEmpty in TQL was converted into the operator isNull in MQL.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

http://192.168.31.210:8080/view/Master/job/Master_03_TMDMEE_FOR-JIRA_Slave2/51/