### PR TITLE
TMDM-13542 "Relations Page" not showing correct text

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/webapp/secure/js/SearchEntityPanel.js
+++ b/org.talend.mdm.webapp.browserecords/src/main/webapp/secure/js/SearchEntityPanel.js
@@ -14,6 +14,9 @@ amalto.itemsbrowser.SearchEntityPanel = function(config) {
 
 var mate = document.getElementById("gwt:property");
 language = mate.content.split("=")[1];
+if (language == 'zh') {
+    language = 'zh_CN';
+}
 
 amalto.itemsbrowser.SearchEntity = {};
 amalto.itemsbrowser.SearchEntity.bundle =  new Ext.i18n.Bundle({bundle:'SearchEntity', path:'secure/resources', lang:language});


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
The language value of chinese is 'zh',it can't find the i18n property file.The name of property file is SearchEntity_zh_CN.properties.


**What is the new behavior?**
Change language value from zh to zh_CN,it will load the property file SearchEntity_zh_CN.properties.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
