### PR TITLE
TMDM-13444 [REST] PUT /data/{containerName}/query : operators eq / contains / startsWith / full_text do not return the same result

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/FullTextQueryHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  *
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -425,32 +425,44 @@ class FullTextQueryHandler extends AbstractQueryHandler {
         return new FullTextStorageResults(pageSize, query.getResultSize(), iterator);
     }
 
+    /**
+     * If the current next is a collection, iterator the list to get each of foreign key Id with a comma separated, like:
+     * <pre>
+     * "entityfk": [
+     *   "11",
+     *   "22"
+     * ]
+     * </pre>
+     * @param next
+     * @param field
+     * @return foreign key list
+     */
+    @SuppressWarnings("unchecked")
     private static Object getReferencedId(DataRecord next, ReferenceFieldMetadata field) {
-        DataRecord record;
+        List<Object> referenceIdList = new ArrayList<>();
         Object recordObject = next.get(field);
         if (recordObject != null && recordObject instanceof List) {
-            if (((List<Object>)recordObject).size() > 0) {
-                record = (DataRecord)((List<Object>)recordObject).get(0);
-            } else {
-                return null;
+            for (Iterator<DataRecord> iterator = ((List<DataRecord>)recordObject).iterator(); iterator.hasNext();) {
+                DataRecord currentItem = iterator.next();
+                referenceIdList.addAll(getFlatReferencedId(currentItem));
             }
         } else {
-            record = (DataRecord)recordObject;
+            DataRecord record = (DataRecord)recordObject;
+            referenceIdList.addAll(getFlatReferencedId(record));
         }
-        
-        if (record != null) {
-            Collection<FieldMetadata> keyFields = record.getType().getKeyFields();
-            if (keyFields.size() == 1) {
-                return record.get(keyFields.iterator().next());
-            } else {
-                List<Object> compositeKeyValues = new ArrayList<Object>(keyFields.size());
-                for (FieldMetadata keyField : keyFields) {
-                    compositeKeyValues.add(record.get(keyField));
-                }
-                return compositeKeyValues.toArray(new Object[keyFields.size()]);
-            }
-        } 
-        return null;
+        return referenceIdList;
+    }
+
+    private static List<Object> getFlatReferencedId(DataRecord record) {
+        if (record == null) {
+            return Collections.emptyList();
+        }
+        Collection<FieldMetadata> keyFields = record.getType().getKeyFields();
+        List<Object> compositeKeyValues = new ArrayList<Object>(keyFields.size());
+        for (FieldMetadata keyField : keyFields) {
+            compositeKeyValues.add(record.get(keyField));
+        }
+        return compositeKeyValues;
     }
 
     @Override


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13444
**What is the current behavior?** (You should also link to an open issue here)
If a Entity is associated with many of Foreign key, with full_text query, now only may return the first FK record, missing other FK information, eg: 
```<Product><name>hello</name><Supplier>11</Supplier><Supplier>22</Supplier></Product>```
if there is a full text query, it will return the following information:
```<Product><name>hello</name><Supplier>11</Supplier></Product>```

**What is the new behavior?**
Modify related snippet of code to get results normally, it will return the the information in actually. 
For above eg, there will be the results:
```<Product><name>hello</name><Supplier>11</Supplier><Supplier>22</Supplier></Product>```


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
