### PR TITLE
TMDM-13545 [REST] GET /data/{containerName}/{type}/{id} with datetime fails

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test77.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test77.xml
@@ -1,0 +1,21 @@
+<!--
+  ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+  ~ 92150 Suresnes, France
+  -->
+
+<Contract xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <id>4</id>
+    <comment/>
+    <detail xsi:type="ContractDetailType">
+        <code>code-1</code>
+    </detail>
+    <detail xsi:type="ContractDetailType">
+        <code>code-1</code>
+    </detail>
+    <enumEle/>
+</Contract>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test77_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test77_original.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<!--
+  ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+  ~ 92150 Suresnes, France
+  -->
+
+<ii>
+    <c>Contract</c>
+    <n>Contract</n>
+    <dmn>Contract</dmn>
+    <i>231035933</i>
+    <t>1327653438644</t>
+    <p>
+        <Contract xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <id>4</id>
+            <comment/>
+            <detail xsi:type="ContractDetailType">
+                <code>code-1</code>
+            </detail>
+            <enumEle/>
+        </Contract>
+    </p>
+</ii>

--- a/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/DataRecordAccessor.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/DataRecordAccessor.java
@@ -231,9 +231,14 @@ public class DataRecordAccessor implements Accessor {
                                 // If specified type is not null, means the field changed the type
                                 // need to get the correct type from subTypes and instantiate a new DataRecord object
                                 if (specifiedType != null) {
-                                    ComplexTypeMetadata complexTypeMetadata = ((ContainedTypeFieldMetadata) field)
-                                            .getContainedType().getSubTypes().stream()
-                                            .filter(item -> item.getName().equals(specifiedType)).findFirst().get();
+                                    ComplexTypeMetadata complexTypeMetadata;
+                                    if (((ContainedTypeFieldMetadata) field).getContainedType().getName().equals(specifiedType)) {
+                                        complexTypeMetadata = ((ContainedTypeFieldMetadata) field).getContainedType();
+                                    } else {
+                                        complexTypeMetadata = ((ContainedTypeFieldMetadata) field).getContainedType()
+                                                .getSubTypes().stream().filter(item -> item.getName().equals(specifiedType))
+                                                .findFirst().get();
+                                    }
                                     record = new DataRecord(complexTypeMetadata, UnsupportedDataRecordMetadata.INSTANCE);
                                 } else {
                                     record = new DataRecord((ComplexTypeMetadata) field.getType(),

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
@@ -56,7 +56,7 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
 
     private static final Logger LOGGER = Logger.getLogger(UpdateActionCreator.class);
 
-    protected final LinkedList<Action> actions = new LinkedList<Action>();
+    protected final LinkedList<Action> actions = new LinkedList<>();
 
     protected final Date date;
 
@@ -72,13 +72,13 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
 
     protected final MetadataRepository repository;
 
-    private final Stack<String> path = new Stack<String>();
+    private final Stack<String> path = new Stack<>();
 
     private final Closure closure = new CompareClosure();
 
-    private final Set<String> touchedPaths = new HashSet<String>();
+    private final Set<String> touchedPaths = new HashSet<>();
 
-    private final Map<FieldMetadata, Integer> invertedIndex = new HashMap<FieldMetadata, Integer>();
+    private final Map<FieldMetadata, Integer> invertedIndex = new HashMap<>();
 
     protected final boolean preserveCollectionOldValues;
 
@@ -90,7 +90,7 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
     
     private boolean isPartialDelete = false;
 
-    private List<String> visitedOneToManyPath = new ArrayList<String>();
+    private List<String> visitedOneToManyPath = new ArrayList<>();
 
     private String rootTypeName = null;
 
@@ -492,7 +492,10 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
                         throw new IllegalArgumentException("Type '" + field.getType().getName()
                                 + "' is not assignable from type '" + newTypeMetadata.getName() + "'");
                     }
-                    if (!newType.equals(previousType) && (!newTypeMetadata.getSuperTypes().isEmpty() || !newTypeMetadata.getSubTypes().isEmpty())) {
+                    boolean isSuperType = newTypeMetadata.getSuperTypes().isEmpty() && !newTypeMetadata.getSubTypes().isEmpty();
+                    boolean addedCreateSuperType = previousType.isEmpty() && isSuperType;
+                    boolean isInherit = !newTypeMetadata.getSuperTypes().isEmpty() || !newTypeMetadata.getSubTypes().isEmpty();
+                    if (!addedCreateSuperType && !newType.equals(previousType) && isInherit) {
                         actions.addAll(ChangeTypeAction.create(originalDocument, date, source, userName, getLeftPath(), previousTypeMetadata, newTypeMetadata, field, userAction));
                     } else if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Ignore type change on '" + getLeftPath() + "': type '" + newTypeMetadata.getName() + "' does not belong to an inheritance tree.");


### PR DESCRIPTION
JIRA: https://jira.talendforge.org/browse/TMDM-13545

**What is the current behavior?** (You should also link to an open issue here)
After modified data, invoke the API to save it, the post content is difference for add new detail and clone it:
added:
```
<Contract xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <id>4</id>
    <comment/>
    <detail xsi:type="ContractDetailType">
        <code>code-1</code>
    </detail>
    <detail>
        <code>code-1</code>
    </detail>
    <enumEle/>
</Contract>
```
Clone:
```
<Contract xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    <id>4</id>
    <comment/>
    <detail xsi:type="ContractDetailType">
        <code>code-1</code>
    </detail>
    <detail xsi:type="ContractDetailType">
        <code>code-1</code>
    </detail>
    <enumEle/>
</Contract>
```
For this difference, contains two issues:

1. doesn't get the correcnt type if the type is supber.
2. it would be create one ChangeTypeAction.


**What is the new behavior?**
1. if the specified type is equaled current field contained, doesn't fetched from the sub type.
reference code in DataRecordAccessor.java :
```
ComplexTypeMetadata complexTypeMetadata;
if (((ContainedTypeFieldMetadata) field).getContainedType().getName().equals(specifiedType)) {
	complexTypeMetadata = ((ContainedTypeFieldMetadata) field).getContainedType();
} else {
	complexTypeMetadata = ((ContainedTypeFieldMetadata) field).getContainedType()
			.getSubTypes().stream().filter(item -> item.getName().equals(specifiedType))
			.findFirst().get();
}
```
2. If the current type is super type and is a new added item, it doesn't create ChangeTypeAction
reference code in UpdateActionCreator.java
```
boolean isSuperType = newTypeMetadata.getSuperTypes().isEmpty() && !newTypeMetadata.getSubTypes().isEmpty();
boolean addedCreateSuperType = previousType.isEmpty() && isSuperType;
boolean isInherit = !newTypeMetadata.getSuperTypes().isEmpty() || !newTypeMetadata.getSubTypes().isEmpty();
if (!addedCreateSuperType && !newType.equals(previousType) && isInherit) {
    actions.addAll(ChangeTypeAction.create(originalDocument, date, source, userName, getLeftPath(), previousTypeMetadata, newTypeMetadata, field, userAction));
} else if (LOGGER.isDebugEnabled()) {
    LOGGER.debug("Ignore type change on '" + getLeftPath() + "': type '" + newTypeMetadata.getName() + "' does not belong to an inheritance tree.");
}
```

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
