### PR TITLE
TMDM-13686 MDM war file deployed on Tomcat 8.5 : Error java.lang.NoSuchMethodError: javax.servlet.ServletContext.getSessionTimeout()

### DIFF
--- a/org.talend.mdm.webapp.general/pom.xml
+++ b/org.talend.mdm.webapp.general/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13686
**What is the current behavior?** (You should also link to an open issue here)

MDM Server 7.3 used function getSessionTimeout() in servlet 4 (existed in Tomcat 9 servlet-api.jar), so it can only be deployed to Tomcat 9, if deployed to Tomcat 8.5, MDM Server cannot be started.

**What is the new behavior?**

Changed the implementation for session timeout through manually reading web.xml in MDM Server, so it can be deployed to both Tomcat 9 and Tomcat 8.5. This solution is same as MDM 7.0.


**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
