### PR TITLE
TMDM-13195 Error in mdm.log: Exception [com.amalto.core.delegator.IXtentisWSDelegator] Error during save. java.util.ConcurrentModificationException

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/server/MDMTransactionManager.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/MDMTransactionManager.java
@@ -206,7 +206,9 @@ public class MDMTransactionManager implements TransactionManager {
 
     @Override
     public boolean hasTransaction() {
-        return !getTransactionStack().isEmpty();
+        synchronized (currentTransactions) {
+            return !getTransactionStack().isEmpty();
+        }
     }
 
     private Stack<Transaction> getTransactionStack(){


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13195

**What is the current behavior?** (You should also link to an open issue here)
when removing the transaction will through java.util.ConcurrentModificationException
In the class MDMTransactionManager, `hasTransaction()` had been referenced much class, but it is not wrapped by synchronized, in the multiple threads, if function `hasTransaction()`  and `remove()`  invoked different thread, sometimes will through exception.

**What is the new behavior?**
wrapped the `currentTransactions ` by `synchronized `in method `hasTransaction()`


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
