### PR TITLE
TMDM-13941 User with role System_interactive can access Data Model info via REST API even if no right via custom roles	

### DIFF
--- a/org.talend.mdm.core/resources/META-INF/mdm-context.xml
+++ b/org.talend.mdm.core/resources/META-INF/mdm-context.xml
@@ -137,10 +137,10 @@ http://activemq.apache.org/schema/core http://activemq.apache.org/schema/core/ac
             access="hasRole('administration')" method="POST" />
         <security:intercept-url pattern="\A/services/pubcomponent.*\Z" requires-channel="any" access="permitAll"
             method="GET" />
-        <security:intercept-url pattern="\A/services/pubcomponent.*\Z" requires-channel="any"
-            access="hasRole('administration')" />
-        <security:intercept-url pattern="\A/services/syncuser.*\Z" requires-channel="any"
-            access="hasRole('administration')" />
+        <security:intercept-url pattern="\A/services/pubcomponent.*\Z" requires-channel="any" access="hasRole('administration')" />
+        <security:intercept-url pattern="\A/services/syncuser.*\Z" requires-channel="any" access="hasRole('administration')" />
+        <security:intercept-url pattern="\A/services/rest/system/containers.*\Z" requires-channel="any" access="hasRole('administration')" />
+        <security:intercept-url pattern="\A/services/rest/system/models.*\Z" requires-channel="any" access="hasRole('administration')" />
         <security:intercept-url pattern="\A/services.*\Z" requires-channel="any" access="hasRole('authenticated')" />
         <security:custom-filter position="BASIC_AUTH_FILTER" ref="basicAuthenticationFilter" />
     </security:http>

--- a/org.talend.mdm.core/src/com/amalto/core/delegator/ILocalUser.java
+++ b/org.talend.mdm.core/src/com/amalto/core/delegator/ILocalUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -38,6 +38,10 @@ import static com.amalto.core.query.user.UserQueryBuilder.from;
 public abstract class ILocalUser implements IBeanDelegator {
     
     public ILocalUser getILocalUser() throws XtentisException {
+        return null;
+    }
+
+    public ILocalUser getILocalUser(boolean isWebServiceAccess) throws XtentisException {
         return null;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/delegator/impl/DefaultLocalUserDelegator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/delegator/impl/DefaultLocalUserDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -20,6 +20,11 @@ public class DefaultLocalUserDelegator extends ILocalUser {
 
     @Override
     public ILocalUser getILocalUser() throws XtentisException {
+        return iUser;
+    }
+
+    @Override
+    public ILocalUser getILocalUser(boolean isWebServiceAccess) throws XtentisException {
         return iUser;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/util/LocalUser.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/LocalUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
  * 
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -43,6 +43,16 @@ public class LocalUser {
      */
     public static ILocalUser getLocalUser() throws XtentisException {
         return findLocalUser().getILocalUser();
+    }
+
+    /**
+     * Called by the Web Service, like DataService.
+     * @param isWebServiceAccess
+     * @return The Local User
+     * @throws XtentisException
+     */
+    public static ILocalUser getLocalUser(boolean isWebServiceAccess) throws XtentisException {
+        return findLocalUser().getILocalUser(isWebServiceAccess);
     }
 
     public static void resetLocalUsers() throws XtentisException {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13941
What is the current behavior? (You should also link to an open issue here)
As some REST API, If the user no operator privileged, he/she CAN access them.

What is the new behavior?
Add the authenticated permission to validate it before calling the API.
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
