### PR TITLE
TMDM-13341 [REST] GET /transactions : json returned is not RFC 4627 ompliant

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/task/staging/SerializableListWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/task/staging/SerializableListWriter.java
@@ -62,7 +62,7 @@ public class SerializableListWriter implements MessageBodyWriter<SerializableLis
             bw.flush();
         } else if (mediaType.equals(MediaType.APPLICATION_JSON_TYPE)) {
             BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream));
-            bw.write("{" + strings.getRootElement() + ":[");
+            bw.write("{\"" + strings.getRootElement() + "\":[");
             Iterator iterator = strings.iterator();
             while (iterator.hasNext()) {
                 bw.write('\"' + String.valueOf(iterator.next()) + '\"');


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
`GET /tasks/staging/ {container}/execs` response starts with `{executions:[`
`GET /transactions`	response starts with `{transactions:[`

The `executions` and `transactions` should be wrapped with `"`  

**What is the new behavior?**
`GET /tasks/staging/ {container}/execs` response starts with `{"executions":[`
`GET /transactions`	response starts with `{"transactions":[`



**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
