### PR TITLE
TMDM-13451 MDM WebUI, When sorting the results on a Date column (NoticeDate) the order is not correct.

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ReferenceEntityBridge.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ReferenceEntityBridge.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import com.amalto.core.storage.record.StorageConstants;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
+import org.apache.lucene.document.DateTools;
 import org.apache.lucene.document.Document;
 import org.hibernate.ObjectNotFoundException;
 import org.hibernate.search.bridge.LuceneOptions;
@@ -264,18 +265,13 @@ public class ReferenceEntityBridge implements TwoWayFieldBridge {
                 LOGGER.debug("insert a new Date index record with key-value pair [ " + name + "." + field.getName() + ":"
                         + value.toString());
             }
-            if (value instanceof java.util.Date) {
-                java.util.Date date = convertStringToDate("yyyy-MM-dd HH:mm:ss", value.toString());
-                Calendar cal = Calendar.getInstance();
-                cal.setTime(date);
-                String indexKey = name + "." + field.getName();
-                luceneOptions.addFieldToDocument(indexKey, cal.get(Calendar.YEAR) + "", document);
-                luceneOptions.addFieldToDocument(indexKey, cal.get(Calendar.MONTH) + 1 + "", document);
-                luceneOptions.addFieldToDocument(indexKey, cal.get(Calendar.DAY_OF_MONTH) + "", document);
-                luceneOptions.addFieldToDocument(indexKey, cal.get(Calendar.HOUR_OF_DAY) + "." + cal.get(Calendar.MINUTE),
-                        document);
-                luceneOptions.addFieldToDocument(indexKey, cal.get(Calendar.SECOND) + "", document);
-            }
+            if (value instanceof Date) {
+                Date date = (Date) value;
+                String stringDate = DateTools.dateToString(date, DateTools.Resolution.SECOND);
+                luceneOptions.addFieldToDocument(name, stringDate, document);
+            } else {
+                luceneOptions.addFieldToDocument(name, String.valueOf(value), document);
+            }            
         }
     }
 

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ToStringBridge.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ToStringBridge.java
@@ -10,9 +10,10 @@
  */
 
 package com.amalto.core.storage.hibernate;
-
+import java.util.Date;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.DateTools;
 import org.hibernate.search.bridge.LuceneOptions;
 import org.hibernate.search.bridge.TwoWayFieldBridge;
 
@@ -30,6 +31,12 @@ public class ToStringBridge implements TwoWayFieldBridge {
     }
 
     public void set(String name, Object value, Document document, LuceneOptions luceneOptions) {
-        luceneOptions.addFieldToDocument(name, String.valueOf(value), document);
+        if (value instanceof Date) {
+            Date date = (Date) value;
+            String stringDate = DateTools.dateToString(date, DateTools.Resolution.SECOND);
+            luceneOptions.addFieldToDocument(name, stringDate, document);
+        } else {
+            luceneOptions.addFieldToDocument(name, String.valueOf(value), document);
+        }
     }
 }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13451

**What is the current behavior?** (You should also link to an open issue here)

During full text search, the dataTime/date/time type entity cannot be sorted properly. It was caused that Lucene index for all kinds of date type, for date time "YYYY-MM-DDThh:mm:ss", it will be split to YYYY, MM, DD, hh, mm, ss etc.

**What is the new behavior?**

During full text search, the first level dataTime/date/time type entity can be sorted properly.
Lucene index for all kinds of date type, for example date time "YYYY-MM-DDThh:mm:ss", it will be saved as "yyyyMMddHHmmss" 

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
