### PR TITLE
TMDM-13991 Advanced Search does not work with AND query on Foreign Key Field

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
@@ -415,6 +415,38 @@ class LuceneQueryGenerator extends VisitorAdapter<Query> {
         return query;
     }
 
+    /**
+     * Get a full path of field for its directory tree.
+     * <pre>
+     * Person
+     *      |__Stores
+     *              |__Store
+     *                      |__Name
+     *      |__Age                
+     * </pre>
+     * @return: Person.Stores.Store.Name
+     */
+    private String getFullPathName(FieldFullText fieldFullText) {
+        FieldMetadata fieldMetadata = fieldFullText.getField().getFieldMetadata();
+        StringBuilder fullPathFieldName = new StringBuilder();
+        while (fieldMetadata instanceof ReferenceFieldMetadata) {
+            String fieldName = fieldMetadata.getName();
+            ReferenceFieldMetadata referenceFieldMetadata = ((ReferenceFieldMetadata) fieldMetadata);
+            if (referenceFieldMetadata.getReferencedType().getKeyFields().size() > 1) {
+                throw new FullTextQueryCompositeKeyException(referenceFieldMetadata.getReferencedType().getName());
+            } else {
+                fullPathFieldName.insert(0, fieldName + ".");//$NON-NLS-1$
+            }
+            ComplexTypeMetadata currentContainingType = fieldMetadata.getContainingType();
+            if (currentContainingType != null && currentContainingType.getContainer() != null) {
+                fieldMetadata = currentContainingType.getContainer();
+            } else {
+                break;
+            }
+        }
+        return fullPathFieldName.toString();
+    }
+
     @Override
     public Query visit(FieldFullText fieldFullText) {
         FieldMetadata fieldMetadata = fieldFullText.getField().getFieldMetadata();
@@ -424,7 +456,7 @@ class LuceneQueryGenerator extends VisitorAdapter<Query> {
             if (referenceFieldMetadata.getReferencedType().getKeyFields().size() > 1) {
                 throw new FullTextQueryCompositeKeyException(referenceFieldMetadata.getReferencedType().getName());
             } else {
-                fieldName = fieldName + "." + referenceFieldMetadata.getReferencedField().getName(); //$NON-NLS-1$
+                fieldName = getFullPathName(fieldFullText) + referenceFieldMetadata.getReferencedField().getName(); //$NON-NLS-1$
             }
         }
         // TMDM-13918 Query by field of joining type, field name in lucene index should be fkIdField.fieldName

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
@@ -10,13 +10,11 @@
 
 package com.amalto.core.query;
 
-import static com.amalto.core.query.user.UserQueryBuilder.*;
+import static com.amalto.core.query.user.UserQueryBuilder.isNull;
 
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-
-import junit.framework.TestCase;
 
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
@@ -34,6 +32,8 @@ import com.amalto.core.storage.Storage;
 import com.amalto.core.storage.StorageType;
 import com.amalto.core.storage.datasource.DataSourceDefinition;
 import com.amalto.core.storage.hibernate.HibernateStorage;
+
+import junit.framework.TestCase;
 
 @SuppressWarnings("nls")
 public class StorageTestCase extends TestCase {
@@ -162,6 +162,10 @@ public class StorageTestCase extends TestCase {
 
     protected static final ComplexTypeMetadata contract;
 
+    protected static final ComplexTypeMetadata myFLIF_RefSourceSystem;
+
+    protected static final ComplexTypeMetadata myFLIF_Partner;
+
     public static final String DATABASE = "H2";
     
     public static final String DATASOURCE_DEFAULT = DATABASE + "-Default";
@@ -236,6 +240,8 @@ public class StorageTestCase extends TestCase {
         nn = repository.getComplexType("NN");
 
         contract = repository.getComplexType("Contract");
+        myFLIF_RefSourceSystem = repository.getComplexType("RefSourceSystem");
+        myFLIF_Partner = repository.getComplexType("Partner");
 
         systemStorage = new SecuredStorage(new HibernateStorage("MDM", StorageType.SYSTEM), userSecurity);
         systemRepository = buildSystemRepository();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -3577,8 +3577,7 @@ public class DocumentSaveTest extends TestCase {
                 assertEquals("a", result.get("name"));
                 assertNull(result.get("desc"));
                 try {
-                    result.get("complx[1]");
-                    fail("Excepted exception for not existing 'complx[1]'");
+                    assertNull(result.get("complx[1]"));//modify code to return null instead of throw exception
                 } catch (IllegalArgumentException e) {
                     // This exception is excepted
                 }

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -2849,4 +2849,95 @@
 	        <xsd:enumeration value="rejected" />
 	    </xsd:restriction>
 	</xsd:simpleType>
+    <xsd:complexType abstract="true" name="PartnerType">
+        <xsd:sequence />
+    </xsd:complexType>
+    <xsd:complexType name="SourceSystemMandantType">
+        <xsd:sequence>
+            <xsd:element maxOccurs="1" minOccurs="1" name="SourceSystemId" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_ForeignKey">RefSourceSystem/RefSourceSystemId</xsd:appinfo>
+                    <xsd:appinfo source="X_ForeignKey_NotSep">false</xsd:appinfo>
+                    <xsd:appinfo source="X_ForeignKeyInfo">RefSourceSystem/RefSourceSystemId</xsd:appinfo>
+                    <xsd:appinfo source="X_ForeignKeyInfo">RefSourceSystem/Bezeichnung</xsd:appinfo>
+                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="1" name="MandantNummer" type="xsd:long">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="1" name="SourceKey" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SourceSystemMandantList">
+        <xsd:sequence>
+            <xsd:element maxOccurs="unbounded" minOccurs="0" name="SourceSystem" type="SourceSystemMandantType">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_AutoExpand">true</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="Partner">
+        <xsd:annotation>
+            <xsd:appinfo source="X_PrimaryKeyInfo">Partner/Name</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="PartnerId" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">fn:concat(format-dateTime(current-dateTime(), "[Y][M][D][H][m][s][f]"),generate-id())</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_DE">Partner ID</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="SourceSystemMap" type="SourceSystemMandantList">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="Partner">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="PartnerId" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="RefSourceSystem">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element name="RefSourceSystemId" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Bezeichnung" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="RefSourceSystem">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="RefSourceSystemId" />
+        </xsd:unique>
+    </xsd:element>
 </xsd:schema>

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
@@ -186,8 +186,18 @@ public class DataRecord {
         StringTokenizer tokenizer = new StringTokenizer(fieldName, "/"); //$NON-NLS-1$
         DataRecord current = this;
         Object currentValue = null;
+        boolean hasField = false;
         while (tokenizer.hasMoreTokens()) {
             String currentPathElement = tokenizer.nextToken();
+            if (!current.getType().hasField(currentPathElement)) {
+                continue;
+            } else {
+                hasField = true;
+            }
+            if (!hasField) {
+                return null;
+            }
+
             FieldMetadata field = current.getType().getField(currentPathElement);
             currentValue = current.get(field);
             if (tokenizer.hasMoreTokens()) {

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordDefaultWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordDefaultWriter.java
@@ -15,11 +15,11 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
-import com.amalto.core.storage.SecuredStorage;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
 
+import com.amalto.core.storage.SecuredStorage;
 import com.amalto.core.storage.StorageMetadataUtils;
 
 

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordJSONWriter.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
- * 
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ *
  * This source code is available under agreement available at
  * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
- * 
+ *
  * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
  * 92150 Suresnes, France
  */
@@ -15,14 +15,21 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.Iterator;
 import java.util.List;
 
-import com.amalto.core.storage.SecuredStorage;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONWriter;
-import org.talend.mdm.commmon.metadata.*;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
+import org.talend.mdm.commmon.metadata.DefaultMetadataVisitor;
+import org.talend.mdm.commmon.metadata.EnumerationFieldMetadata;
+import org.talend.mdm.commmon.metadata.FieldMetadata;
+import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
+import org.talend.mdm.commmon.metadata.SimpleTypeFieldMetadata;
 
+import com.amalto.core.storage.SecuredStorage;
 import com.amalto.core.storage.StorageMetadataUtils;
+import com.amalto.core.storage.StorageResults;
 
 /**
  * A {@link com.amalto.core.storage.record.DataRecordWriter} implementation to serialize a {@link DataRecord record} to
@@ -30,7 +37,14 @@ import com.amalto.core.storage.StorageMetadataUtils;
  */
 public class DataRecordJSONWriter implements DataRecordWriter {
 
+    // Controls attribute name to be lowcase or raw value defined in schema, default: true, lowcase
+    private boolean ignoreCase = true;
+
     private SecuredStorage.UserDelegator delegator = SecuredStorage.UNSECURED;
+
+    public DataRecordJSONWriter(boolean ignoreCase) {
+        this.ignoreCase = ignoreCase;
+    }
 
     private void writeRecord(final DataRecord record, final JSONWriter writer) throws JSONException {
         writer.object();
@@ -38,19 +52,19 @@ public class DataRecordJSONWriter implements DataRecordWriter {
             if(record != null){
                 for (FieldMetadata field : record.getType().getFields()) {
                     field.accept(new DefaultMetadataVisitor<Void>() {
-    
+
                         private Void handleSimpleField(FieldMetadata field) {
                             if (delegator.hide(field)) {
                                 return null;
                             }
+                            String fieldName = getQualifiedName(field.getName());
                             try {
                                 if (!field.isMany()) {
-                                    writer.key(field.getName().toLowerCase()).value(
-                                            StorageMetadataUtils.toString(record.get(field), false));
+                                    writer.key(fieldName).value(StorageMetadataUtils.toString(record.get(field), false));
                                 } else {
                                     List<Object> values = (List<Object>) record.get(field);
                                     if (values != null) {
-                                        writer.key(field.getName().toLowerCase()).array();
+                                        writer.key(fieldName).array();
                                         for (Object value : values) {
                                             writer.value(StorageMetadataUtils.toString(value, false));
                                         }
@@ -58,28 +72,29 @@ public class DataRecordJSONWriter implements DataRecordWriter {
                                     }
                                 }
                             } catch (JSONException e) {
-                                throw new RuntimeException("Unable to serialize simple field '" + field.getName() + "'", e);
+                                throw new RuntimeException("Unable to serialize simple field '" + field.getName() + "'", e);//$NON-NLS-1$ //$NON-NLS-2$
                             }
                             return null;
                         }
-    
+
                         @Override
                         public Void visit(SimpleTypeFieldMetadata simpleField) {
                             return handleSimpleField(simpleField);
                         }
-    
+
                         @Override
                         public Void visit(EnumerationFieldMetadata enumField) {
                             return handleSimpleField(enumField);
                         }
-    
+
                         @Override
                         public Void visit(ContainedTypeFieldMetadata containedField) {
                             if (delegator.hide(containedField)) {
                                 return null;
                             }
+                            String containedName = getQualifiedName(containedField.getName());
                             try {
-                                writer.key(containedField.getName().toLowerCase());
+                                writer.key(containedName);
                                 if (!containedField.isMany()) {
                                     writeRecord((DataRecord) record.get(containedField), writer);
                                 } else {
@@ -87,7 +102,7 @@ public class DataRecordJSONWriter implements DataRecordWriter {
                                     {
                                         writer.array();
                                         if (values != null) {
-                                            
+
                                             for (DataRecord value : values) {
                                                 writeRecord(value, writer);
                                             }
@@ -96,11 +111,11 @@ public class DataRecordJSONWriter implements DataRecordWriter {
                                     }
                                 }
                             } catch (JSONException e) {
-                                throw new RuntimeException("Unable to serialize complex field '" + containedField.getName() + "'", e);
+                                throw new RuntimeException("Unable to serialize complex field '" + containedField.getName() + "'", e);//$NON-NLS-1$ //$NON-NLS-2$
                             }
                             return null;
                         }
-    
+
                         @Override
                         public Void visit(ReferenceFieldMetadata referenceField) {
                             return handleSimpleField(referenceField);
@@ -113,15 +128,45 @@ public class DataRecordJSONWriter implements DataRecordWriter {
     }
 
     @Override
+    public void write(StorageResults recordList, OutputStream output) throws IOException {
+        Writer writer = new OutputStreamWriter(output, Charset.forName("UTF-8"));//$NON-NLS-1$
+        for (Iterator<DataRecord> iterator = recordList.iterator(); iterator.hasNext();) {
+            JSONWriter jsonWriter = new JSONWriter(writer);
+            DataRecord record = iterator.next();
+            write(record, jsonWriter);
+            if (iterator.hasNext()) {
+                output.write(",".getBytes()); //$NON-NLS-1$
+            }
+            writer.flush();
+        }
+    }
+
+    private void write(DataRecord record, JSONWriter jsonWriter) throws IOException {
+        String typeName = getQualifiedName(record.getType().getName());
+        try {
+            jsonWriter.object().key(typeName);
+            {
+                if (!delegator.hide(record.getType())) {
+                    writeRecord(record, jsonWriter);
+                }
+            }
+            jsonWriter.endObject();
+        } catch (JSONException e) {
+            throw new IOException("Could not serialize to JSON.", e);//$NON-NLS-1$
+        }
+    }
+
+    @Override
     public void write(DataRecord record, OutputStream output) throws IOException {
-        write(record, new OutputStreamWriter(output, Charset.forName("UTF-8")));
+        write(record, new OutputStreamWriter(output, Charset.forName("UTF-8")));//$NON-NLS-1$
     }
 
     @Override
     public void write(DataRecord record, Writer writer) throws IOException {
         JSONWriter jsonWriter = new JSONWriter(writer);
+        String typeName = getQualifiedName(record.getType().getName());
         try {
-            jsonWriter.object().key(record.getType().getName().toLowerCase());
+            jsonWriter.object().key(typeName);
             {
                 if (!delegator.hide(record.getType())) {
                     writeRecord(record, jsonWriter);
@@ -130,15 +175,19 @@ public class DataRecordJSONWriter implements DataRecordWriter {
             jsonWriter.endObject();
             writer.flush();
         } catch (JSONException e) {
-            throw new IOException("Could not serialize to JSON.", e);
+            throw new IOException("Could not serialize to JSON.", e);//$NON-NLS-1$
         }
     }
 
     @Override
     public void setSecurityDelegator(SecuredStorage.UserDelegator delegator) {
         if(delegator == null) {
-            throw new IllegalArgumentException("Delegator cannot be null.");
+            throw new IllegalArgumentException("Delegator cannot be null.");//$NON-NLS-1$
         }
         this.delegator = delegator;
+    }
+
+    private String getQualifiedName(String name) {
+        return ignoreCase ? name.toLowerCase() : name;
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordWriter.java
@@ -11,11 +11,13 @@
 
 package com.amalto.core.storage.record;
 
-import com.amalto.core.storage.SecuredStorage;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
+import java.util.Iterator;
+
+import com.amalto.core.storage.SecuredStorage;
+import com.amalto.core.storage.StorageResults;
 
 /**
  *
@@ -31,6 +33,18 @@ public interface DataRecordWriter {
      * @see DataRecordReader#read(org.talend.mdm.commmon.metadata.MetadataRepository, org.talend.mdm.commmon.metadata.ComplexTypeMetadata, Object)
      */
     void write(DataRecord record, OutputStream output) throws IOException;
+
+    /**
+     * Writes all of {@link DataRecord} record to the <code>output</code>.
+     * @param recordList
+     * @param output
+     * @throws IOException
+     */
+    default void write(StorageResults recordList, OutputStream output) throws IOException {
+        for (Iterator<DataRecord> iterator = recordList.iterator(); iterator.hasNext();) {
+            write(iterator.next(), output);
+        }
+    }
 
     /**
      * Writes a {@link DataRecord} record to the <code>writer</code>.

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordXmlWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordXmlWriter.java
@@ -16,9 +16,11 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.core.MediaType;
 import javax.xml.XMLConstants;
 
 import org.apache.commons.lang.StringEscapeUtils;
@@ -42,8 +44,8 @@ import com.amalto.core.query.user.metadata.TaskId;
 import com.amalto.core.query.user.metadata.Timestamp;
 import com.amalto.core.schema.validation.SkipAttributeDocumentBuilder;
 import com.amalto.core.storage.SecuredStorage;
-import com.amalto.core.storage.StagingStorage;
 import com.amalto.core.storage.StorageMetadataUtils;
+import com.amalto.core.storage.StorageResults;
 import com.amalto.core.storage.record.metadata.DataRecordMetadata;
 
 public class DataRecordXmlWriter implements DataRecordWriter {

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/SystemDataRecordXmlWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/SystemDataRecordXmlWriter.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import com.amalto.core.storage.SecuredStorage;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
@@ -39,6 +38,7 @@ import com.amalto.core.metadata.ClassRepository;
 import com.amalto.core.query.user.DateConstant;
 import com.amalto.core.query.user.DateTimeConstant;
 import com.amalto.core.query.user.TimeConstant;
+import com.amalto.core.storage.SecuredStorage;
 
 public class SystemDataRecordXmlWriter implements DataRecordWriter {
 

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
@@ -18,14 +18,21 @@ import java.io.Writer;
 
 import javax.xml.XMLConstants;
 
-import com.amalto.core.storage.SecuredStorage;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
-import org.talend.mdm.commmon.metadata.*;
+import org.talend.mdm.commmon.metadata.AliasedFieldMetadata;
+import org.talend.mdm.commmon.metadata.CompoundFieldMetadata;
+import org.talend.mdm.commmon.metadata.FieldMetadata;
+import org.talend.mdm.commmon.metadata.MetadataUtils;
+import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
+import org.talend.mdm.commmon.metadata.SimpleTypeFieldMetadata;
+import org.talend.mdm.commmon.metadata.TypeMetadata;
+import org.talend.mdm.commmon.metadata.Types;
 
 import com.amalto.core.query.user.DateConstant;
 import com.amalto.core.query.user.DateTimeConstant;
 import com.amalto.core.query.user.TimeConstant;
+import com.amalto.core.storage.SecuredStorage;
 import com.amalto.core.storage.StorageMetadataUtils;
 
 public class ViewSearchResultsWriter implements DataRecordWriter {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13991
What is the current behavior? (You should also link to an open issue here)
Lucene query need to use full path as condition based on above description,but now only have the Node and the element below the Node when the current FieldMetadata element to be parsed

What is the new behavior?
Modify related method, get the current field's containingType, if it's not empty, continue to rise up until it's containingType is empty, finally, get the absolute path of the field, get the absolute path for the current fieldName.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
