### PR TITLE
TMDM-13371 MDM REST API PUT /data/{containerName}/query : select where eq does not work when non ascii characters

### DIFF
--- a/org.talend.mdm.core/src/org/talend/mdm/query/QueryParser.java
+++ b/org.talend.mdm.core/src/org/talend/mdm/query/QueryParser.java
@@ -14,6 +14,7 @@ import com.google.gson.GsonBuilder;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
 
 import java.io.*;
+import java.nio.charset.Charset;
 
 /**
  *
@@ -49,7 +50,7 @@ public class QueryParser {
         if (query == null) {
             throw new IllegalArgumentException("Query cannot be null.");
         }
-        return parse(new InputStreamReader(query)).normalize();
+        return parse(new InputStreamReader(query, Charset.forName("UTF-8"))).normalize(); //$NON-NLS-1$
     }
 
     public Expression parse(Reader query) {

--- a/org.talend.mdm.core/test/org/talend/mdm/QueryParserTest.java
+++ b/org.talend.mdm.core/test/org/talend/mdm/QueryParserTest.java
@@ -495,4 +495,40 @@ public class QueryParserTest extends TestCase {
         assertEquals(0, condition.getDateTime());
     }
 
+    //Test non ascii characters
+    public void testQuery32() {
+        QueryParser parser = QueryParser.newParser(repository);
+        Expression expression = parser.parse(QueryParserTest.class.getResourceAsStream("query32_1.json")); //$NON-NLS-1$
+        assertTrue(expression instanceof Select);
+        Select select = (Select) expression;
+
+        Condition condition = select.getCondition();
+        assertNotNull(condition);
+        assertTrue(condition instanceof Compare);
+        Compare compare = (Compare)condition;
+        assertEquals("æ", ((StringConstant)compare.getRight()).getValue());
+
+        parser = QueryParser.newParser(repository);
+        expression = parser.parse(QueryParserTest.class.getResourceAsStream("query32_2.json")); //$NON-NLS-1$
+        assertTrue(expression instanceof Select);
+        select = (Select) expression;
+
+        condition = select.getCondition();
+        assertNotNull(condition);
+        assertTrue(condition instanceof Compare);
+        compare = (Compare)condition;
+        assertEquals("我是中国人", ((StringConstant)compare.getRight()).getValue());
+
+        parser = QueryParser.newParser(repository);
+        expression = parser.parse(QueryParserTest.class.getResourceAsStream("query32_3.json")); //$NON-NLS-1$
+        assertTrue(expression instanceof Select);
+        select = (Select) expression;
+
+        condition = select.getCondition();
+        assertNotNull(condition);
+        assertTrue(condition instanceof Compare);
+        compare = (Compare)condition;
+        assertEquals("æœøÆŒØï", ((StringConstant)compare.getRight()).getValue());
+    }
+
 }

--- a/org.talend.mdm.core/test/org/talend/mdm/query32_1.json
+++ b/org.talend.mdm.core/test/org/talend/mdm/query32_1.json
@@ -1,0 +1,15 @@
+{
+  "select": {
+    "from": ["Type1"],
+    "where": {
+      "eq": [
+        {
+          "field": "Type1/value1"
+        },
+        {
+          "value": "æ"
+        }
+      ]
+    }
+  }
+}

--- a/org.talend.mdm.core/test/org/talend/mdm/query32_2.json
+++ b/org.talend.mdm.core/test/org/talend/mdm/query32_2.json
@@ -1,0 +1,15 @@
+{
+  "select": {
+    "from": ["Type1"],
+    "where": {
+      "eq": [
+        {
+          "field": "Type1/value1"
+        },
+        {
+          "value": "我是中国人"
+        }
+      ]
+    }
+  }
+}

--- a/org.talend.mdm.core/test/org/talend/mdm/query32_3.json
+++ b/org.talend.mdm.core/test/org/talend/mdm/query32_3.json
@@ -1,0 +1,15 @@
+{
+  "select": {
+    "from": ["Type1"],
+    "where": {
+      "eq": [
+        {
+          "field": "Type1/value1"
+        },
+        {
+          "value": "æœøÆŒØï"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13371

**What is the current behavior?** (You should also link to an open issue here)
MDM criteria query not only support ASCII, but also should also support non-ASCII Characters, like Greece character. 


**What is the new behavior?**
Use UTF-8 charset to read MQL JSON content into InputStreamReader.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
