### PR TITLE
TMDM-13686 MDM war file deployed on Tomcat 8.5 : Error java.lang.NoSuchMethodError: javax.servlet.ServletContext.getSessionTimeout()

### DIFF
--- a/org.talend.mdm.webapp.general/pom.xml
+++ b/org.talend.mdm.webapp.general/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
+++ b/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
@@ -23,6 +23,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.util.ServletContextPropertyUtils;
@@ -73,9 +75,12 @@ public class MDMContextListener implements ServletContextListener {
     }
 
     private int getSessionTimeoutInSeconds(ServletContext servletContext) {
+        // Servlet 3.1 doesn't provide a way to get Session timeout defined in web.xml
         int webSessionTimeoutInSeconds;
         try {
-            webSessionTimeoutInSeconds = servletContext.getSessionTimeout() * 60;
+            String webXmlContent = IOUtils.toString(servletContext.getResourceAsStream("/WEB-INF/web.xml")); //$NON-NLS-1$
+            String sessionTimeout = StringUtils.substringBetween(webXmlContent, "<session-timeout>", "</session-timeout>"); //$NON-NLS-1$ //$NON-NLS-2$
+            webSessionTimeoutInSeconds = Integer.parseInt(sessionTimeout) * 60;
         } catch (Exception e) {
             LOGGER.warn("Failed to retrieve session timeout, using default value of 30 mins.", e); //$NON-NLS-1$
             webSessionTimeoutInSeconds = 30 * 60;

--- a/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
+++ b/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/servlet/MDMContextListener.java
@@ -75,7 +75,8 @@ public class MDMContextListener implements ServletContextListener {
     }
 
     private int getSessionTimeoutInSeconds(ServletContext servletContext) {
-        // Servlet 3.1 doesn't provide a way to get Session timeout defined in web.xml
+        // Tomcat 8.5 uses Servlet 3.1, and it doesn't provide a way to get Session timeout defined in web.xml. 
+        // In order to support both Tomcat 8.5 and Tomcat 9, we have to read it manually.
         int webSessionTimeoutInSeconds;
         try {
             String webXmlContent = IOUtils.toString(servletContext.getResourceAsStream("/WEB-INF/web.xml")); //$NON-NLS-1$


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13686
**What is the current behavior?** (You should also link to an open issue here)

MDM Server 7.3 used function getSessionTimeout() in servlet 4 (existed in Tomcat 9 servlet-api.jar), so it can only be deployed to Tomcat 9, if deployed to Tomcat 8.5, MDM Server cannot be started.

**What is the new behavior?**

Changed the implementation for session timeout through manually reading web.xml in MDM Server, so it can be deployed to both Tomcat 9 and Tomcat 8.5. This solution is same as MDM 7.0.


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
