### PR TITLE
TMDM-13550 : Support multiple fields on NOT_EQUALS in TQL -> MQL

### DIFF
--- a/org.talend.mdm.query/src/com/amalto/core/query/user/TQLPredicateToMDMPredicate.java
+++ b/org.talend.mdm.query/src/com/amalto/core/query/user/TQLPredicateToMDMPredicate.java
@@ -86,6 +86,14 @@ public class TQLPredicateToMDMPredicate implements IASTVisitor<Condition> {
         return current;
     }
 
+    private Condition mergeNotEquals(Predicate predicate, TypedExpression fieldLeftValue, TypedExpression fieldRightValue) {
+        Condition current = new UnaryLogicOperator(new Compare(fieldLeftValue, Predicate.EQUALS, fieldRightValue), Predicate.NOT);
+        for (int i = 0; i < typedValues.size(); i++) {
+            current = new BinaryLogicOperator(current, predicate, new UnaryLogicOperator(new Compare(popCurrentExpression(), Predicate.EQUALS, fieldRightValue), Predicate.NOT));
+        }
+        return current;
+    }
+
 
     private TypedExpression peekCurrentExpression() {
         return typedValues.peek();
@@ -114,7 +122,7 @@ public class TQLPredicateToMDMPredicate implements IASTVisitor<Condition> {
             case GT:
                 return new Compare(left, Predicate.GREATER_THAN, right);
             case NEQ:
-                return new UnaryLogicOperator(new Compare(left, Predicate.EQUALS, right), Predicate.NOT);
+                return mergeNotEquals(Predicate.AND, left, right);
             case LET:
                 return new Compare(left, Predicate.LOWER_THAN_OR_EQUALS, right);
             case GET:

--- a/org.talend.mdm.query/test/org/talend/mdm/query/UserQueryJsonSerializerTest.java
+++ b/org.talend.mdm.query/test/org/talend/mdm/query/UserQueryJsonSerializerTest.java
@@ -240,6 +240,19 @@ public class UserQueryJsonSerializerTest extends TestCase {
         assertRoundTrip(select);
     }
 
+    public void testNotFkMultipleInTQL() {
+        final ComplexTypeMetadata type1 = this.repository.getComplexType("Type1");
+        final UserQueryBuilder userQueryBuilder = UserQueryBuilder.from(type1).where("Type1.fk2 != 'value1'");
+        final Select select = userQueryBuilder.getSelect();
+        assertNotNull(select.getCondition());
+        assertTrue(select.getCondition() instanceof BinaryLogicOperator);
+        assertEquals(((BinaryLogicOperator)select.getCondition()).getPredicate(), Predicate.AND);
+        assertTrue(((BinaryLogicOperator)select.getCondition()).getRight() instanceof UnaryLogicOperator);
+        assertEquals(((UnaryLogicOperator) ((BinaryLogicOperator) select.getCondition()).getRight()).getPredicate(),  Predicate.NOT);
+        assertEquals(((UnaryLogicOperator) ((BinaryLogicOperator) select.getCondition()).getLeft()).getPredicate(),  Predicate.NOT);
+        assertRoundTrip(select);
+    }
+
     private void assertRoundTrip(Select select) {
         // when
         final String jsonAsString = UserQueryJsonSerializer.toJson(select);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13550

**What is the current behavior?** (You should also link to an open issue here)

Not equals operator supported only one field

**What is the new behavior?**

Not equals operator supported multiple fields, used for foreign key infos

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
