### PR TITLE
TMDM-13490 [REST] GET /data/{containerName}/{type}/{id} with datetime fails when swing = BEFORE

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -1649,13 +1649,20 @@ public class DocumentSaveTest extends TestCase {
         path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
         oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
         newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("detail[1]/code", path);
-        assertEquals("code-original", oldValue);
-        assertEquals("code-new", newValue);
+        assertEquals("detail[1]/@xsi:type", path);
+        assertEquals("ContractDetailType", oldValue);
+        assertEquals("ContractDetailSubType", newValue);
 
         path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
         oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
         newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
+        assertEquals("detail[1]/code", path);
+        assertEquals("code-original", oldValue);
+        assertEquals("code-new", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
         assertEquals("detail[1]/features/actor", path);
         assertEquals("", oldValue);
         assertEquals("actor-new", newValue);
@@ -1715,22 +1722,37 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("actor-original", oldValue);
         assertEquals("", newValue);
 
+        path = (String) evaluate(doc.getDocumentElement(), "Item[5]/path");
         oldValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/oldValue");
         newValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/newValue");
-        assertEquals("detail[1]/features/actor", path);
-        assertEquals("true", oldValue);
+        assertEquals("detail[1]/features", path);
+        assertEquals("", oldValue);
         assertEquals("", newValue);
 
         path = (String) evaluate(doc.getDocumentElement(), "Item[6]/path");
         oldValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/oldValue");
         newValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/newValue");
-        assertEquals("detail[1]/ReadOnlyEle", path);
-        assertEquals("[readOnlyEle-original]", oldValue);
+        assertEquals("detail[1]/boolTest", path);
+        assertEquals("true", oldValue);
         assertEquals("", newValue);
 
         path = (String) evaluate(doc.getDocumentElement(), "Item[7]/path");
         oldValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/oldValue");
         newValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/newValue");
+        assertEquals("detail[1]/ReadOnlyEle", path);
+        assertEquals("[readOnlyEle-original]", oldValue);
+        assertEquals("", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[8]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[8]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[8]/newValue");
+        assertEquals("detail[1]/@xsi:type", path);
+        assertEquals("ContractDetailSubType", oldValue);
+        assertEquals("ContractDetailType", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[9]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[9]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[9]/newValue");
         assertEquals("detail[1]/code", path);
         assertEquals("code-original", oldValue);
         assertEquals("code-new", newValue);

--- a/org.talend.mdm.core/src/com/amalto/core/history/accessor/AttributeAccessor.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/accessor/AttributeAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  *
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -52,6 +52,10 @@ class AttributeAccessor implements DOMAccessor {
 
     private Node getAttribute() {
         Node parentNode = parent.getNode();
+        if (parentNode == null && this.attributeName.contains("xsi:type")) { ////$NON-NLS-1$
+            parent.insert();
+            parentNode = parent.getNode();
+        }
         if (parentNode == null) {
             throw new IllegalStateException("Could not find a parent node in document (check if document has a root element)."); //$NON-NLS-1$
         }
@@ -65,6 +69,9 @@ class AttributeAccessor implements DOMAccessor {
         if (attribute == null) {
             // Look up with namespace didn't work, falls back to standard getNamedItem
             attribute = attributes.getNamedItem(qName.getLocalPart());
+        }
+        if (attribute == null) {
+            attribute = createAttribute(parentNode, document.asDOM());
         }
         return attribute;
     }

--- a/org.talend.mdm.core/src/com/amalto/core/history/action/CompositeAction.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/action/CompositeAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  *
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -13,10 +13,16 @@ package com.amalto.core.history.action;
 
 import com.amalto.core.history.Action;
 import com.amalto.core.history.MutableDocument;
+import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
+import java.util.stream.Collectors;
 
 /**
  *
@@ -40,7 +46,8 @@ public class CompositeAction implements Action {
 
     public MutableDocument perform(MutableDocument document) {
         MutableDocument mutableDocument = document;
-        for (Action action : actions) {
+        List<Action> reorderedAction = reorderDeleteContainedTypeActions(actions);
+        for (Action action : reorderedAction) {
             mutableDocument = action.perform(document);
         }
         return mutableDocument;
@@ -48,7 +55,8 @@ public class CompositeAction implements Action {
 
     public MutableDocument undo(MutableDocument document) {
         MutableDocument mutableDocument = document;
-        for (Action action : actions) {
+        List<Action> copyActions = reorderDeleteContainedTypeActions(reverseXSITypeActions(actions));
+        for (Action action : copyActions) {
             mutableDocument = action.undo(document);
         }
         return mutableDocument;
@@ -106,5 +114,136 @@ public class CompositeAction implements Action {
             }
         }
         return true;
+    }
+
+    public List<Action> getActions() {
+        return actions;
+    }
+
+    /**
+     * reorder the actions if the actions contains one which is a delete contained type
+     * eg.:
+     * actions[0] ="FieldUpdateAction{path='detail[2]/code', oldValue='s', newValue='null'}"
+     * actions[1] ="FieldUpdateAction{path='detail[2]/features/actor', oldValue='sf', newValue='null'}"
+     * actions[2] ="FieldUpdateAction{path='detail[2]/features/vendor[1]', oldValue='sd', newValue='null'}"
+     * actions[3] ="FieldUpdateAction{path='detail[2]/features', oldValue='null', newValue='null'}"
+     * <p>
+     * return:
+     * actions[0] ="FieldUpdateAction{path='detail[2]/code', oldValue='s', newValue='null'}"
+     * actions[1] ="FieldUpdateAction{path='detail[2]/features', oldValue='null', newValue='null'}"
+     * actions[2] ="FieldUpdateAction{path='detail[2]/features/actor', oldValue='sf', newValue='null'}"
+     * actions[3] ="FieldUpdateAction{path='detail[2]/features/vendor[1]', oldValue='sd', newValue='null'}"
+     *
+     * @param actions the action list need to be reordered
+     * @return reordered action list
+     */
+    protected List<Action> reorderDeleteContainedTypeActions(List<Action> actions) {
+        List<Action> copyActions = new ArrayList<>(actions);
+        int beginIndex = 0;
+        String previousPath = StringUtils.EMPTY;
+        for (int i = actions.size() - 1; i >= 0; i--) {
+            FieldUpdateAction fieldUpdateAction = (FieldUpdateAction) actions.get(i);
+            if (fieldUpdateAction.getOldValue() == null && fieldUpdateAction.getNewValue() == null) {
+                beginIndex = i;
+                previousPath = fieldUpdateAction.getPath();
+            } else if (beginIndex > 0 && !StringUtils
+                    .equals(previousPath, StringUtils.substringBeforeLast(fieldUpdateAction.getPath(), "/"))) { //$NON-NLS-1$
+                copyActions.remove(actions.get(beginIndex));
+                copyActions.add(i + 1, actions.get(beginIndex));
+                beginIndex = 0;
+                previousPath = StringUtils.EMPTY;
+            }
+
+        }
+        return copyActions;
+    }
+
+    /**
+     * reverse the actions if the actions contains <pre>xsi:type</pre>
+     * eg.
+     * action[0] = "FieldUpdateAction{path='User/first/Location', oldValue='J-Location-N', newValue='null'}"
+     * action[1] = "FieldUpdateAction{path='User/first/@xsi:type', oldValue='JuniorSchool', newValue='SeniorSchool'}"
+     * action[2] = "FieldUpdateAction{path='User/first/Name', oldValue='J-Name-N', newValue='J-Name-N-to-O'}"
+     * action[3] = "FieldUpdateAction{path='User/first/Gaokao', oldValue='null', newValue='J-Location-N-O'}"
+     * action[4] = "FieldUpdateAction{path='User/second/Gaokao', oldValue='S-Gaokao-N', newValue='null'}"
+     * action[5] = "FieldUpdateAction{path='User/second/@xsi:type', oldValue='SeniorSchool', newValue='JuniorSchool'}"
+     * action[6] = "FieldUpdateAction{path='User/second/Name', oldValue='S-Name-N', newValue='S-Name-N-O'}"
+     * action[7] = "FieldUpdateAction{path='User/second/Location', oldValue='null', newValue='S-Gaokao-N-O'}"
+     * <p>
+     * finally return:
+     * action[0] = "FieldUpdateAction{path='User/first/Gaokao', oldValue='null', newValue='J-Location-N-O'}"
+     * action[1] = "FieldUpdateAction{path='User/first/Name', oldValue='J-Name-N', newValue='J-Name-N-to-O'}"
+     * action[2] = "FieldUpdateAction{path='User/first/@xsi:type', oldValue='JuniorSchool', newValue='SeniorSchool'}"
+     * action[3] = "FieldUpdateAction{path='User/first/Location', oldValue='J-Location-N', newValue='null'}"
+     * action[4] = "FieldUpdateAction{path='User/second/Location', oldValue='null', newValue='S-Gaokao-N-O'}"
+     * action[5] = "FieldUpdateAction{path='User/second/Name', oldValue='S-Name-N', newValue='S-Name-N-O'}"
+     * action[6] = "FieldUpdateAction{path='User/second/@xsi:type', oldValue='SeniorSchool', newValue='JuniorSchool'}"
+     * action[7] = "FieldUpdateAction{path='User/second/Gaokao', oldValue='S-Gaokao-N', newValue='null'}"
+     *
+     * @param actions the actions need to be reversed
+     * @return reversed action list
+     */
+    protected List<Action> reverseXSITypeActions(List<Action> actions) {
+        List<Action> copyActions = new ArrayList<>(actions);
+        List<String> parents = copyActions.stream().filter(action -> ((FieldUpdateAction) action).getPath().contains("@xsi:type"))
+                .map(action -> (StringUtils.substringBeforeLast(((FieldUpdateAction) action).getPath(), "@xsi:type")))
+                .collect(Collectors.toList());
+        if (parents.isEmpty()) {
+            return copyActions;
+        }
+        int beginIndex = -1;
+        List<Action> changeTypeActions = new ArrayList<>(actions.size());
+        int i = 0;
+        for (String parent : parents) {
+            for (; i < actions.size(); i++) {
+                FieldUpdateAction fieldUpdateAction = (FieldUpdateAction) actions.get(i);
+                String path = fieldUpdateAction.getPath();
+                if (path.indexOf(parent) == 0) {
+                    changeTypeActions.add(fieldUpdateAction);
+                    if (beginIndex < 0) {
+                        beginIndex = i;
+                    }
+                } else {
+                    if (changeTypeActions.size() > 1) {
+                        resetActions(beginIndex, copyActions, changeTypeActions);
+                        changeTypeActions.clear();
+                        beginIndex = -1;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (changeTypeActions.size() > 1) {
+            resetActions(beginIndex, copyActions, changeTypeActions);
+        }
+        return copyActions;
+    }
+
+    /**
+     * remove the actions if the actions contains <pre>xsi:type</pre>
+     * remove the action which the newValue and oldValue both are null
+     *
+     * below two actions will be removed
+     * action[0] = "FieldUpdateAction{path='User/first/Gaokao', oldValue='null', newValue='John'}"
+     * action[0] = "FieldUpdateAction{path='User/detail', oldValue='null', newValue='null'}"
+     */
+    public void removeXSITypeAndNullValueAction() {
+        Iterator<Action> iterator = actions.iterator();
+        while (iterator.hasNext()) {
+            Action action = iterator.next();
+            FieldUpdateAction fieldUpdateAction = (FieldUpdateAction) action;
+            if (fieldUpdateAction.getNewValue() == null && fieldUpdateAction.getOldValue() == null) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private void resetActions(int beginIndex, List<Action> copyActions, List<Action> changeTypeActions) {
+        Collections.reverse(changeTypeActions);
+        int resetIndex = beginIndex;
+        for (Action changeTypeAction : changeTypeActions) {
+            copyActions.set(resetIndex++, changeTypeAction);
+        }
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateReport.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateReport.java
@@ -15,18 +15,14 @@ import java.util.List;
 import java.util.UUID;
 
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
-import org.talend.mdm.commmon.metadata.MetadataRepository;
-import org.talend.mdm.commmon.metadata.TypeMetadata;
 import org.w3c.dom.Document;
 
 import com.amalto.core.history.Action;
 import com.amalto.core.history.MutableDocument;
 import com.amalto.core.history.accessor.Accessor;
-import com.amalto.core.history.action.FieldUpdateAction;
 import com.amalto.core.objects.UpdateReportPOJO;
 import com.amalto.core.save.DocumentSaverContext;
 import com.amalto.core.save.SaverSession;
-import com.amalto.core.util.Util;
 
 class UpdateReport implements DocumentSaver {
 
@@ -76,11 +72,8 @@ class UpdateReport implements DocumentSaver {
                 hasHeader = true;
                 updateReportDocument.enableRecordFieldChange();
             }
-
-            if (!(action instanceof ChangeTypeAction) && !isInherit(action, type)) {
-                action.perform(updateReportDocument);
-                action.undo(updateReportDocument);
-            }
+            action.perform(updateReportDocument);
+            action.undo(updateReportDocument);
         }
         if (!updateReportDocument.isCreated()) {
             updateReportDocument.setOperationType(UpdateReportPOJO.OPERATION_TYPE_UPDATE);
@@ -89,26 +82,6 @@ class UpdateReport implements DocumentSaver {
 
         context.setUpdateReportDocument(updateReportDocument);
         next.save(session, context);
-    }
-
-    private boolean isInherit(Action action, ComplexTypeMetadata type) {
-        if (!(action instanceof FieldUpdateAction)) {
-            return false;
-        }
-        FieldUpdateAction filedUpdateAction = (FieldUpdateAction) action;
-
-        String path = filedUpdateAction.getPath();
-        path = Util.removeBracketWithNumber(path);
-
-        TypeMetadata filedType = type.getField(path).getType();
-
-        if (filedType instanceof ComplexTypeMetadata) {
-            if (((ComplexTypeMetadata) filedType).getContainer().getType().getName()
-                    .startsWith(MetadataRepository.ANONYMOUS_PREFIX)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     private void setHeader(MutableDocument updateReportDocument, String fieldName, String value) {

--- a/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ *  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+
+package com.amalto.core.history.action;
+
+import com.amalto.core.history.Action;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class CompositeActionTest {
+
+    private CompositeAction compositeAction;
+
+    @Before
+    public void setUp() {
+        compositeAction = new CompositeAction(null, null, null, null);
+    }
+
+    @Test
+    public void reverseXSITypeActionsTest() {
+        List<Action> actions = new ArrayList<>();
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/Location", "J-Location-N", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/@xsi:type", "JuniorSchool", "SeniorSchool", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/Name", "J-Name-N", "J-Name-N-to-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/Gaokao", null, "J-Location-N-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/Gaokao", "S-Gaokao-N", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/@xsi:type", "SeniorSchool", "JuniorSchool", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/Name", "S-Name-N", "S-Name-N-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/Location", null, "S-Gaokao-N-O", null, null));
+
+        List<Action> actualResult = compositeAction.reverseXSITypeActions(actions);
+        assertEquals("User/first/Gaokao", ((FieldUpdateAction) actualResult.get(0)).getPath());
+        assertEquals("User/first/Name", ((FieldUpdateAction) actualResult.get(1)).getPath());
+        assertEquals("User/first/@xsi:type", ((FieldUpdateAction) actualResult.get(2)).getPath());
+        assertEquals("User/first/Location", ((FieldUpdateAction) actualResult.get(3)).getPath());
+        assertEquals("User/second/Location", ((FieldUpdateAction) actualResult.get(4)).getPath());
+        assertEquals("User/second/Name", ((FieldUpdateAction) actualResult.get(5)).getPath());
+        assertEquals("User/second/@xsi:type", ((FieldUpdateAction) actualResult.get(6)).getPath());
+        assertEquals("User/second/Gaokao", ((FieldUpdateAction) actualResult.get(7)).getPath());
+
+        actions.clear();
+        actions.add(new FieldUpdateAction(null, null, null, "changeName", null, "update1", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "phoneNumber", null, "22222222222", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "mobileNumber", null, "22222222222", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/mrMrs", "2", "null", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/lastName", "john", "null", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/@xsi:type", "addressPersonType", "addressPaymentBeneficiaryType", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/addressLine1", "Beijing", "eee", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/addressLine2", "Dongcheng", "eee", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/street", "wangfujing", "eee", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/houseNumber", "2", "33", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/dwellingNumber", "2", "33", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/postOfficeBoxNumber", "2", "33", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "addressAttorneyAF/postOfficeBoxText", "2", "33", null, null));
+
+        actualResult = compositeAction.reverseXSITypeActions(actions);
+        assertEquals("changeName", ((FieldUpdateAction) actualResult.get(0)).getPath());
+        assertEquals("phoneNumber", ((FieldUpdateAction) actualResult.get(1)).getPath());
+        assertEquals("mobileNumber", ((FieldUpdateAction) actualResult.get(2)).getPath());
+        assertEquals("addressAttorneyAF/postOfficeBoxText", ((FieldUpdateAction) actualResult.get(3)).getPath());
+        assertEquals("addressAttorneyAF/postOfficeBoxNumber", ((FieldUpdateAction) actualResult.get(4)).getPath());
+        assertEquals("addressAttorneyAF/dwellingNumber", ((FieldUpdateAction) actualResult.get(5)).getPath());
+        assertEquals("addressAttorneyAF/houseNumber", ((FieldUpdateAction) actualResult.get(6)).getPath());
+        assertEquals("addressAttorneyAF/street", ((FieldUpdateAction) actualResult.get(7)).getPath());
+        assertEquals("addressAttorneyAF/addressLine2", ((FieldUpdateAction) actualResult.get(8)).getPath());
+        assertEquals("addressAttorneyAF/addressLine1", ((FieldUpdateAction) actualResult.get(9)).getPath());
+        assertEquals("addressAttorneyAF/@xsi:type", ((FieldUpdateAction) actualResult.get(10)).getPath());
+        assertEquals("addressAttorneyAF/lastName", ((FieldUpdateAction) actualResult.get(11)).getPath());
+        assertEquals("addressAttorneyAF/mrMrs", ((FieldUpdateAction) actualResult.get(12)).getPath());
+
+        actions.clear();
+        actions.add(new FieldUpdateAction(null, null, null, "paymentBenefitType/iban", "aa", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "paymentBenefitType/addressBanking/addressLine1", "Beijing", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "paymentBenefitType/@xsi:type", "paymentTransferType", "paymentCashType", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "paymentBenefitType/dummy", null, "dd", null, null));
+
+        actualResult = compositeAction.reverseXSITypeActions(actions);
+        assertEquals("paymentBenefitType/dummy", ((FieldUpdateAction) actualResult.get(0)).getPath());
+        assertEquals("paymentBenefitType/@xsi:type", ((FieldUpdateAction) actualResult.get(1)).getPath());
+        assertEquals("paymentBenefitType/addressBanking/addressLine1", ((FieldUpdateAction) actualResult.get(2)).getPath());
+        assertEquals("paymentBenefitType/iban", ((FieldUpdateAction) actualResult.get(3)).getPath());
+    }
+
+    @Test
+    public void reorderDeleteContainedTypeActionsTest() {
+        List<Action> actions = new ArrayList<>();
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/code", "s", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/features/actor", "sf", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/features/vendor[1]", "sd", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/features", null, null, null, null));
+
+        List<Action> actualResult = compositeAction.reorderDeleteContainedTypeActions(actions);
+        assertEquals("detail[2]/code", ((FieldUpdateAction) actualResult.get(0)).getPath());
+        assertEquals("detail[2]/features", ((FieldUpdateAction) actualResult.get(1)).getPath());
+        assertEquals("detail[2]/features/actor", ((FieldUpdateAction) actualResult.get(2)).getPath());
+        assertEquals("detail[2]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(3)).getPath());
+    }
+
+    @Test
+    public void removeXSITypeAndNullValueActionTest(){
+        List<Action> actions = new ArrayList<>();
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/Location", "J-Location-N", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/@xsi:type", "JuniorSchool", "SeniorSchool", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/Name", "J-Name-N", "J-Name-N-to-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/first/Gaokao", null, "J-Location-N-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/Gaokao", "S-Gaokao-N", null, null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/@xsi:type", "SeniorSchool", "JuniorSchool", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/Name", "S-Name-N", "S-Name-N-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second/Location", null, "S-Gaokao-N-O", null, null));
+
+        compositeAction = new CompositeAction(null, null, null, actions);
+        compositeAction.removeXSITypeAndNullValueAction();
+        List<Action> actualResult = compositeAction.getActions();
+        assertEquals("User/first/Gaokao", ((FieldUpdateAction)actualResult.get(0)).getPath());
+        assertEquals("User/first/Name", ((FieldUpdateAction)actualResult.get(1)).getPath());
+        assertEquals("User/first/@xsi:type", ((FieldUpdateAction)actualResult.get(2)).getPath());
+        assertEquals("User/first/Location", ((FieldUpdateAction)actualResult.get(3)).getPath());
+        assertEquals("User/second/Location", ((FieldUpdateAction)actualResult.get(4)).getPath());
+        assertEquals("User/second/Name", ((FieldUpdateAction)actualResult.get(5)).getPath());
+        assertEquals("User/second/@xsi:type", ((FieldUpdateAction)actualResult.get(6)).getPath());
+        assertEquals("User/second/Gaokao", ((FieldUpdateAction)actualResult.get(7)).getPath());
+    }
+}

--- a/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
@@ -118,21 +118,23 @@ public class CompositeActionTest {
         actions.add(new FieldUpdateAction(null, null, null, "User/first/@xsi:type", "JuniorSchool", "SeniorSchool", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "User/first/Name", "J-Name-N", "J-Name-N-to-O", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "User/first/Gaokao", null, "J-Location-N-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/first", null, null, null, null));
         actions.add(new FieldUpdateAction(null, null, null, "User/second/Gaokao", "S-Gaokao-N", null, null, null));
         actions.add(new FieldUpdateAction(null, null, null, "User/second/@xsi:type", "SeniorSchool", "JuniorSchool", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "User/second/Name", "S-Name-N", "S-Name-N-O", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "User/second/Location", null, "S-Gaokao-N-O", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "User/second", null, null, null, null));
 
-        compositeAction = new CompositeAction(null, null, null, actions);
+        CompositeAction compositeAction = new CompositeAction(null, null, null, actions);
         compositeAction.removeXSITypeAndNullValueAction();
         List<Action> actualResult = compositeAction.getActions();
-        assertEquals("User/first/Gaokao", ((FieldUpdateAction)actualResult.get(0)).getPath());
-        assertEquals("User/first/Name", ((FieldUpdateAction)actualResult.get(1)).getPath());
-        assertEquals("User/first/@xsi:type", ((FieldUpdateAction)actualResult.get(2)).getPath());
-        assertEquals("User/first/Location", ((FieldUpdateAction)actualResult.get(3)).getPath());
-        assertEquals("User/second/Location", ((FieldUpdateAction)actualResult.get(4)).getPath());
-        assertEquals("User/second/Name", ((FieldUpdateAction)actualResult.get(5)).getPath());
-        assertEquals("User/second/@xsi:type", ((FieldUpdateAction)actualResult.get(6)).getPath());
-        assertEquals("User/second/Gaokao", ((FieldUpdateAction)actualResult.get(7)).getPath());
+        assertEquals("User/first/Location", ((FieldUpdateAction)actualResult.get(0)).getPath());
+        assertEquals("User/first/@xsi:type", ((FieldUpdateAction)actualResult.get(1)).getPath());
+        assertEquals("User/first/Name", ((FieldUpdateAction)actualResult.get(2)).getPath());
+        assertEquals("User/first/Gaokao", ((FieldUpdateAction)actualResult.get(3)).getPath());
+        assertEquals("User/second/Gaokao", ((FieldUpdateAction)actualResult.get(4)).getPath());
+        assertEquals("User/second/@xsi:type", ((FieldUpdateAction)actualResult.get(5)).getPath());
+        assertEquals("User/second/Name", ((FieldUpdateAction)actualResult.get(6)).getPath());
+        assertEquals("User/second/Location", ((FieldUpdateAction)actualResult.get(7)).getPath());
     }
 }


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13490

**What is the current behavior?** (You should also link to an open issue here)
It happens about Data model which having an inheritance relationship.
1. change one field type to another type(both extend one type)
2. delete one field record(this field is one-to-many)

**What is the new behavior?**
1. change one field type to another type(both extend one type)
 1). When changed the field type, generate the ChangeTypeAction for updateReport, but it doesn't store in the database. it influences the history query, so remove the condition of below code:
```
 if (!(action instanceof ChangeTypeAction) && !isInherit(action, type)) {
        action.perform(updateReportDocument);
        action.undo(updateReportDocument);
 }
```
2). when recovering the before the record, the field type needs to change to the before type, the field type is non-instantiable type,
```
repository.getNonInstantiableType(StringUtils.EMPTY, value);
```
it's not correct, it need form the current entity.
 3). when recovering the before the record, the action of updateReport is not correct,
```
action[0] = "FieldUpdateAction{path='addressAttorneyAF/mrMrs', oldValue='2', newValue='null'}"
action[1] = "FieldUpdateAction{path='addressAttorneyAF/lastName', oldValue='aa', newValue='null'}"
action[2] = "FieldUpdateAction{path='addressAttorneyAF/@xsi:type', oldValue='addressPersonType', newValue='addressOrganisationType'}"
action[3] = "FieldUpdateAction{path='addressAttorneyAF/organisationName', oldValue='null', newValue='dd'}"
```
for above 4 actions, the first 3 are before type, the last one is the new type, if do the undo, need to reverse the action, the correct actions are:
```
action[0] = "FieldUpdateAction{path='addressAttorneyAF/organisationName', oldValue='null', newValue='dd'}"
action[1] = "FieldUpdateAction{path='addressAttorneyAF/@xsi:type', oldValue='addressPersonType', newValue='addressOrganisationType'}"
action[2] = "FieldUpdateAction{path='addressAttorneyAF/lastName', oldValue='aa', newValue='null'}"
action[3] = "FieldUpdateAction{path='addressAttorneyAF/mrMrs', oldValue='2', newValue='null'}"
```
4). throw the journal to view change on WEB UI, query the before the record, get the null attribute of the changeType action, like:
```
action[2] = "FieldUpdateAction{path='addressAttorneyAF/@xsi:type', oldValue='addressPersonType', newValue='addressOrganisationType'}"
```
here, if the node of *addressAttorneyAF* and attribute are null, first to create **addressAttorneyAF** element and create **xsi:type** attribute.
 2. delete one field record(this field is one-to-many)
 when deleting one record(original contains two records), generate below update record:
```
actions[0] ="FieldUpdateAction{path='detail[2]/code', oldValue='s', newValue='null'}"
actions[1] ="FieldUpdateAction{path='detail[2]/features/actor', oldValue='sf', newValue='null'}"
actions[2] ="FieldUpdateAction{path='detail[2]/features/vendor[1]', oldValue='sd', newValue='null'}"
actions[3] ="FieldUpdateAction{path='detail[2]/features', oldValue='null', newValue='null'}"
```
it needs to reorder the action to :
```
actions[0] ="FieldUpdateAction{path='detail[2]/code', oldValue='s', newValue='null'}"
actions[1] ="FieldUpdateAction{path='detail[2]/features', oldValue='null', newValue='null'}"
actions[2] ="FieldUpdateAction{path='detail[2]/features/actor', oldValue='sf', newValue='null'}"
actions[3] ="FieldUpdateAction{path='detail[2]/features/vendor[1]', oldValue='sd', newValue='null'}"
```
 


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
