### PR TITLE
TMDM-13810 [REST] Get a data record by id with datetime for inheritance type fails

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -780,12 +780,7 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("Information/MoreInfo[1]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.fr", newValue);
+        assertUpdateReportAction(doc, 1, "Information/MoreInfo[1]", "", "http://www.mynewsite.fr");
     }
 
     public void testPartialUpdateWithOverwriteEqFalseOneToThree() throws Exception {
@@ -815,26 +810,9 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("Information/MoreInfo[4]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.cn", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("Information/MoreInfo[3]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.com", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("Information/MoreInfo[2]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.fr", newValue);
+        assertUpdateReportAction(doc, 1, "Information/MoreInfo[4]", "", "http://www.mynewsite.cn");
+        assertUpdateReportAction(doc, 2, "Information/MoreInfo[3]", "", "http://www.mynewsite.com");
+        assertUpdateReportAction(doc, 3, "Information/MoreInfo[2]", "", "http://www.mynewsite.fr");
     }
 
     public void testPartialUpdateSameCountWithOverwriteFalse() throws Exception {
@@ -865,19 +843,8 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("Information/MoreInfo[4]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.com", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("Information/MoreInfo[3]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.fr", newValue);
+        assertUpdateReportAction(doc, 1, "Information/MoreInfo[4]", "", "http://www.mynewsite.com");
+        assertUpdateReportAction(doc, 2, "Information/MoreInfo[3]", "", "http://www.mynewsite.fr");
     }
 
     public void testPartialUpdateLessCountWithOverwriteFalse() throws Exception {
@@ -909,19 +876,8 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("Information/MoreInfo[5]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.com", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("Information/MoreInfo[4]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.mynewsite.fr", newValue);
+        assertUpdateReportAction(doc, 1, "Information/MoreInfo[5]", "", "http://www.mynewsite.com");
+        assertUpdateReportAction(doc, 2, "Information/MoreInfo[4]", "", "http://www.mynewsite.fr");
     }
 
     public void testPartialUpdateWithOverwriteEqualsTrue() throws Exception {
@@ -1458,20 +1414,9 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("detail[2]/@xsi:type", path);
         assertEquals("", oldValue);
         assertEquals("ContractDetailSubType", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("detail[2]/code", path);
-        assertEquals("", oldValue);
-        assertEquals("sdfsdf", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("detail[2]/features/actor", path);
-        assertEquals("", oldValue);
-        assertEquals("sdfsdf", newValue);
+        assertUpdateReportAction(doc, 1, "detail[2]/@xsi:type", "", "ContractDetailSubType");
+        assertUpdateReportAction(doc, 2, "detail[2]/code", "", "sdfsdf");
+        assertUpdateReportAction(doc, 3, "detail[2]/features/actor", "", "sdfsdf");
     }
 
 
@@ -1503,12 +1448,7 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("detail[2]/code", path);
-        assertEquals("", oldValue);
-        assertEquals("code-1", newValue);
+        assertUpdateReportAction(doc, 1, "detail[2]/code", "", "code-1");
     }
 
     public void testWithChangeSubTypeToSuperType() throws Exception {
@@ -1536,54 +1476,13 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("detail[1]/features/vendor", path);
-        assertEquals("[vendor-1-1]", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("detail[1]/features/boolValue", path);
-        assertEquals("true", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("detail[1]/features/actor", path);
-        assertEquals("actor-1", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
-        assertEquals("detail[1]/features", path);
-        assertEquals("", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[5]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/newValue");
-        assertEquals("detail[1]/ReadOnlyEle", path);
-        assertEquals("[1]", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[6]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/newValue");
-        assertEquals("detail[1]/@xsi:type", path);
-        assertEquals("ContractDetailSubType", oldValue);
-        assertEquals("ContractDetailType", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[7]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/newValue");
-        assertEquals("detail[1]/code", path);
-        assertEquals("code-1", oldValue);
-        assertEquals("sdfsdf", newValue);
+        assertUpdateReportAction(doc, 1, "detail[1]/features/vendor", "[vendor-1-1]", "");
+        assertUpdateReportAction(doc, 2, "detail[1]/features/boolValue", "true", "");
+        assertUpdateReportAction(doc, 3, "detail[1]/features/actor", "actor-1", "");
+        assertUpdateReportAction(doc, 4, "detail[1]/features", "", "");
+        assertUpdateReportAction(doc, 5, "detail[1]/ReadOnlyEle", "[1]", "");
+        assertUpdateReportAction(doc, 6, "detail[1]/@xsi:type", "ContractDetailSubType", "ContractDetailType");
+        assertUpdateReportAction(doc, 7, "detail[1]/code", "code-1", "sdfsdf");
     }
 
     public void testSubclassTypeChange() throws Exception {
@@ -1631,58 +1530,17 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("cccccc", evaluate(committedElement, "/Contract/detail[1]/code"));
         assertEquals("sdfsdf", evaluate(committedElement, "/Contract/detail[1]/features/actor"));
 
-        //TODO this is change detail from ContractDetailType to ContractDetailSubType
+        //this is change detail from ContractDetailType to ContractDetailSubType
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("detail[1]/@xsi:type", path);
-        assertEquals("ContractDetailType", oldValue);
-        assertEquals("ContractDetailSubType", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("detail[1]/code", path);
-        assertEquals("sdfsdf", oldValue);
-        assertEquals("cccccc", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("detail[1]/features/actor", path);
-        assertEquals("", oldValue);
-        assertEquals("sdfsdf", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
-        assertEquals("detail[1]/features/vendor[1]", path);
-        assertEquals("", oldValue);
-        assertEquals("sdf", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[5]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/newValue");
-        assertEquals("detail[1]/features/boolValue", path);
-        assertEquals("", oldValue);
-        assertEquals("true", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[6]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/newValue");
-        assertEquals("detail[1]/ReadOnlyEle[1]", path);
-        assertEquals("", oldValue);
-        assertEquals("sdf", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[7]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/newValue");
-        assertEquals("detail[1]/boolTest", path);
-        assertEquals("", oldValue);
-        assertEquals("true", newValue);
+        assertUpdateReportAction(doc, 1, "detail[1]/@xsi:type", "ContractDetailType", "ContractDetailSubType");
+        assertUpdateReportAction(doc, 2, "detail[1]/code", "sdfsdf", "cccccc");
+        assertUpdateReportAction(doc, 3, "detail[1]/features/actor", "", "sdfsdf");
+        assertUpdateReportAction(doc, 4, "detail[1]/features/vendor[1]", "", "sdf");
+        assertUpdateReportAction(doc, 5, "detail[1]/features/boolValue", "", "true");
+        assertUpdateReportAction(doc, 6, "detail[1]/ReadOnlyEle[1]", "", "sdf");
+        assertUpdateReportAction(doc, 7, "detail[1]/boolTest", "", "true");
     }
 
     public void testUpdateSequence() throws Exception {
@@ -1973,33 +1831,10 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("comment[1]", path);
-        assertEquals("comment-original", oldValue);
-        assertEquals("comment-new", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("detail[1]/@xsi:type", path);
-        assertEquals("ContractDetailType", oldValue);
-        assertEquals("ContractDetailSubType", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("detail[1]/code", path);
-        assertEquals("code-original", oldValue);
-        assertEquals("code-new", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
-        assertEquals("detail[1]/features/actor", path);
-        assertEquals("", oldValue);
-        assertEquals("actor-new", newValue);
+        assertUpdateReportAction(doc, 1, "comment[1]", "comment-original", "comment-new");
+        assertUpdateReportAction(doc, 2, "detail[1]/@xsi:type", "ContractDetailType", "ContractDetailSubType");
+        assertUpdateReportAction(doc, 3, "detail[1]/code", "code-original", "code-new");
+        assertUpdateReportAction(doc, 4, "detail[1]/features/actor", "", "actor-new");
     }
 
     public void testUpdateReportForContractRemoveOneDetail() throws Exception {
@@ -2028,68 +1863,15 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("comment[1]", path);
-        assertEquals("comment-original", oldValue);
-        assertEquals("comment-new", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("detail[2]/code", path);
-        assertEquals("bb-1", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("detail[2]/features/actor", path);
-        assertEquals("bb-2", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
-        assertEquals("detail[2]/features/vendor[1]", path);
-        assertEquals("bb-3", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[5]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/newValue");
-        assertEquals("detail[2]/features/boolValue", path);
-        assertEquals("true", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[6]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/newValue");
-        assertEquals("detail[2]/features", path);
-        assertEquals("", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[7]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/newValue");
-        assertEquals("detail[2]/ReadOnlyEle[1]", path);
-        assertEquals("readOnlyEle-two", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[8]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[8]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[8]/newValue");
-        assertEquals("detail[2]/boolTest", path);
-        assertEquals("true", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[9]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[9]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[9]/newValue");
-        assertEquals("detail[2]/@xsi:type", path);
-        assertEquals("ContractDetailSubType", oldValue);
-        assertEquals("", newValue);
+        assertUpdateReportAction(doc, 1, "comment[1]", "comment-original", "comment-new");
+        assertUpdateReportAction(doc, 2, "detail[2]/code", "bb-1", "");
+        assertUpdateReportAction(doc, 3, "detail[2]/features/actor", "bb-2", "");
+        assertUpdateReportAction(doc, 4, "detail[2]/features/vendor[1]", "bb-3", "");
+        assertUpdateReportAction(doc, 5, "detail[2]/features/boolValue", "true", "");
+        assertUpdateReportAction(doc, 6, "detail[2]/features", "", "");
+        assertUpdateReportAction(doc, 7, "detail[2]/ReadOnlyEle[1]", "readOnlyEle-two", "");
+        assertUpdateReportAction(doc, 8, "detail[2]/boolTest", "true", "");
+        assertUpdateReportAction(doc, 9, "detail[2]/@xsi:type", "ContractDetailSubType", "");
     }
 
     public void testUpdateReportChangeToSuperTypeAction() throws Exception {
@@ -2118,69 +1900,15 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument2 = context2.getUpdateReportDocument();
         assertNotNull(updateReportDocument2);
         Document doc = updateReportDocument2.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("comment[1]", path);
-        assertEquals("comment-original", oldValue);
-        assertEquals("comment-new", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("detail[1]/features/vendor", path);
-        assertEquals("[vendor-original]", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("detail[1]/features/boolValue", path);
-        assertEquals("true", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
-        assertEquals("detail[1]/features/actor", path);
-        assertEquals("actor-original", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[5]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/newValue");
-        assertEquals("detail[1]/features", path);
-        assertEquals("", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[6]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/newValue");
-        assertEquals("detail[1]/boolTest", path);
-        assertEquals("true", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[7]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/newValue");
-        assertEquals("detail[1]/ReadOnlyEle", path);
-        assertEquals("[readOnlyEle-original]", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[8]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[8]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[8]/newValue");
-        assertEquals("detail[1]/@xsi:type", path);
-        assertEquals("ContractDetailSubType", oldValue);
-        assertEquals("ContractDetailType", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[9]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[9]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[9]/newValue");
-        assertEquals("detail[1]/code", path);
-        assertEquals("code-original", oldValue);
-        assertEquals("code-new", newValue);
-
+        assertUpdateReportAction(doc, 1, "comment[1]", "comment-original", "comment-new");
+        assertUpdateReportAction(doc, 2, "detail[1]/features/vendor", "[vendor-original]", "");
+        assertUpdateReportAction(doc, 3, "detail[1]/features/boolValue", "true", "");
+        assertUpdateReportAction(doc, 4, "detail[1]/features/actor", "actor-original", "");
+        assertUpdateReportAction(doc, 5, "detail[1]/features", "", "");
+        assertUpdateReportAction(doc, 6, "detail[1]/boolTest", "true", "");
+        assertUpdateReportAction(doc, 7, "detail[1]/ReadOnlyEle", "[readOnlyEle-original]", "");
+        assertUpdateReportAction(doc, 8, "detail[1]/@xsi:type", "ContractDetailSubType", "ContractDetailType");
+        assertUpdateReportAction(doc, 9, "detail[1]/code", "code-original", "code-new");
     }
 
     public void testUpdateFKToSuperType() throws Exception {
@@ -2597,35 +2325,13 @@ public class DocumentSaveTest extends TestCase {
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();
-        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
-        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
-        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
-        assertEquals("Name", path);
-        assertEquals("name1", oldValue);
-        assertEquals("beforeSaving_Agency", newValue);
 
-        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
-        assertEquals("City", path);
-        assertEquals("city1", oldValue);
-        assertEquals("Chicago", newValue);
+        assertUpdateReportAction(doc, 1, "Name", "name1", "beforeSaving_Agency");
+        assertUpdateReportAction(doc, 2, "City", "city1", "Chicago");
+        assertUpdateReportAction(doc, 3, "State", "ME", "");
+        assertUpdateReportAction(doc, 4, "Information/MoreInfo[2]", "", "http://www.newSite2.org");
 
-        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
-        assertEquals("State", path);
-        assertEquals("ME", oldValue);
-        assertEquals("", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
-        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
-        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
-        assertEquals("Information/MoreInfo[2]", path);
-        assertEquals("", oldValue);
-        assertEquals("http://www.newSite2.org", newValue);
-
-        path = (String) evaluate(doc.getDocumentElement(), "OperationType");
+        String path = (String) evaluate(doc.getDocumentElement(), "OperationType");
         assertEquals("UPDATE", path);
 
         MockCommitter committer = new MockCommitter();
@@ -4695,6 +4401,16 @@ public class DocumentSaveTest extends TestCase {
         committedElement = committer.getCommittedElement();
         assertEquals("3", evaluate(committedElement, "/TestC/Id"));
         assertEquals("[11]", evaluate(committedElement, "/TestC/DocterField/BaseField/TestA_FK"));
+    }
+
+    private void assertUpdateReportAction(Document doc, int index, String expectedPath, String expectedOldValue,
+            String expectedNewValue) throws Exception {
+        String path = (String) evaluate(doc.getDocumentElement(), "Item[" + index + "]/path");
+        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[" + index + "]/oldValue");
+        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[" + index + "]/newValue");
+        assertEquals(expectedPath, path);
+        assertEquals(expectedOldValue, oldValue);
+        assertEquals(expectedNewValue, newValue);
     }
 
     private static class MockCommitter implements SaverSession.Committer {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -1530,7 +1530,7 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("cccccc", evaluate(committedElement, "/Contract/detail[1]/code"));
         assertEquals("sdfsdf", evaluate(committedElement, "/Contract/detail[1]/features/actor"));
 
-        //this is change detail from ContractDetailType to ContractDetailSubType
+        // this is change detail from ContractDetailType to ContractDetailSubType
         MutableDocument updateReportDocument = context.getUpdateReportDocument();
         assertNotNull(updateReportDocument);
         Document doc = updateReportDocument.asDOM();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -1447,7 +1447,34 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("ContractDetailSubType", evaluate(committedElement, "/Contract/detail[2]/@xsi:type"));
         assertEquals("sdfsdf", evaluate(committedElement, "/Contract/detail[2]/code"));
         assertEquals("sdfsdf", evaluate(committedElement, "/Contract/detail[2]/features/actor"));
+
+        // this is the add one ContractDetailSubType, need to add the update report test
+        MutableDocument updateReportDocument = context.getUpdateReportDocument();
+        assertNotNull(updateReportDocument);
+        Document doc = updateReportDocument.asDOM();
+        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
+        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
+        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
+        assertEquals("detail[2]/@xsi:type", path);
+        assertEquals("", oldValue);
+        assertEquals("ContractDetailSubType", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
+        assertEquals("detail[2]/code", path);
+        assertEquals("", oldValue);
+        assertEquals("sdfsdf", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
+        assertEquals("detail[2]/features/actor", path);
+        assertEquals("", oldValue);
+        assertEquals("sdfsdf", newValue);
     }
+
+
 
     public void testWithCloneSuperType() throws Exception {
         MetadataRepository repository = new MetadataRepository();
@@ -1482,6 +1509,81 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("detail[2]/code", path);
         assertEquals("", oldValue);
         assertEquals("code-1", newValue);
+    }
+
+    public void testWithChangeSubTypeToSuperType() throws Exception {
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata3.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("Contract", repository);
+
+        SaverSource source = new TestSaverSource(repository, true, "test78_original.xml", "metadata3.xsd");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream recordXml = DocumentSaveTest.class.getResourceAsStream("test78.xml");
+        DocumentSaverContext context = session.getContextFactory().create("MDM", "Contract", "Source", recordXml, false, true,
+                true, false, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        assertEquals("ContractDetailType", evaluate(committedElement, "/Contract/detail[1]/@xsi:type"));
+        assertEquals("sdfsdf", evaluate(committedElement, "/Contract/detail[1]/code"));
+
+        // test update report
+        MutableDocument updateReportDocument = context.getUpdateReportDocument();
+        assertNotNull(updateReportDocument);
+        Document doc = updateReportDocument.asDOM();
+        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
+        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
+        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
+        assertEquals("detail[1]/features/vendor", path);
+        assertEquals("[vendor-1-1]", oldValue);
+        assertEquals("", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
+        assertEquals("detail[1]/features/boolValue", path);
+        assertEquals("true", oldValue);
+        assertEquals("", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
+        assertEquals("detail[1]/features/actor", path);
+        assertEquals("actor-1", oldValue);
+        assertEquals("", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
+        assertEquals("detail[1]/features", path);
+        assertEquals("", oldValue);
+        assertEquals("", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[5]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/newValue");
+        assertEquals("detail[1]/ReadOnlyEle", path);
+        assertEquals("[1]", oldValue);
+        assertEquals("", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[6]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/newValue");
+        assertEquals("detail[1]/@xsi:type", path);
+        assertEquals("ContractDetailSubType", oldValue);
+        assertEquals("ContractDetailType", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[7]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/newValue");
+        assertEquals("detail[1]/code", path);
+        assertEquals("code-1", oldValue);
+        assertEquals("sdfsdf", newValue);
     }
 
     public void testSubclassTypeChange() throws Exception {
@@ -1528,6 +1630,59 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("ContractDetailSubType", evaluate(committedElement, "/Contract/detail[1]/@xsi:type"));
         assertEquals("cccccc", evaluate(committedElement, "/Contract/detail[1]/code"));
         assertEquals("sdfsdf", evaluate(committedElement, "/Contract/detail[1]/features/actor"));
+
+        //TODO this is change detail from ContractDetailType to ContractDetailSubType
+        MutableDocument updateReportDocument = context.getUpdateReportDocument();
+        assertNotNull(updateReportDocument);
+        Document doc = updateReportDocument.asDOM();
+        String path = (String) evaluate(doc.getDocumentElement(), "Item[1]/path");
+        String oldValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/oldValue");
+        String newValue = (String) evaluate(doc.getDocumentElement(), "Item[1]/newValue");
+        assertEquals("detail[1]/@xsi:type", path);
+        assertEquals("ContractDetailType", oldValue);
+        assertEquals("ContractDetailSubType", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[2]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[2]/newValue");
+        assertEquals("detail[1]/code", path);
+        assertEquals("sdfsdf", oldValue);
+        assertEquals("cccccc", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[3]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[3]/newValue");
+        assertEquals("detail[1]/features/actor", path);
+        assertEquals("", oldValue);
+        assertEquals("sdfsdf", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[4]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[4]/newValue");
+        assertEquals("detail[1]/features/vendor[1]", path);
+        assertEquals("", oldValue);
+        assertEquals("sdf", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[5]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[5]/newValue");
+        assertEquals("detail[1]/features/boolValue", path);
+        assertEquals("", oldValue);
+        assertEquals("true", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[6]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[6]/newValue");
+        assertEquals("detail[1]/ReadOnlyEle[1]", path);
+        assertEquals("", oldValue);
+        assertEquals("sdf", newValue);
+
+        path = (String) evaluate(doc.getDocumentElement(), "Item[7]/path");
+        oldValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/oldValue");
+        newValue = (String) evaluate(doc.getDocumentElement(), "Item[7]/newValue");
+        assertEquals("detail[1]/boolTest", path);
+        assertEquals("", oldValue);
+        assertEquals("true", newValue);
     }
 
     public void testUpdateSequence() throws Exception {

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test78.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test78.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+  ~ 92150 Suresnes, France
+  -->
+
+<Contract xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <id>2</id>
+    <comment/>
+    <detail xsi:type="ContractDetailType">
+        <code>sdfsdf</code>
+    </detail>
+    <enumEle/>
+</Contract>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test78_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test78_original.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<!--
+  ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+  ~ 92150 Suresnes, France
+  -->
+
+<ii>
+    <c>Contract</c>
+    <n>Contract</n>
+    <dmn>Contract</dmn>
+    <i>231035933</i>
+    <t>1327653438644</t>
+    <p>
+        <Contract xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <id>2</id>
+            <comment/>
+            <detail xsi:type="ContractDetailSubType">
+                <code>code-1</code>
+                <features>
+                    <actor>actor-1</actor>
+                    <vendor>vendor-1-1</vendor>
+                    <boolValue>true</boolValue>
+                </features>
+                <ReadOnlyEle>1</ReadOnlyEle>
+                <boolTest/>
+            </detail>
+            <enumEle/>
+        </Contract>
+    </p>
+</ii>

--- a/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/DataRecordAccessor.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/DataRecordAccessor.java
@@ -373,6 +373,20 @@ public class DataRecordAccessor implements Accessor {
         try {
             initPath();
             DataRecord current = dataRecord;
+            // remove the duplicate
+            ListIterator<PathElement> elementIterator = pathElements.listIterator();
+            PathElement previousElement = null;
+            while (elementIterator.hasNext()) {
+                PathElement currentElement = elementIterator.next();
+                if (previousElement != null) {
+                    if (previousElement.field.equals(currentElement.field)) {
+                        elementIterator.remove();
+                    }
+                }
+                if (elementIterator.hasNext()) {
+                    previousElement = currentElement;
+                }
+            }
             ListIterator<PathElement> listIterator = pathElements.listIterator();
             PathElement pathElement = null;
             while (listIterator.hasNext()) {

--- a/org.talend.mdm.core/src/com/amalto/core/history/action/CompositeAction.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/action/CompositeAction.java
@@ -263,13 +263,13 @@ public class CompositeAction implements Action {
      * return :
      *   0 = {FieldUpdateAction@7041} "FieldUpdateAction{path='detail[1]/ReadOnlyEle[2]', oldValue='null', newValue='false'}"
      *   1 = {FieldUpdateAction@7040} "FieldUpdateAction{path='detail[1]/ReadOnlyEle[1]', oldValue='null', newValue='yes'}"
-     * @param changeTypeActions
+     * @param actions the list of update operation action
      * @return
      */
-    private List<Action> resetMultipleFieldsSort(List<Action> changeTypeActions) {
+    private List<Action> resetMultipleFieldsSort(List<Action> actions) {
         Stack<Action> actionStack = new Stack<>();
         boolean isNeedToPush;
-        for (Action changeTypeAction : changeTypeActions) {
+        for (Action changeTypeAction : actions) {
             isNeedToPush = true;
             FieldUpdateAction fieldUpdateAction = (FieldUpdateAction) changeTypeAction;
             String path = fieldUpdateAction.getPath();

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/ChangeTypeAction.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/ChangeTypeAction.java
@@ -68,6 +68,8 @@ class ChangeTypeAction extends AbstractChangeTypeAction {
         Accessor accessor = document.createAccessor(path + "/@xsi:type"); //$NON-NLS-1$
         if (previousType != null) {
             accessor.set(previousType.getName());
+        } else {
+            accessor.set(null);
         }
         return document;
     }

--- a/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
@@ -94,6 +94,25 @@ public class CompositeActionTest {
         assertEquals("paymentBenefitType/@xsi:type", ((FieldUpdateAction) actualResult.get(1)).getPath());
         assertEquals("paymentBenefitType/addressBanking/addressLine1", ((FieldUpdateAction) actualResult.get(2)).getPath());
         assertEquals("paymentBenefitType/iban", ((FieldUpdateAction) actualResult.get(3)).getPath());
+
+        actions.clear();
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/@xsi:type", "ContractDetailType", "ContractDetailSubType", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/code", "super-code", "sub-code", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/actor", null, "sub-actor", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/vendor[1]", null, "sub-vendor", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/boolValue", null, "true", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[2]", null, "false", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[1]", null, "yes", null, null));
+
+
+        actualResult = compositeAction.reverseXSITypeActions(actions);
+        assertEquals("detail[1]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(0)).getPath());
+        assertEquals("detail[1]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(1)).getPath());
+        assertEquals("detail[1]/features/boolValue", ((FieldUpdateAction) actualResult.get(2)).getPath());
+        assertEquals("detail[1]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(3)).getPath());
+        assertEquals("detail[1]/features/actor", ((FieldUpdateAction) actualResult.get(4)).getPath());
+        assertEquals("detail[1]/code", ((FieldUpdateAction) actualResult.get(5)).getPath());
+        assertEquals("detail[1]/@xsi:type", ((FieldUpdateAction) actualResult.get(6)).getPath());
     }
 
     @Test

--- a/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
@@ -96,14 +96,20 @@ public class CompositeActionTest {
         assertEquals("paymentBenefitType/iban", ((FieldUpdateAction) actualResult.get(3)).getPath());
 
         actions.clear();
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/Name[2]", "ContractDetailType", "ContractDetailSubType", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/Name[1]", "ContractDetailType", "ContractDetailSubType", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/@xsi:type", "ContractDetailType", "ContractDetailSubType", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/code", "super-code", "sub-code", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/actor", null, "sub-actor", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/vendor[1]", null, "sub-vendor", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/boolValue", null, "true", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/Price[2]", null, "yes", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/Price[1]", null, "yes", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[3]", null, "false", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[2]", null, "false", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[1]", null, "yes", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/Description[2]", null, "yes", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/Description[1]", null, "yes", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[2]/@xsi:type", "ContractDetailType", "ContractDetailSubType", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[2]/code", "super-code", "sub-code", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[2]/features/actor", null, "sub-actor", null, null));
@@ -112,25 +118,35 @@ public class CompositeActionTest {
         actions.add(new FieldUpdateAction(null, null, null, "detail[2]/ReadOnlyEle[3]", null, "false", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[2]/ReadOnlyEle[2]", null, "false", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[2]/ReadOnlyEle[1]", null, "yes", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/Description[2]", null, "yes", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/Description[1]", null, "yes", null, null));
 
 
         actualResult = compositeAction.reverseXSITypeActions(actions);
-        assertEquals("detail[1]/ReadOnlyEle[3]", ((FieldUpdateAction) actualResult.get(0)).getPath());
-        assertEquals("detail[1]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(1)).getPath());
-        assertEquals("detail[1]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(2)).getPath());
-        assertEquals("detail[1]/features/boolValue", ((FieldUpdateAction) actualResult.get(3)).getPath());
-        assertEquals("detail[1]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(4)).getPath());
-        assertEquals("detail[1]/features/actor", ((FieldUpdateAction) actualResult.get(5)).getPath());
-        assertEquals("detail[1]/code", ((FieldUpdateAction) actualResult.get(6)).getPath());
-        assertEquals("detail[1]/@xsi:type", ((FieldUpdateAction) actualResult.get(7)).getPath());
-        assertEquals("detail[2]/ReadOnlyEle[3]", ((FieldUpdateAction) actualResult.get(8)).getPath());
-        assertEquals("detail[2]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(9)).getPath());
-        assertEquals("detail[2]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(10)).getPath());
-        assertEquals("detail[2]/features/boolValue", ((FieldUpdateAction) actualResult.get(11)).getPath());
-        assertEquals("detail[2]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(12)).getPath());
-        assertEquals("detail[2]/features/actor", ((FieldUpdateAction) actualResult.get(13)).getPath());
-        assertEquals("detail[2]/code", ((FieldUpdateAction) actualResult.get(14)).getPath());
-        assertEquals("detail[2]/@xsi:type", ((FieldUpdateAction) actualResult.get(15)).getPath());
+        assertEquals("detail[1]/Description[2]", ((FieldUpdateAction) actualResult.get(0)).getPath());
+        assertEquals("detail[1]/Description[1]", ((FieldUpdateAction) actualResult.get(1)).getPath());
+        assertEquals("detail[1]/ReadOnlyEle[3]", ((FieldUpdateAction) actualResult.get(2)).getPath());
+        assertEquals("detail[1]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(3)).getPath());
+        assertEquals("detail[1]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(4)).getPath());
+        assertEquals("detail[1]/Price[2]", ((FieldUpdateAction) actualResult.get(5)).getPath());
+        assertEquals("detail[1]/Price[1]", ((FieldUpdateAction) actualResult.get(6)).getPath());
+        assertEquals("detail[1]/features/boolValue", ((FieldUpdateAction) actualResult.get(7)).getPath());
+        assertEquals("detail[1]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(8)).getPath());
+        assertEquals("detail[1]/features/actor", ((FieldUpdateAction) actualResult.get(9)).getPath());
+        assertEquals("detail[1]/code", ((FieldUpdateAction) actualResult.get(10)).getPath());
+        assertEquals("detail[1]/@xsi:type", ((FieldUpdateAction) actualResult.get(11)).getPath());
+        assertEquals("detail[1]/Name[2]", ((FieldUpdateAction) actualResult.get(12)).getPath());
+        assertEquals("detail[1]/Name[1]", ((FieldUpdateAction) actualResult.get(13)).getPath());
+        assertEquals("detail[2]/Description[2]", ((FieldUpdateAction) actualResult.get(14)).getPath());
+        assertEquals("detail[2]/Description[1]", ((FieldUpdateAction) actualResult.get(15)).getPath());
+        assertEquals("detail[2]/ReadOnlyEle[3]", ((FieldUpdateAction) actualResult.get(16)).getPath());
+        assertEquals("detail[2]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(17)).getPath());
+        assertEquals("detail[2]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(18)).getPath());
+        assertEquals("detail[2]/features/boolValue", ((FieldUpdateAction) actualResult.get(19)).getPath());
+        assertEquals("detail[2]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(20)).getPath());
+        assertEquals("detail[2]/features/actor", ((FieldUpdateAction) actualResult.get(21)).getPath());
+        assertEquals("detail[2]/code", ((FieldUpdateAction) actualResult.get(22)).getPath());
+        assertEquals("detail[2]/@xsi:type", ((FieldUpdateAction) actualResult.get(23)).getPath());
     }
 
     @Test

--- a/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/action/CompositeActionTest.java
@@ -101,18 +101,36 @@ public class CompositeActionTest {
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/actor", null, "sub-actor", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/vendor[1]", null, "sub-vendor", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/features/boolValue", null, "true", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[3]", null, "false", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[2]", null, "false", null, null));
         actions.add(new FieldUpdateAction(null, null, null, "detail[1]/ReadOnlyEle[1]", null, "yes", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/@xsi:type", "ContractDetailType", "ContractDetailSubType", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/code", "super-code", "sub-code", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/features/actor", null, "sub-actor", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/features/vendor[1]", null, "sub-vendor", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/features/boolValue", null, "true", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/ReadOnlyEle[3]", null, "false", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/ReadOnlyEle[2]", null, "false", null, null));
+        actions.add(new FieldUpdateAction(null, null, null, "detail[2]/ReadOnlyEle[1]", null, "yes", null, null));
 
 
         actualResult = compositeAction.reverseXSITypeActions(actions);
-        assertEquals("detail[1]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(0)).getPath());
-        assertEquals("detail[1]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(1)).getPath());
-        assertEquals("detail[1]/features/boolValue", ((FieldUpdateAction) actualResult.get(2)).getPath());
-        assertEquals("detail[1]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(3)).getPath());
-        assertEquals("detail[1]/features/actor", ((FieldUpdateAction) actualResult.get(4)).getPath());
-        assertEquals("detail[1]/code", ((FieldUpdateAction) actualResult.get(5)).getPath());
-        assertEquals("detail[1]/@xsi:type", ((FieldUpdateAction) actualResult.get(6)).getPath());
+        assertEquals("detail[1]/ReadOnlyEle[3]", ((FieldUpdateAction) actualResult.get(0)).getPath());
+        assertEquals("detail[1]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(1)).getPath());
+        assertEquals("detail[1]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(2)).getPath());
+        assertEquals("detail[1]/features/boolValue", ((FieldUpdateAction) actualResult.get(3)).getPath());
+        assertEquals("detail[1]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(4)).getPath());
+        assertEquals("detail[1]/features/actor", ((FieldUpdateAction) actualResult.get(5)).getPath());
+        assertEquals("detail[1]/code", ((FieldUpdateAction) actualResult.get(6)).getPath());
+        assertEquals("detail[1]/@xsi:type", ((FieldUpdateAction) actualResult.get(7)).getPath());
+        assertEquals("detail[2]/ReadOnlyEle[3]", ((FieldUpdateAction) actualResult.get(8)).getPath());
+        assertEquals("detail[2]/ReadOnlyEle[2]", ((FieldUpdateAction) actualResult.get(9)).getPath());
+        assertEquals("detail[2]/ReadOnlyEle[1]", ((FieldUpdateAction) actualResult.get(10)).getPath());
+        assertEquals("detail[2]/features/boolValue", ((FieldUpdateAction) actualResult.get(11)).getPath());
+        assertEquals("detail[2]/features/vendor[1]", ((FieldUpdateAction) actualResult.get(12)).getPath());
+        assertEquals("detail[2]/features/actor", ((FieldUpdateAction) actualResult.get(13)).getPath());
+        assertEquals("detail[2]/code", ((FieldUpdateAction) actualResult.get(14)).getPath());
+        assertEquals("detail[2]/@xsi:type", ((FieldUpdateAction) actualResult.get(15)).getPath());
     }
 
     @Test


### PR DESCRIPTION
Jira: https://jira.talendforge.org/login.jsp?os_destination=%2Fbrowse%2FTMDM-13810

**What is the current behavior?** (You should also link to an open issue here)
1. For attachment DataModel, field detail contains one subtype field, do below operation:

create one record, no detail item.add one detail, detail type is the ContractDetailType(supertype)
modify this record, add one detail, detail type is the ContractDetailSubType(subtype)
after save, the Update report like below:
```
<Update>
 <Item>
     <path>detail[1]/code</path>
     <oldValue>ContractDetailType</oldValue>
     <newValue>aa-1</newValue>
 </Item>
 <Item>
     <path>detail[1]/features/actor</path>
     <newValue>aa-2</newValue>
 </Item>
 <Item>
     <path>detail[1]/features/vendor[1]</path>
     <newValue>aa-3</newValue>
 </Item>
</Update>
```
2. For the attachment data model, field detail is inherited, first, add one sub details and saved, cloned it and updated. it should get the correct data used the history query.

Analysis
For this case, after updating the record, the UpdateReport records like below:
```
0 = {FieldUpdateAction@6575} "FieldUpdateAction{path='detail[2]/@xsi:type', oldValue='null', newValue='ContractDetailSubType'}"
1 = {FieldUpdateAction@6574} "FieldUpdateAction{path='detail[2]/code', oldValue='null', newValue='a'}"
2 = {FieldUpdateAction@6573} "FieldUpdateAction{path='detail[2]/features/actor', oldValue='null', newValue='b'}"
3 = {FieldUpdateAction@6572} "FieldUpdateAction{path='detail[2]/features/vendor[1]', oldValue='null', newValue='c'}"
4 = {FieldUpdateAction@6571} "FieldUpdateAction{path='detail[2]/features/boolValue', oldValue='null', newValue='true'}"
5 = {FieldUpdateAction@6570} "FieldUpdateAction{path='detail[2]/ReadOnlyEle[1]', oldValue='null', newValue='1'}"
```
If go back to the previous status, it should remove all detail[2]'s content. when executing action:
```
0 = {FieldUpdateAction@6575} "FieldUpdateAction{path='detail[2]/@xsi:type', oldValue='null', newValue='ContractDetailSubType'}"
```
It will delete the detal[2]'s node
However, when executing here DataRecordAccessor.javaL377
```
            ListIterator<PathElement> listIterator = pathElements.listIterator();
```
the value of the pathElements, contains two elements. and the two emelents's field is the same: Contract/Detail, because it's duplicated, get the DataRecord value will wrong.
3. The update report actions, when restoring to the previous status, need to execute undo operation based update report's actions, if the operation is one operation tath adds new inherited type, need reverse the actions, but if one multiple field. it doesn't reverse it.
eg:
```
0 = {FieldUpdateAction@7046} "FieldUpdateAction{path='detail[1]/@xsi:type', oldValue='ContractDetailType', newValue='ContractDetailSubType'}"
1 = {FieldUpdateAction@7045} "FieldUpdateAction{path='detail[1]/code', oldValue='super-code', newValue='sub-code'}"
2 = {FieldUpdateAction@7044} "FieldUpdateAction{path='detail[1]/features/actor', oldValue='null', newValue='sub-actor'}"
3 = {FieldUpdateAction@7043} "FieldUpdateAction{path='detail[1]/features/vendor[1]', oldValue='null', newValue='sub-vendor'}"
4 = {FieldUpdateAction@7042} "FieldUpdateAction{path='detail[1]/features/boolValue', oldValue='null', newValue='true'}"
5 = {FieldUpdateAction@7041} "FieldUpdateAction{path='detail[1]/ReadOnlyEle[2]', oldValue='null', newValue='false'}"
6 = {FieldUpdateAction@7040} "FieldUpdateAction{path='detail[1]/ReadOnlyEle[1]', oldValue='null', newValue='yes'}"
```
After reverse the above actions, the final result:
```
0 = {FieldUpdateAction@942} "FieldUpdateAction{path='detail[1]/ReadOnlyEle[2]', oldValue='null', newValue='false'}"
1 = {FieldUpdateAction@943} "FieldUpdateAction{path='detail[1]/ReadOnlyEle[1]', oldValue='null', newValue='yes'}"
2 = {FieldUpdateAction@944} "FieldUpdateAction{path='detail[1]/features/boolValue', oldValue='null', newValue='true'}"
3 = {FieldUpdateAction@945} "FieldUpdateAction{path='detail[1]/features/vendor[1]', oldValue='null', newValue='sub-vendor'}"
4 = {FieldUpdateAction@946} "FieldUpdateAction{path='detail[1]/features/actor', oldValue='null', newValue='sub-actor'}"
5 = {FieldUpdateAction@947} "FieldUpdateAction{path='detail[1]/code', oldValue='super-code', newValue='sub-code'}"
6 = {FieldUpdateAction@948} "FieldUpdateAction{path='detail[1]/@xsi:type', oldValue='ContractDetailType', newValue='ContractDetailSubType'}"
```

**What is the new behavior?**
1. If the old value, it also should generate the item node
reference code in ChangeTypeAction.java
```
public MutableDocument undo(MutableDocument document) {
if (!hasChangedType){ 
    document.createAccessor(path).touch(); return document; }
    Accessor accessor = document.createAccessor(path + "/@xsi:type");
    if (previousType != null) { 
        accessor.set(previousType.getName()); 
	} else{ 
		accessor.set(null); 
	}
	return document;
}
```
2. need remove the duplicated.
code in DataRecordAccessor.java in delete() method
```
// remove the duplicate
ListIterator<PathElement> elementIterator = pathElements.listIterator();
PathElement previousElement = null;
while (elementIterator.hasNext()) {
	PathElement currentElement = elementIterator.next();
	if (previousElement != null) {
		if (previousElement.field.equals(currentElement.field)) {
			elementIterator.remove();
		}
	}
	if (elementIterator.hasNext()) {
		previousElement = currentElement;
	}
}
```
3. add a new method to restore multiple field's action:
code in CompositeAction.java
```
private List<Action> resetActionOrderForMultiField(List<Action> actions) {
        String prePath = StringUtils.EMPTY;
        List<Action> resultActions = new ArrayList<>();
        List<Action> samePathActions = new ArrayList<>();
        for (Action action : actions) {
            String path = ((FieldUpdateAction) action).getPath();
            if (path.endsWith("]")) { // if current actions is multiple field's
                String curPath = path.substring(0, path.lastIndexOf('['));
                if (prePath.length() == 0 || curPath.equals(prePath)) {
                    // if current actions's path is same with previous's, add current action to samePathActions
                    samePathActions.add(action);
                } else if (!samePathActions.isEmpty()) {
                    // if current action's path is not same with previous's, but also is a multiple field
                    addToResultActions(resultActions, samePathActions);
                    samePathActions.add(action);
                }
                prePath = curPath;
            } else { // if current actions is not multiple field's
                if (!samePathActions.isEmpty()) {
                    addToResultActions(resultActions, samePathActions);
                }
                prePath = StringUtils.EMPTY;
                resultActions.add(action);
            }
        }
        if (!samePathActions.isEmpty()) {
            // if the last action is the multiple field's, also add to result
            addToResultActions(resultActions, samePathActions);
        }
        return resultActions;
    }
```

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
