### PR TITLE
TMDM-14012 Failed deploying data model with default value

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
@@ -26,6 +26,7 @@ import org.talend.mdm.commmon.metadata.DefaultMetadataVisitor;
 import org.talend.mdm.commmon.metadata.EnumerationFieldMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.metadata.MetadataUtils;
 import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
 import org.talend.mdm.commmon.metadata.SimpleTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.TypeMetadata;
@@ -674,15 +675,15 @@ public class MappingGenerator extends DefaultMetadataVisitor<Element> {
 
     private void addDefaultValueAttribute(FieldMetadata field, Element columnElement) {
         // default value
-        String defaultValue = field.<String>getData(MetadataRepository.DEFAULT_VALUE);
+        String defaultValue = field.<String> getData(MetadataRepository.DEFAULT_VALUE);
         if (StringUtils.isNotBlank(defaultValue)) {
 
             Attr defaultValueAttr = document.createAttribute("default"); //$NON-NLS-1$
-
-            if (!field.getType().getName().equals(TypeMapping.SQL_TYPE_BOOLEAN)
-                    || HibernateStorageUtils.isBooleanDefaultValue(field.getType().getName(), defaultValue.trim())) {
-                defaultValueAttr.setValue(HibernateStorageUtils.convertedDefaultValue(field.getType().getName(),
-                        dataSource.getDialectName(), defaultValue.trim(), "'"));
+            //TMDM-14012 fixed the block of code to parse the XPath, and got the correct field type Name
+            String fieldName = MetadataUtils.getSuperConcreteType(field.getType()).getName();
+            if (!fieldName.equals(TypeMapping.SQL_TYPE_BOOLEAN)
+                    || HibernateStorageUtils.isBooleanDefaultValue(fieldName, defaultValue.trim())) {
+                defaultValueAttr.setValue(HibernateStorageUtils.convertedDefaultValue(fieldName, dataSource.getDialectName(), defaultValue.trim(), "'")); //$NON-NLS-1$
                 columnElement.getAttributes().setNamedItem(defaultValueAttr);
             }
         }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/StoragePrepareTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/StoragePrepareTest.java
@@ -11,7 +11,6 @@ package com.amalto.core.storage;
 
 import static com.amalto.core.query.user.UserQueryBuilder.eq;
 import static com.amalto.core.query.user.UserQueryBuilder.from;
-import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -701,6 +700,75 @@ public class StoragePrepareTest extends TestCase {
                 ((DataRecord) ((LinkedList<DataRecord>) ((DataRecord) ((DataRecord) ((DataRecord) ((DataRecord) dataRecord
                         .get("BaseType")).get("TeacherCircleType")).get("entitesPassees")).get("EDAs")).get("EDA")).get(0)
                                 .get("eda")).get("Id"));
+    }
+
+    //TMDM-14012 XPath functions cannot be used on default values
+    public void testParseXPathWithDefaultValueInDataModel() {
+        Storage storage = new SecuredStorage(new HibernateStorage("EEC_Default_Value", StorageType.MASTER), userSecurity);//$NON-NLS-1$
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(StoragePrepareTest.class.getResourceAsStream("EEC_Default_Value.xsd"));//$NON-NLS-1$
+        MockMetadataRepositoryAdmin.INSTANCE.register("EEC_Default_Value", repository);//$NON-NLS-1$
+
+        storage.init(getDatasource("H2-DS3"));// //$NON-NLS-1$
+        storage.prepare(repository, Collections.<Expression> emptySet(), true, true);
+        ((MockStorageAdmin) ServerContext.INSTANCE.get().getStorageAdmin()).register(storage);
+
+        storage.begin();
+        ComplexTypeMetadata country = repository.getComplexType("Country");//$NON-NLS-1$
+        UserQueryBuilder qb = from(country);
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(0, results.getCount());
+        } finally {
+            results.close();
+        }
+        storage.end();
+
+        List<DataRecord> records = new ArrayList<DataRecord>();
+        DataRecordReader<String> factory = new XmlStringDataRecordReader();
+        records.add(factory.read(repository, country, "<Country><Code>1</Code><ImportToBelarus></ImportToBelarus><ImportToString></ImportToString></Country>")); //$NON-NLS-1$
+        records.add(factory.read(repository, country, "<Country><Code>2</Code><ImportToBelarus>false</ImportToBelarus><ImportToString>hello world</ImportToString></Country>")); //$NON-NLS-1$
+        records.add(factory.read(repository, country, "<Country><Code>3</Code><ImportToBelarus>true</ImportToBelarus><ImportToString>very good</ImportToString></Country>")); //$NON-NLS-1$
+        records.add(factory.read(repository, country, "<Country><Code>4</Code><ImportToBelarus>false</ImportToBelarus><ImportToString>This is a test</ImportToString></Country>")); //$NON-NLS-1$
+        try {
+            storage.begin();
+            storage.update(records);
+            storage.commit();
+        } finally {
+            storage.end();
+        }
+        storage.begin();
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(4, results.getCount());
+            for (DataRecord result : results) {
+                String id = result.get("Code").toString();
+                switch (id) {
+                case "1"://$NON-NLS-1$
+                    assertEquals(false, result.get("Country/ImportToBelarus"));//$NON-NLS-1$
+                    assertEquals(null, result.get("Country/ImportToString"));//$NON-NLS-1$
+                    break;
+                case "2"://$NON-NLS-1$
+                    assertEquals(false, result.get("Country/ImportToBelarus"));//$NON-NLS-1$
+                    assertEquals("hello world", result.get("Country/ImportToString"));//$NON-NLS-1$ $NON-NLS-2$
+                    break;
+                case "3"://$NON-NLS-1$
+                    assertEquals(true, result.get("Country/ImportToBelarus"));//$NON-NLS-1$
+                    assertEquals("very good", result.get("Country/ImportToString"));//$NON-NLS-1$ $NON-NLS-2$
+                    break;
+                case "4"://$NON-NLS-1$
+                    assertEquals(false, result.get("Country/ImportToBelarus"));//$NON-NLS-1$
+                    assertEquals("This is a test", result.get("Country/ImportToString"));//$NON-NLS-1$ $NON-NLS-2$
+                    break;
+                default:
+                    assertNull(id);
+                }
+            }
+        } finally {
+            results.close();
+        }
+        storage.end();
+        storage.close();
     }
 
     protected static DataSourceDefinition getDatasource(String dataSourceName) {

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/EEC_Default_Value.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/EEC_Default_Value.xsd
@@ -1,0 +1,76 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:simpleType name="IndicatorStringType">
+        <xsd:annotation>
+            <xsd:documentation>IndicatorStringType</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="IndicatorType">
+        <xsd:annotation>
+            <xsd:documentation>IndicatorType</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:boolean" />
+    </xsd:simpleType>  
+    <xsd:element name="Country" type="CountryType">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Label_EN">Country</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:unique name="Country">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Code" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="CountryType">
+        <xsd:sequence>
+            <xsd:element maxOccurs="1" minOccurs="1" name="Code" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Label_EN">Code</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="0" name="ImportToBelarus" type="IndicatorType">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Default_Value_Rule">fn:false()</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="0" name="ImportToString" type="IndicatorStringType">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Default_Value_Rule">fn:concat("hello", " ", "world")</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="Product">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Gender" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Default_Value_Rule">fn:false()</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Product">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14012
**What is the current behavior?** (You should also link to an open issue here)
All type can't use XPath function within their default value.
If the default value be assigned in the multiple hierarchy Complex type, the XPath will not be parsed correctly that caused the data model failed to deploy. 

**What is the new behavior?**
Modify the logic of code to parse XPath within the multiple hierarchy complex type, create an iterator to loop the XPath to find the actual field name. for example:
`<xsd:element name="Country" type="CountryType"></xsd:element>
    <xsd:complexType name="CountryType">
        <xsd:sequence>
            <xsd:element name="ImportToBelarus" type="IndicatorType">
                <xsd:annotation>
                    <xsd:appinfo source="X_Default_Value_Rule">fn:false()</xsd:appinfo>
                </xsd:annotation>
            </xsd:element>
        </xsd:sequence>
    </xsd:complexType>
    <xsd:simpleType name="IndicatorType">
        <xsd:annotation>
            <xsd:documentation>IndicatorType</xsd:documentation>
        </xsd:annotation>
        <xsd:restriction base="xsd:boolean" />
    </xsd:simpleType>`
With above snippet of XSD, before got the field type name is importToBelarus, actually, it should be boolean.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
