### PR TITLE
TMDM-13587 Can't save FK under the reusable type with customer's data model

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StatefulContext.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StatefulContext.java
@@ -10,13 +10,16 @@
 
 package com.amalto.core.storage.hibernate;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.ContainedComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.DefaultMetadataVisitor;
 import org.talend.mdm.commmon.metadata.EnumerationFieldMetadata;
@@ -31,7 +34,7 @@ public class StatefulContext implements MappingCreatorContext {
 
     private static final Logger LOGGER = Logger.getLogger(StatefulContext.class);
 
-    private final Map<FieldMetadata, String> enforcedUniqueNames = new HashMap<FieldMetadata, String>();
+    private final Map<String, String> enforcedUniqueNames = new HashMap<String, String>();
 
     private final AtomicInteger uniqueInheritanceCounter = new AtomicInteger();
 
@@ -43,18 +46,18 @@ public class StatefulContext implements MappingCreatorContext {
 
     @Override
     public String getFieldColumn(FieldMetadata field) {
+
         if (!field.getContainingType().getSuperTypes().isEmpty() && !field.getContainingType().isInstantiable()) {
             boolean isUnique = isUniqueWithinTypeHierarchy(field.getContainingType(), field.getName());
             boolean isExistEntity = isExistInSameEntity(field);
             if (field.getDeclaringType().equals(field.getContainingType()) && !isUnique && !isExistEntity) {
                 // Non instantiable types are mapped using a "table per hierarchy" strategy, if field name isn't unique
-                // make sure name becomes unique to avoid conflict (Hibernate doesn't issue warning/errors in case of
-                // overlap).
+                // make sure name becomes unique to avoid conflict (Hibernate doesn't issue warning/errors in case of overlap).
                 synchronized (enforcedUniqueNames) {
-                    String enforcedUniqueName = enforcedUniqueNames.get(field);
+                    String enforcedUniqueName = enforcedUniqueNames.get(getQualifiedKey(field));
                     if (enforcedUniqueName == null) {
                         enforcedUniqueName = getFieldColumn(field.getName()) + uniqueInheritanceCounter.incrementAndGet();
-                        enforcedUniqueNames.put(field, enforcedUniqueName);
+                        enforcedUniqueNames.put(getQualifiedKey(field), enforcedUniqueName);
                     }
                     return enforcedUniqueName;
                 }
@@ -66,19 +69,70 @@ public class StatefulContext implements MappingCreatorContext {
         }
     }
 
+    /**
+     * return the specific format key, that composed of namespace and name of subType, plus namespace and name of top
+     * level base type. like <code>sub_namespace_student/sub_name_student/base_namespace_person/base_name_person</code>
+     * the new key only is using reusable type.
+     *
+     * @param field : A field's Metadata
+
+     * @return: the actual key info
+     */
+    private static String getQualifiedKey(FieldMetadata field) {
+        String key = field.toString();
+        ComplexTypeMetadata type = field.getContainingType();
+        if (type == null) {
+            return key;
+        }
+        ComplexTypeMetadata topLevelType = (ComplexTypeMetadata) MetadataUtils.getSuperConcreteType(type);
+        boolean isDupFKName = false;
+
+        Collection<ComplexTypeMetadata> subTypeSet = topLevelType.getSubTypes().stream()
+                .filter(item -> !item.getName().equals(field.getDeclaringType().getName())).collect(Collectors.toList());
+        outloop: for (ComplexTypeMetadata subType : subTypeSet) {
+            for (FieldMetadata fieldMetadata : subType.getFields()) {
+                if (fieldMetadata instanceof ReferenceFieldMetadata && ((ReferenceFieldMetadata) fieldMetadata).isFKIntegrity()
+                        && fieldMetadata.getName().equals(field.getName())) {
+                    isDupFKName = true;
+                    break outloop;
+                }
+            }
+        }
+
+        if (type instanceof ContainedComplexTypeMetadata && isDupFKName) {
+            ComplexTypeMetadata containedType = ((ContainedComplexTypeMetadata) type).getContainedType();
+            key = String.join("/", containedType.getNamespace(), containedType.getName(), topLevelType.getNamespace(), topLevelType.getName());
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("The current qualified key is " + key);
+        }
+        return key;
+    }
+
     private static boolean isExistInSameEntity(FieldMetadata field) {
         ComplexTypeMetadata type = field.getContainingType();
+
         if (type == null) {
             return false;
         }
-        ComplexTypeMetadata topLevelType = (ComplexTypeMetadata) MetadataUtils.getSuperConcreteType(type);
+        ComplexTypeMetadata topType = (ComplexTypeMetadata) MetadataUtils.getSuperConcreteType(type);
+        int expectedLength = 18;
         if (type.getContainer() != null && type.getContainer().getContainingType() != null) {
             String curName = type.getContainer().getContainingType().getName();
+
             if (StringUtils.isEmpty(curName)) {
                 return false;
             }
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("The current containType name of field is " + curName);
+            }
+            String rawTypeName = type.getContainer().getType().getName();
+            //If the current field's type is the same with it's super type name, return true.
+            if (topType.getName().equals(rawTypeName) && curName.length() == expectedLength) {
+                return true;
+            }
             Boolean isSameName = null;
-            boolean isExist = topLevelType.getSubTypes().stream()
+            boolean isExist = topType.getSubTypes().stream()
                     .anyMatch(action -> action.getUsages().stream().anyMatch(item -> {
                         if (item.getContainer() != null && item.getContainer().getContainingType() != null) {
                             return curName.equals(item.getContainer().getContainingType().getName());
@@ -87,7 +141,8 @@ public class StatefulContext implements MappingCreatorContext {
                         }
                     }));
             if (isExist) {
-                isSameName = topLevelType.getSubTypes().stream().anyMatch(action -> action.getFields().stream().anyMatch(
+                //This logic code only use in RTE DM
+                isSameName = topType.getSubTypes().stream().anyMatch(action -> action.getFields().stream().anyMatch(
                         item -> !item.equals(field) && !item.getContainingType().equals(field.getContainingType())
                                 && field.getContainingType().getUsages().size() == item.getContainingType().getUsages().size()
                                 && item.getName().equals(field.getName())));

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -4173,6 +4173,106 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("[2]", evaluate(committedElement, "/organisation/fkServices[1]"));
     }
 
+    public void test13587_SaveForeignKeyForReusableType() throws Exception {
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata23.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("testab", repository);
+        SaverSource source = new TestSaverSource(repository, false, "", "metadata23.xsd");
+
+        //Case 1 add record for entity TestA as fk using in below entity TestB and TestC.
+        SaverSession session = SaverSession.newSession(source);
+        InputStream recordXml = new ByteArrayInputStream(("<TestA><Id>11</Id></TestA>").getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().create("testab", "testab", "Source", recordXml, true, true, true, false, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        //case 2, add record for entity TestB with reusable type BaseType
+        session = SaverSession.newSession(source);
+        recordXml = new ByteArrayInputStream(("<TestB><Id>1</Id><DocterField><BaseField xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"BaseType\"><TestA_FK>[11]</TestA_FK></BaseField><Basename>b1</Basename></DocterField></TestB>").getBytes("UTF-8"));
+        context = session.getContextFactory().create("testab", "testab", "Source", recordXml, true, true, true, false, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/TestB/Id"));
+        assertEquals("[11]", evaluate(committedElement, "/TestB/DocterField/BaseField/TestA_FK"));
+
+        //case 3, add record for entity TestB with reusable type FirstType
+        session = SaverSession.newSession(source);
+        recordXml = new ByteArrayInputStream(("<TestB><Id>2</Id><DocterField><BaseField xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"FirstType\"><TestA_FK>[11]</TestA_FK></BaseField><Basename>b2</Basename></DocterField></TestB>").getBytes("UTF-8"));
+        context = session.getContextFactory().create("testab", "testab", "Source", recordXml, true, true, true, false, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("2", evaluate(committedElement, "/TestB/Id"));
+        assertEquals("[11]", evaluate(committedElement, "/TestB/DocterField/BaseField/TestA_FK"));
+
+        //case 4, add record for entity TestB with reusable type SecondType
+        session = SaverSession.newSession(source);
+        recordXml = new ByteArrayInputStream(("<TestB><Id>3</Id><DocterField><BaseField xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"SecondType\"><TestA_FK>[11]</TestA_FK></BaseField><Basename>b3</Basename></DocterField></TestB>").getBytes("UTF-8"));
+        context = session.getContextFactory().create("testab", "testab", "Source", recordXml, true, true, true, false, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("3", evaluate(committedElement, "/TestB/Id"));
+        assertEquals("[11]", evaluate(committedElement, "/TestB/DocterField/BaseField/TestA_FK"));
+
+        //case 5, add record for entity TestC with reusable type BaseType
+        session = SaverSession.newSession(source);
+        recordXml = new ByteArrayInputStream(("<TestC><Id>1</Id><DocterField><BaseField xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"BaseType\"><TestA_FK>[11]</TestA_FK></BaseField><Basename>b1</Basename></DocterField></TestC>").getBytes("UTF-8"));
+        context = session.getContextFactory().create("testab", "testab", "Source", recordXml, true, true, true, false, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/TestC/Id"));
+        assertEquals("[11]", evaluate(committedElement, "/TestC/DocterField/BaseField/TestA_FK"));
+
+        //case 6, add record for entity TestC with reusable type FirstType
+        session = SaverSession.newSession(source);
+        recordXml = new ByteArrayInputStream(("<TestC><Id>2</Id><DocterField><BaseField xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"FirstType\"><TestA_FK>[11]</TestA_FK></BaseField><Basename>b2</Basename></DocterField></TestC>").getBytes("UTF-8"));
+        context = session.getContextFactory().create("testab", "testab", "Source", recordXml, true, true, true, false, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("2", evaluate(committedElement, "/TestC/Id"));
+        assertEquals("[11]", evaluate(committedElement, "/TestC/DocterField/BaseField/TestA_FK"));
+
+        //case 7, add record for entity TestC with reusable type SecondType
+        session = SaverSession.newSession(source);
+        recordXml = new ByteArrayInputStream(("<TestC><Id>3</Id><DocterField><BaseField xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"SecondType\"><TestA_FK>[11]</TestA_FK></BaseField><Basename>b3</Basename></DocterField></TestC>").getBytes("UTF-8"));
+        context = session.getContextFactory().create("testab", "testab", "Source", recordXml, true, true, true, false, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("3", evaluate(committedElement, "/TestC/Id"));
+        assertEquals("[11]", evaluate(committedElement, "/TestC/DocterField/BaseField/TestA_FK"));
+    }
+
     private static class MockCommitter implements SaverSession.Committer {
 
         private MutableDocument lastSaved;

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/metadata23.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/metadata23.xsd
@@ -1,0 +1,172 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:complexType name="PersonType">
+        <xsd:sequence />
+    </xsd:complexType>
+    <xsd:complexType name="StudentType">
+        <xsd:complexContent>
+            <xsd:extension base="PersonType">
+                <xsd:sequence />
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="MasterType">
+        <xsd:complexContent>
+            <xsd:extension base="StudentType">
+                <xsd:sequence />
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="DocterType">
+        <xsd:complexContent>
+            <xsd:extension base="MasterType">
+                <xsd:sequence>
+                    <xsd:element maxOccurs="1" minOccurs="1"
+                        name="BaseField" type="BaseType">
+                        <xsd:annotation>
+                            <xsd:appinfo source="X_Write">Demo_Manager
+                            </xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element maxOccurs="1" minOccurs="1"
+                        name="Basename" type="xsd:string">
+                        <xsd:annotation>
+                            <xsd:appinfo source="X_Write">Demo_Manager
+                            </xsd:appinfo>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="BaseType">
+        <xsd:sequence>
+            <xsd:element maxOccurs="1" minOccurs="1"
+                name="TestA_FK" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_ForeignKey">TestA/Id
+                    </xsd:appinfo>
+                    <xsd:appinfo
+                        source="X_ForeignKey_NotSep">true</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager
+                    </xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="TestA">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1"
+                    name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="TestA">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="TestB">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1"
+                    name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1"
+                    name="DocterField" type="DocterType">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="TestB">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="TestC">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1"
+                    name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1"
+                    name="DocterField" type="DocterType">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="TestC">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="FirstType">
+        <xsd:complexContent>
+            <xsd:extension base="BaseType">
+                <xsd:sequence />
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="SecondType">
+        <xsd:complexContent>
+            <xsd:extension base="BaseType">
+                <xsd:sequence />
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:element name="TestD">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1"
+                    name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1"
+                    name="FirstField" type="SecondType">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager
+                        </xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="TestD">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13587
What is the current behavior?** (You should also link to an open issue here)
Can't save the FK under the reusable type, The key point is the column FK don't be mapped correctly when creating a Java Class object in memory based on the Hibernate mapping file.

**What is the new behavior?**
Modified the snippet of code to generate the correct column name, then can save the FK under the reusable type.

**Please check if the PR fulfills these requirements**

- [*] The commit message follows Talend standard
- [*] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [*] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [*] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
