### PR TITLE
TMDM-13444 [REST] PUT /data/{containerName}/query : operators eq / contains / startsWith / full_text do not return the same result

### DIFF
--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/util/CommonUtil.java
@@ -247,7 +247,7 @@ public class CommonUtil {
         return idList.toArray(new String[idList.size()]);
     }
 
-    public static String[] getFKRefValue(String ids) {
+    public static String[] extractFKRefValue(String ids) {
         return new String[] { ids.replaceAll("^\\[|\\]$", "").replace("][", ".").replace(", ", ".") }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
     }
 

--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/util/CommonUtil.java
@@ -247,6 +247,10 @@ public class CommonUtil {
         return idList.toArray(new String[idList.size()]);
     }
 
+    public static String[] getFKRefValue(String ids) {
+        return new String[] { ids.replaceAll("^\\[|\\]$", "").replace("][", ".").replace(", ", ".") }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$ //$NON-NLS-6$
+    }
+
     public static String buildCriteriaByIds(String[] keys, String[] ids) {
         if (keys == null || ids == null) {
             return null;

--- a/org.talend.mdm.webapp.base/src/test/java/org/talend/mdm/webapp/base/server/util/CommonUtilTest.java
+++ b/org.talend.mdm.webapp.base/src/test/java/org/talend/mdm/webapp/base/server/util/CommonUtilTest.java
@@ -378,6 +378,13 @@ public class CommonUtilTest extends TestCase {
         String[] id = CommonUtil.extractFKRefValue(ids, "en");
         assertEquals("1", id[0]);
         assertEquals("2", id[1]);
+
+        id = CommonUtil.extractFKRefValue(ids);
+        assertEquals("1.2", id[0]);
+
+        ids = "[1, 2]";
+        id = CommonUtil.extractFKRefValue(ids);
+        assertEquals("1.2", id[0]);
     }
 
     public void testSplitString() {

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
@@ -279,7 +279,7 @@ public class CommonUtil {
                 return bean;
             } else {
                 ItemPOJOPK pk = new ItemPOJOPK();
-                String[] itemId = org.talend.mdm.webapp.base.server.util.CommonUtil.extractFKRefValue(ids, language);
+                String[] itemId = org.talend.mdm.webapp.base.server.util.CommonUtil.getFKRefValue(ids);
                 pk.setIds(itemId);
                 String conceptName = model.getForeignkey().split("/")[0]; //$NON-NLS-1$
                 // get deriveType's conceptName, otherwise getItem() method will throw exception.

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
@@ -279,7 +279,7 @@ public class CommonUtil {
                 return bean;
             } else {
                 ItemPOJOPK pk = new ItemPOJOPK();
-                String[] itemId = org.talend.mdm.webapp.base.server.util.CommonUtil.getFKRefValue(ids);
+                String[] itemId = org.talend.mdm.webapp.base.server.util.CommonUtil.extractFKRefValue(ids);
                 pk.setIds(itemId);
                 String conceptName = model.getForeignkey().split("/")[0]; //$NON-NLS-1$
                 // get deriveType's conceptName, otherwise getItem() method will throw exception.


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
After this jira task commit, change format from [1][2] to [1, 2] when foreign key is composite key. 


**What is the new behavior?**
Handle the composite foreign key format [1][2] and [1, 2].


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
