### PR TITLE
TMDM-13991 Advanced Search does not work with AND query on Foreign Key Field

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordXmlWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecordXmlWriter.java
@@ -16,11 +16,9 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.core.MediaType;
 import javax.xml.XMLConstants;
 
 import org.apache.commons.lang.StringEscapeUtils;
@@ -44,8 +42,8 @@ import com.amalto.core.query.user.metadata.TaskId;
 import com.amalto.core.query.user.metadata.Timestamp;
 import com.amalto.core.schema.validation.SkipAttributeDocumentBuilder;
 import com.amalto.core.storage.SecuredStorage;
+import com.amalto.core.storage.StagingStorage;
 import com.amalto.core.storage.StorageMetadataUtils;
-import com.amalto.core.storage.StorageResults;
 import com.amalto.core.storage.record.metadata.DataRecordMetadata;
 
 public class DataRecordXmlWriter implements DataRecordWriter {

--- a/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONWriterTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/storage/record/DataRecordJSONWriterTestCase.java
@@ -29,7 +29,7 @@ public class DataRecordJSONWriterTestCase extends DataRecordDataWriterTestCase {
     @Before
     public void setup() throws Exception {
         super.setup();
-        writer = new DataRecordJSONWriter();
+        writer = new DataRecordJSONWriter(true);
         writer.setSecurityDelegator(delegate);
         repository.load(this.getClass().getResourceAsStream("metadata.xsd"));
     }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13991
What is the current behavior? (You should also link to an open issue here)
Lucene query need to use full path as condition based on above description,but now only have the Node and the element below the Node when the current FieldMetadata element to be parsed

What is the new behavior?
Modify related method, get the current field's containingType, if it's not empty, continue to rise up until it's containingType is empty, finally, get the absolute path of the field, get the absolute path for the current fieldName.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
