### PR TITLE
TMDM-13991 Advanced Search does not work with AND query on Foreign Key Field

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
@@ -415,6 +415,38 @@ class LuceneQueryGenerator extends VisitorAdapter<Query> {
         return query;
     }
 
+    /**
+     * Get a full path of field for its directory tree.
+     * <pre>
+     * Person
+     *      |__Stores
+     *              |__Store
+     *                      |__Name
+     *      |__Age                
+     * </pre>
+     * @return: Person.Stores.Store.Name
+     */
+    private String getFullPathName(FieldFullText fieldFullText) {
+        FieldMetadata fieldMetadata = fieldFullText.getField().getFieldMetadata();
+        StringBuilder fullPathFieldName = new StringBuilder();
+        while (fieldMetadata instanceof ReferenceFieldMetadata) {
+            String fieldName = fieldMetadata.getName();
+            ReferenceFieldMetadata referenceFieldMetadata = ((ReferenceFieldMetadata) fieldMetadata);
+            if (referenceFieldMetadata.getReferencedType().getKeyFields().size() > 1) {
+                throw new FullTextQueryCompositeKeyException(referenceFieldMetadata.getReferencedType().getName());
+            } else {
+                fullPathFieldName.insert(0, fieldName + ".");//$NON-NLS-1$
+            }
+            ComplexTypeMetadata currentContainingType = fieldMetadata.getContainingType();
+            if (currentContainingType != null && currentContainingType.getContainer() != null) {
+                fieldMetadata = currentContainingType.getContainer();
+            } else {
+                break;
+            }
+        }
+        return fullPathFieldName.toString();
+    }
+
     @Override
     public Query visit(FieldFullText fieldFullText) {
         FieldMetadata fieldMetadata = fieldFullText.getField().getFieldMetadata();
@@ -424,7 +456,7 @@ class LuceneQueryGenerator extends VisitorAdapter<Query> {
             if (referenceFieldMetadata.getReferencedType().getKeyFields().size() > 1) {
                 throw new FullTextQueryCompositeKeyException(referenceFieldMetadata.getReferencedType().getName());
             } else {
-                fieldName = fieldName + "." + referenceFieldMetadata.getReferencedField().getName(); //$NON-NLS-1$
+                fieldName = getFullPathName(fieldFullText) + referenceFieldMetadata.getReferencedField().getName(); //$NON-NLS-1$
             }
         }
         // TMDM-13918 Query by field of joining type, field name in lucene index should be fkIdField.fieldName

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -284,6 +284,12 @@ public class StorageFullTextTest extends StorageTestCase {
         allRecords.add(factory.read(repository, manager, "<Manager><name>manager 3</name><age>33</age><jobTitle>jobTitle 33</jobTitle><dept>dept 3</dept></Manager>"));
         allRecords.add(factory.read(repository, nn, "<NN><Id>pp</Id><name>tyu</name><sub><name>yu67</name><title>67</title></sub></NN>"));
         allRecords.add(factory.read(repository, contract, "<Contract><id>1</id><comment>1</comment><detail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"ContractDetailType\"></detail><detail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"ContractDetailType\"><code>1</code></detail><detail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"ContractDetailType\"><code>1</code></detail><detail xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"ContractDetailSubType\"><code>1</code><features><actor>1</actor><vendor>1</vendor></features></detail><enumEle>pending</enumEle></Contract>"));
+
+        allRecords.add(factory.read(repository, myFLIF_RefSourceSystem, "<RefSourceSystem><RefSourceSystemId>11</RefSourceSystemId><Bezeichnung>12</Bezeichnung></RefSourceSystem>"));
+        allRecords.add(factory.read(repository, myFLIF_RefSourceSystem, "<RefSourceSystem><RefSourceSystemId>22</RefSourceSystemId><Bezeichnung>23</Bezeichnung></RefSourceSystem>"));
+        allRecords.add(factory.read(repository, myFLIF_Partner, "<Partner><PartnerId>2019926111626752d3e2</PartnerId><SourceSystemMap><SourceSystem><SourceSystemId>[11]</SourceSystemId><MandantNummer>1</MandantNummer><SourceKey>2</SourceKey></SourceSystem></SourceSystemMap><Name>world</Name></Partner>"));
+        allRecords.add(factory.read(repository, myFLIF_Partner, "<Partner><PartnerId>2019926111652083d5e2</PartnerId><SourceSystemMap><SourceSystem><SourceSystemId>[22]</SourceSystemId><MandantNummer>33</MandantNummer><SourceKey>4</SourceKey></SourceSystem></SourceSystemMap><Name>good</Name></Partner>"));
+        allRecords.add(factory.read(repository, myFLIF_Partner, "<Partner><PartnerId>2019926111652084d5e2</PartnerId><SourceSystemMap><SourceSystem><SourceSystemId>[22]</SourceSystemId><MandantNummer>44</MandantNummer><SourceKey>4</SourceKey></SourceSystem></SourceSystemMap><Name>go</Name></Partner>"));
         try {
             storage.begin();
             storage.update(allRecords);
@@ -346,6 +352,12 @@ public class StorageFullTextTest extends StorageTestCase {
             storage.delete(qb.getSelect());
 
             qb = from(contract);
+            storage.delete(qb.getSelect());
+
+            qb = from(myFLIF_RefSourceSystem);
+            storage.delete(qb.getSelect());
+
+            qb = from(myFLIF_Partner);
             storage.delete(qb.getSelect());
         }
         storage.commit();
@@ -744,6 +756,16 @@ public class StorageFullTextTest extends StorageTestCase {
         return results;
     }
 
+    private List<FieldMetadata> prepareFLIFFields(ComplexTypeMetadata partner) {
+        List<FieldMetadata> results = new ArrayList<>();
+        results.add(partner.getField("PartnerId"));
+        results.add(partner.getField("Name"));
+        results.add(partner.getField("SourceSystemMap/SourceSystem/SourceSystemId"));
+        results.add(partner.getField("SourceSystemMap/SourceSystem/MandantNummer"));
+        results.add(partner.getField("SourceSystemMap/SourceSystem/SourceKey"));
+        return results;
+    }
+
     private List<FieldMetadata> prepareSelectProductFields(ComplexTypeMetadata product) {
         List<FieldMetadata> results = new ArrayList<>();
         results.add(product.getField("Family"));
@@ -906,6 +928,69 @@ public class StorageFullTextTest extends StorageTestCase {
             assertEquals(1, results.getCount());
             for (DataRecord result : results) {
                 assertNotSame(0, result.get("Id"));
+            }
+        } finally {
+            results.close();
+        }
+    }
+
+    //TMDM-13991 Advanced Search does not work with AND query on Foreign Key Field
+    public void testAdvancedSearchWithCompostCondition() throws Exception {
+        //case 1: condition (name = good and fk = 22), expected results : one record
+        UserQueryBuilder qb = from(myFLIF_Partner).select(prepareFLIFFields(myFLIF_Partner)).where(and(contains(myFLIF_Partner.getField("Name"), "good"),
+                eq(myFLIF_Partner.getField("SourceSystemMap/SourceSystem/SourceSystemId"), "22")));
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(1, results.getCount());
+            for (DataRecord result : results) {
+                assertEquals("2019926111652083d5e2", result.get("PartnerId"));
+            }
+        } finally {
+            results.close();
+        }
+
+        //case 2: condition (name = well and fk = 22), expected results : nothing
+        qb = from(myFLIF_Partner).select(prepareFLIFFields(myFLIF_Partner)).where(and(contains(myFLIF_Partner.getField("Name"), "well"),
+                eq(myFLIF_Partner.getField("SourceSystemMap/SourceSystem/SourceSystemId"), "22")));
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(0, results.getCount());
+        } finally {
+            results.close();
+        }
+
+        //case 3: condition (name = world and fk = 11), expected results : one record
+        qb = from(myFLIF_Partner).select(prepareFLIFFields(myFLIF_Partner)).where(and(contains(myFLIF_Partner.getField("Name"), "world"),
+                eq(myFLIF_Partner.getField("SourceSystemMap/SourceSystem/SourceSystemId"), "11")));
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(1, results.getCount());
+            for (DataRecord result : results) {
+                assertEquals("2019926111626752d3e2", result.get("PartnerId"));
+                assertEquals(1L, result.get("SourceSystemMap/SourceSystem/MandantNummer"));
+            }
+        } finally {
+            results.close();
+        }
+
+        //case 4: condition (name = go and fk = 22), expected results : two record
+        qb = from(myFLIF_Partner).select(prepareFLIFFields(myFLIF_Partner)).where(and(contains(myFLIF_Partner.getField("Name"), "go"),
+                eq(myFLIF_Partner.getField("SourceSystemMap/SourceSystem/SourceSystemId"), "22")));
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(2, results.getCount());
+            for (DataRecord result : results) {
+                String id = (String) result.get("PartnerId");
+                switch (id) {
+                case "2019926111652083d5e2"://$NON-NLS-1$
+                    assertEquals(33L, result.get("SourceSystemMap/SourceSystem/MandantNummer"));//$NON-NLS-1$
+                    break;
+                case "2019926111652084d5e2"://$NON-NLS-1$
+                    assertEquals(44L, result.get("SourceSystemMap/SourceSystem/MandantNummer"));//$NON-NLS-1$
+                    break;
+                default:
+                    assertNull(id);
+                }
             }
         } finally {
             results.close();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
@@ -10,13 +10,11 @@
 
 package com.amalto.core.query;
 
-import static com.amalto.core.query.user.UserQueryBuilder.*;
+import static com.amalto.core.query.user.UserQueryBuilder.isNull;
 
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
@@ -34,6 +32,8 @@ import com.amalto.core.storage.Storage;
 import com.amalto.core.storage.StorageType;
 import com.amalto.core.storage.datasource.DataSourceDefinition;
 import com.amalto.core.storage.hibernate.HibernateStorage;
+
+import junit.framework.TestCase;
 
 @SuppressWarnings("nls")
 public class StorageTestCase extends TestCase {
@@ -162,6 +162,10 @@ public class StorageTestCase extends TestCase {
 
     protected static final ComplexTypeMetadata contract;
 
+    protected static final ComplexTypeMetadata myFLIF_RefSourceSystem;
+
+    protected static final ComplexTypeMetadata myFLIF_Partner;
+
     public static final String DATABASE = "H2";
 
     public static final String DATASOURCE_DEFAULT = DATABASE + "-Default";
@@ -236,6 +240,8 @@ public class StorageTestCase extends TestCase {
         nn = repository.getComplexType("NN");
 
         contract = repository.getComplexType("Contract");
+        myFLIF_RefSourceSystem = repository.getComplexType("RefSourceSystem");
+        myFLIF_Partner = repository.getComplexType("Partner");
 
         systemStorage = new SecuredStorage(new HibernateStorage("MDM", StorageType.SYSTEM), userSecurity);
         systemRepository = buildSystemRepository();

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -2851,4 +2851,95 @@
 	        <xsd:enumeration value="rejected" />
 	    </xsd:restriction>
 	</xsd:simpleType>
+    <xsd:complexType abstract="true" name="PartnerType">
+        <xsd:sequence />
+    </xsd:complexType>
+    <xsd:complexType name="SourceSystemMandantType">
+        <xsd:sequence>
+            <xsd:element maxOccurs="1" minOccurs="1" name="SourceSystemId" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_ForeignKey">RefSourceSystem/RefSourceSystemId</xsd:appinfo>
+                    <xsd:appinfo source="X_ForeignKey_NotSep">false</xsd:appinfo>
+                    <xsd:appinfo source="X_ForeignKeyInfo">RefSourceSystem/RefSourceSystemId</xsd:appinfo>
+                    <xsd:appinfo source="X_ForeignKeyInfo">RefSourceSystem/Bezeichnung</xsd:appinfo>
+                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="1" name="MandantNummer" type="xsd:long">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="1" name="SourceKey" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SourceSystemMandantList">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SourceSystem" type="SourceSystemMandantType">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_AutoExpand">true</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="Partner">
+        <xsd:annotation>
+            <xsd:appinfo source="X_PrimaryKeyInfo">Partner/Name</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="PartnerId" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">fn:concat(format-dateTime(current-dateTime(), "[Y][M][D][H][m][s][f]"),generate-id())</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_DE">Partner ID</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="SourceSystemMap" type="SourceSystemMandantList">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="Partner">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="PartnerId" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="RefSourceSystem">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="RefSourceSystemId" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Bezeichnung" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="RefSourceSystem">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="RefSourceSystemId" />
+        </xsd:unique>
+    </xsd:element>
 </xsd:schema>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13991
What is the current behavior? (You should also link to an open issue here)
Lucene query need to use full path as condition based on above description,but now only have the Node and the element below the Node when the current FieldMetadata element to be parsed

What is the new behavior?
Modify related method, get the current field's containingType, if it's not empty, continue to rise up until it's containingType is empty, finally, get the absolute path of the field, get the absolute path for the current fieldName.
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
