### PR TITLE
TMDM-13918 Wrong value returned by MDM REST API select query / contains when 2 fields with same name in 2 different entities.(7.2)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
@@ -427,6 +427,11 @@ class LuceneQueryGenerator extends VisitorAdapter<Query> {
                 fieldName = fieldName + "." + referenceFieldMetadata.getReferencedField().getName(); //$NON-NLS-1$
             }
         }
+        // TMDM-13918 Query by field of joining type, field name in lucene index should be fkIdField.fieldName
+        else if (fieldMetadata instanceof SimpleTypeFieldMetadata && !types.contains(fieldMetadata.getContainingType())) {
+            FieldMetadata keyField = fieldMetadata.getContainingType().getKeyFields().iterator().next();
+            fieldName = keyField.getName() + "." + fieldName; //$NON-NLS-1$
+        }
         String[] fieldsAsArray = new String[] { fieldName };
         String fullTextValue = getFullTextValue(fieldFullText);
         String fullTextQuery = fieldName + ':' + fullTextValue;


### PR DESCRIPTION
What is the current behavior? (You should also link to an open issue here)
Query / contains with the field of joining type, it will be recognized as the main type's field.

What is the new behavior?
Support query / contains with the field of joining type.
Set the field of joining type in lucene query like idField.fieldName.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
