### PR TITLE
TMDM-13917 [SOAP API] Delete records for entity with the attached data model failed

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -1540,6 +1540,8 @@ public class HibernateStorage implements Storage {
                                                                     + referenceTableName).list();
                                                     if (list != null && !list.isEmpty()) {
                                                         fieldsCondition.put(columnName, list);
+                                                    } else {
+                                                        isNeedToDropDeleteType = false;
                                                     }
                                                 }
                                             } else {
@@ -1555,6 +1557,8 @@ public class HibernateStorage implements Storage {
                                                     } else {
                                                         fieldsCondition.put(columnName, list);
                                                     }
+                                                } else {
+                                                    isNeedToDropDeleteType = false;
                                                 }
                                             }
                                         }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
@@ -89,42 +89,40 @@ public class FKConstraintTest extends TestCase {
             storage.end();
         }
 
-        Exception e_a11 = null;
         try {
             storage.begin();
             storage.update(factory.read(repository, entityA1, ENTITY_A1_EMPTY));
             storage.commit();
-        } catch (Exception e) {
-            e_a11 = e;
         } finally {
             storage.end();
         }
-        assertNull(e_a11);
+        UserQueryBuilder qb = from(entityA1);
+        StorageResults results = storage.fetch(qb.getSelect());
+        assertEquals(1, results.getCount());
 
-        Exception e_a21 = null;
         try {
             storage.begin();
             storage.update(factory.read(repository, entityA2, ENTITY_A2_1));
             storage.commit();
-        } catch(Exception e){
-            e_a21 = e;
         } finally {
             storage.end();
         }
-        assertNull(e_a21);
+        qb = from(entityA2);
+        results = storage.fetch(qb.getSelect());
+        assertEquals(1, results.getCount());
 
         // ENTITY_A1_EMPTY has no FK record, so delete this table will success
-        UserQueryBuilder qb = from(entityA1);
+        qb = from(entityA1);
         try {
             storage.begin();
             storage.delete(qb.getSelect());
             storage.commit();
-        } catch (Exception e) {
-            e_a11 = e;
         } finally {
             storage.end();
         }
-        assertNull(e_a11);
+        qb = from(entityA1);
+        results = storage.fetch(qb.getSelect());
+        assertEquals(0, results.getCount());
 
         // ENTITY_C1 is FK of entity A2, so delete this table will fail
         qb = from(entityC).where(eq(entityC.getField("C_Id"), "C1"));
@@ -133,11 +131,11 @@ public class FKConstraintTest extends TestCase {
             storage.delete(qb.getSelect());
             storage.commit();
         } catch (Exception e) {
-            e_a11 = e;
         } finally {
             storage.end();
         }
-        assertNotNull(e_a11);
+        results = storage.fetch(qb.getSelect());
+        assertEquals(1, results.getCount());
     }
 
     public void testMaster(){

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
@@ -90,13 +90,10 @@ public class FKConstraintTest extends TestCase {
             storage.end();
         }
 
-        Exception e_a11 = null;
         try {
             storage.begin();
             storage.update(factory.read(repository, entityA1, ENTITY_A1_EMPTY));
             storage.commit();
-        } catch (Exception e) {
-            e_a11 = e;
         } finally {
             storage.end();
         }
@@ -109,8 +106,6 @@ public class FKConstraintTest extends TestCase {
             storage.begin();
             storage.update(factory.read(repository, entityA2, ENTITY_A2_1));
             storage.commit();
-        } catch (Exception e) {
-            e_a11 = e;
         } finally {
             storage.end();
         }
@@ -120,6 +115,7 @@ public class FKConstraintTest extends TestCase {
         assertEquals(1, results.getCount());
 
         // ENTITY_A1_EMPTY has no FK record, so delete this table will success
+        Exception e_a11 = null;
         qb = from(entityA1);
         try {
             storage.begin();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
@@ -9,6 +9,9 @@
  */
 package com.amalto.core.storage;
 
+import static com.amalto.core.query.user.UserQueryBuilder.eq;
+import static com.amalto.core.query.user.UserQueryBuilder.from;
+
 import java.util.LinkedList;
 import java.util.List;
 
@@ -16,6 +19,7 @@ import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
 
+import com.amalto.core.query.user.UserQueryBuilder;
 import com.amalto.core.server.MockServerLifecycle;
 import com.amalto.core.server.ServerContext;
 import com.amalto.core.storage.Storage;
@@ -41,6 +45,8 @@ public class FKConstraintTest extends TestCase {
 
     private static Logger LOG = Logger.getLogger(FKConstraintTest.class);
 
+    private static String ENTITY_A1_EMPTY = "<Entity_A1><A1_Id>A1</A1_Id><A1_Name>A1 Name</A1_Name><B1><B1_Name>B1 Name</B1_Name></B1></Entity_A1>";
+
     private static String ENTITY_A1_1 = "<Entity_A1><A1_Id>A1</A1_Id><A1_Name>A1 Name</A1_Name><B1><B1_Name>B1 Name</B1_Name><C_Id>[C1]</C_Id><C_Id>[C2]</C_Id></B1></Entity_A1>";
 
     private static String ENTITY_A1_2 = "<Entity_A1><A1_Id>A1</A1_Id><A1_Name>A1 Name</A1_Name><B1><B1_Name>B1 Name</B1_Name><C_Id>[C3]</C_Id><C_Id>[C4]</C_Id></B1></Entity_A1>";
@@ -56,6 +62,83 @@ public class FKConstraintTest extends TestCase {
     private static String ENTITY_C3 = "<Entity_C><C_Id>C3</C_Id><C_Name>C3 Name</C_Name></Entity_C>";
 
     private static String ENTITY_C4 = "<Entity_C><C_Id>C4</C_Id><C_Name>C4 Name</C_Name></Entity_C>";
+
+    public void testDeleteFKTable() {
+        ServerContext.INSTANCE.get(new MockServerLifecycle());
+
+        Storage storage = new HibernateStorage("MDM", StorageType.MASTER);
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(FKConstraintTest.class.getResourceAsStream("FKConstraintTest.xsd"));
+        storage.init(ServerContext.INSTANCE.get().getDefinition("H2-DS1", "MDM"));
+        storage.prepare(repository, true);
+
+        DataRecordReader<String> factory = new XmlStringDataRecordReader();
+        ComplexTypeMetadata entityA1 = repository.getComplexType("Entity_A1");
+        ComplexTypeMetadata entityA2 = repository.getComplexType("Entity_A2");
+        ComplexTypeMetadata entityC = repository.getComplexType("Entity_C");
+
+        List<DataRecord> recordCs = new LinkedList<DataRecord>();
+        recordCs.add(factory.read(repository, entityC, ENTITY_C1));
+        recordCs.add(factory.read(repository, entityC, ENTITY_C2));
+        recordCs.add(factory.read(repository, entityC, ENTITY_C3));
+        try {
+            storage.begin();
+            storage.update(recordCs);
+            storage.commit();
+        } finally {
+            storage.end();
+        }
+
+        Exception e_a11 = null;
+        try {
+            storage.begin();
+            storage.update(factory.read(repository, entityA1, ENTITY_A1_EMPTY));
+            storage.commit();
+        } catch (Exception e) {
+            e_a11 = e;
+        } finally {
+            storage.end();
+        }
+        assertNull(e_a11);
+
+        Exception e_a21 = null;
+        try {
+            storage.begin();
+            storage.update(factory.read(repository, entityA2, ENTITY_A2_1));
+            storage.commit();
+        } catch(Exception e){
+            e_a21 = e;
+        } finally {
+            storage.end();
+        }
+        assertNull(e_a21);
+
+        // ENTITY_A1_EMPTY has no FK record, so delete this table will success
+        UserQueryBuilder qb = from(entityA1);
+        try {
+            storage.begin();
+            storage.delete(qb.getSelect());
+            storage.commit();
+        } catch (Exception e) {
+            e_a11 = e;
+        } finally {
+            storage.end();
+        }
+        assertNull(e_a11);
+
+        // ENTITY_C1 is FK of entity A2, so delete this table will fail
+        qb = from(entityC).where(eq(entityC.getField("C_Id"), "C1"));
+        try {
+            storage.begin();
+            storage.delete(qb.getSelect());
+            storage.commit();
+        } catch (Exception e) {
+            e_a11 = e;
+        } finally {
+            storage.end();
+        }
+        assertNotNull(e_a11);
+    }
 
     public void testMaster(){
         LOG.info("Setting up MDM server environment...");
@@ -225,5 +308,4 @@ public class FKConstraintTest extends TestCase {
         }
         assertNull(e_a22);
     }
-
 }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
@@ -24,6 +24,7 @@ import com.amalto.core.server.MockServerLifecycle;
 import com.amalto.core.server.ServerContext;
 import com.amalto.core.storage.Storage;
 import com.amalto.core.storage.StorageType;
+import com.amalto.core.storage.exception.ConstraintViolationException;
 import com.amalto.core.storage.hibernate.HibernateStorage;
 import com.amalto.core.storage.record.DataRecord;
 import com.amalto.core.storage.record.DataRecordReader;
@@ -89,13 +90,18 @@ public class FKConstraintTest extends TestCase {
             storage.end();
         }
 
+        Exception e_a11 = null;
         try {
             storage.begin();
             storage.update(factory.read(repository, entityA1, ENTITY_A1_EMPTY));
             storage.commit();
+        } catch (Exception e) {
+            e_a11 = e;
         } finally {
             storage.end();
         }
+        assertNull(e_a11);
+
         UserQueryBuilder qb = from(entityA1);
         StorageResults results = storage.fetch(qb.getSelect());
         assertEquals(1, results.getCount());
@@ -104,9 +110,13 @@ public class FKConstraintTest extends TestCase {
             storage.begin();
             storage.update(factory.read(repository, entityA2, ENTITY_A2_1));
             storage.commit();
+        } catch (Exception e) {
+            e_a11 = e;
         } finally {
             storage.end();
         }
+        assertNull(e_a11);
+
         qb = from(entityA2);
         results = storage.fetch(qb.getSelect());
         assertEquals(1, results.getCount());
@@ -117,9 +127,13 @@ public class FKConstraintTest extends TestCase {
             storage.begin();
             storage.delete(qb.getSelect());
             storage.commit();
+        } catch (Exception e) {
+            e_a11 = e;
         } finally {
             storage.end();
         }
+        assertNull(e_a11);
+
         qb = from(entityA1);
         results = storage.fetch(qb.getSelect());
         assertEquals(0, results.getCount());
@@ -130,10 +144,13 @@ public class FKConstraintTest extends TestCase {
             storage.begin();
             storage.delete(qb.getSelect());
             storage.commit();
-        } catch (Exception e) {
+        } catch (ConstraintViolationException e) {
+            e_a11 = e;
         } finally {
             storage.end();
         }
+        assertNotNull(e_a11);
+
         results = storage.fetch(qb.getSelect());
         assertEquals(1, results.getCount());
     }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/FKConstraintTest.java
@@ -100,7 +100,6 @@ public class FKConstraintTest extends TestCase {
         } finally {
             storage.end();
         }
-        assertNull(e_a11);
 
         UserQueryBuilder qb = from(entityA1);
         StorageResults results = storage.fetch(qb.getSelect());
@@ -115,7 +114,6 @@ public class FKConstraintTest extends TestCase {
         } finally {
             storage.end();
         }
-        assertNull(e_a11);
 
         qb = from(entityA2);
         results = storage.fetch(qb.getSelect());


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13917

**What is the current behavior?** (You should also link to an open issue here)

Failed to delete an empty entity which has FK reference entity, the FK reference entity was used by other entity with data.

**What is the new behavior?**

The main entity table has FK reference entity, and the FK reference entity was used by other entity, the Studio job to delete main entity table is succeeded.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
