### PR TITLE
TMDM-13220 Sorting FK in FK picker will always show loading.

### DIFF
--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/ForeignKeyHelper.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/ForeignKeyHelper.java
@@ -10,7 +10,6 @@
 package org.talend.mdm.webapp.base.server;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -186,11 +185,12 @@ public class ForeignKeyHelper {
                     // TMDM-5276: use substringBeforeLast in case sort field is a contained field
                     // (Entity/field1/.../fieldN)
                     xpath = config.getSortField();
+                    // Set sort language if foreign key info field is multiple lingual.
+                    if (Types.MULTI_LINGUAL.equals(entityModel.getTypeModel(config.getSortField()).getType().getTypeName())) {
+                        OrderBy.SortLanguage.set(language.toUpperCase());
+                    }
                 } else {
                     xpath = StringUtils.substringBefore(xPaths.get(0), "/") + "/../../i"; //$NON-NLS-1$ //$NON-NLS-2$
-                }
-                if (Types.MULTI_LINGUAL.equals(entityModel.getTypeModel(config.getSortField()).getType().getTypeName())) {
-                    OrderBy.SortLanguage.set(language.toUpperCase());
                 }
             } else {
                 xpath = null;


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13220
**What is the current behavior?** (You should also link to an open issue here)
The value of sort id field is not a path,and the id field can't be a multiple language field.It shouldn't sort by language


**What is the new behavior?**
When sort field is not id field,we sort it by language.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
