### PR TITLE
TMDM-13997 Failed on editing the FK value in grid if FK filter's value contain a field not defined in view's viewable elements

### DIFF
--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/shared/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/shared/util/CommonUtil.java
@@ -329,12 +329,12 @@ public class CommonUtil {
     /**
      * Parse the xpath in the function content
      * eg:
-     *     fn:string-length("xpath:/Product/Name") > 3") ==> key=Product/Name,value=Product/Name
-     *     fn:concat("xpath:Product/Name", "xpath:Product/Description") ==> key=Product/Name,value=Product/Name & key=Product/Description,value=Product/Description
-     *     fn:concat("xpath:Product/Name") ==> key=Product/Name,value=Product/Name
-     *     fn:concat("xpath:Product/Name", " s") ==> key=Product/Name,value=Product/Name
-     *     fn:starts-with("xpath:Product/Name","s")  ==> key=Product/Name,value=Product/Name
-     *     fn:matches("xpath:../Name" ,"test")  ==> key=../Name,valye=../Name
+     *     fn:string-length("xpath:/Product/Name") > 3") ==> key=xpath:Product/Name,value=Product/Name
+     *     fn:concat("xpath:Product/Name", "xpath:Product/Description") ==> key=xpath:Product/Name,value=Product/Name & key=xpath:Product/Description,value=Product/Description
+     *     fn:concat("xpath:Product/Name") ==> key=xpath:Product/Name,value=Product/Name
+     *     fn:concat("xpath:Product/Name", " s") ==> key=xpath:Product/Name,value=Product/Name
+     *     fn:starts-with("xpath:Product/Name","s")  ==> key=xpath:Product/Name,value=Product/Name
+     *     fn:matches("xpath:../Name" ,"test")  ==> key=xpath:../Name,valye=../Name
      *     fn:abs(xpath:Product/Price) ==> key=xpath:Product/Price, value=Product/Price
      *     fn:abs(/Product/Price) ==> key=/Product/Price, value=Product/Price
      * @param function the parse function

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecords.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecords.java
@@ -70,8 +70,6 @@ public class BrowseRecords implements EntryPoint {
 
     public static final String FOREIGN_KEY_FIELD = "foreignKeyField"; //$NON-NLS-1$
 
-    public static final String FOREIGN_KEY_FILTER = "foreignKeyFilter"; //$NON-NLS-1$
-
     private static JavaScriptObject stagingArea;
 
     public static JavaScriptObject getStagingArea() {

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsServiceAsync.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/BrowseRecordsServiceAsync.java
@@ -162,5 +162,5 @@ public interface BrowseRecordsServiceAsync {
     void getForeignKeySuggestion(BasePagingLoadConfigImpl config, TypeModel model, String foreignKeyFilterValue,
             String dataClusterPK, String language, AsyncCallback<List<ForeignKeyBean>> callback);
 
-    void transformFunctionValue(List<String> funciton,  AsyncCallback<List<String>> callback);
+    void transformFunctionValue(List<String> funciton, AsyncCallback<List<String>> callback);
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
@@ -425,9 +425,6 @@ public class BrowseRecordsController extends Controller {
     private void onTransformFkFilter(final AppEvent event) {
         ForeignKeyField foreignKeyField = event.getData(BrowseRecords.FOREIGN_KEY_FIELD);
         String foreignKeyFilter = foreignKeyField.getOriginForeignKeyFilter();
-        if (!foreignKeyFilter.contains(CommonUtil.FN_PREFIX)) {
-            return;
-        }
         List<String> filterList = new ArrayList<String>();
         if (foreignKeyFilter != null && foreignKeyFilter.contains(CommonUtil.FN_PREFIX)) {
             String[] criterias = CommonUtil.getCriteriasByForeignKeyFilter(foreignKeyFilter);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsController.java
@@ -423,10 +423,13 @@ public class BrowseRecordsController extends Controller {
      * @param event
      */
     private void onTransformFkFilter(final AppEvent event) {
-        String foreignKeyFilter = event.getData();
+        ForeignKeyField foreignKeyField = event.getData(BrowseRecords.FOREIGN_KEY_FIELD);
+        String foreignKeyFilter = foreignKeyField.getOriginForeignKeyFilter();
+        if (!foreignKeyFilter.contains(CommonUtil.FN_PREFIX)) {
+            return;
+        }
         List<String> filterList = new ArrayList<String>();
         if (foreignKeyFilter != null && foreignKeyFilter.contains(CommonUtil.FN_PREFIX)) {
-            ForeignKeyField foreignKeyField = event.getData(BrowseRecords.FOREIGN_KEY_FIELD);
             String[] criterias = CommonUtil.getCriteriasByForeignKeyFilter(foreignKeyFilter);
             if (foreignKeyField instanceof ForeignKeySelector) {
                 ForeignKeySelector foreignKeySelector = (ForeignKeySelector) foreignKeyField;
@@ -486,8 +489,8 @@ public class BrowseRecordsController extends Controller {
                                 }
                             }
                         }
+                        filterList.add(filterValue);
                     }
-                    filterList.add(filterValue);
                 }
             }
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsView.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsView.java
@@ -12,9 +12,11 @@ package org.talend.mdm.webapp.browserecords.client.mvc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.talend.mdm.webapp.base.shared.ComplexTypeModel;
 import org.talend.mdm.webapp.base.shared.EntityModel;
@@ -67,6 +69,8 @@ import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.GridCellRenderer;
 import com.extjs.gxt.ui.client.widget.layout.FitLayout;
+import com.google.gwt.regexp.shared.MatchResult;
+import com.google.gwt.regexp.shared.RegExp;
 
 /**
  * DOC Administrator class global comment. Detailled comment
@@ -281,6 +285,49 @@ public class BrowseRecordsView extends View {
                 itemsMainTabPanel.setSelection(tabItem);
             }
         }
+        List<Field> fkFieldList = event.getData("FKFieldList");
+        for(Field field : fkFieldList){
+            ForeignKeyCellField foreignKeyField = (ForeignKeyCellField)field;
+            String foreignKeyFilter = foreignKeyField.getDataType().getForeignKeyFilter();
+            Set<String> notInViewFieldSet = foreignKeyField.getNotInViewFieldSet();
+            Map<String, String> relativePathMapping = foreignKeyField.getRelativePathMapping();
+            String[] criterias = org.talend.mdm.webapp.base.shared.util.CommonUtil.getCriteriasByForeignKeyFilter(foreignKeyFilter);
+            StringBuilder sb = new StringBuilder();
+
+            Map<String, String> result = new HashMap<String, String>();
+
+            for (String fieldName : notInViewFieldSet) {
+                String[] paths = fieldName.split("/");
+                String pattern = "<" + paths[1] + ">([^<]+)</" + paths[1] + ">";
+                RegExp reg = RegExp.compile(pattern); //$NON-NLS-1$
+                MatchResult matchResult = reg.exec(item.getItemXml());
+                String value = "";
+                if (matchResult != null) {
+                    value = matchResult.getGroup(1);
+                    result.put(fieldName, value);
+                }
+            }
+
+            for (String criteria : criterias) {
+                Map<String, String> conditionMap = org.talend.mdm.webapp.base.shared.util.CommonUtil
+                        .buildConditionByCriteria(criteria);
+                String filterValue = conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.VALUE_STR);
+
+                filterValue = ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filterValue);
+                String predicate = conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.PREDICATE_STR);
+                predicate = predicate == null ? org.talend.mdm.webapp.base.shared.util.CommonUtil.EMPTY : predicate;
+                // the content like: Product/Name$$Contains$$"Hat"$$#
+                sb.append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.XPATH_STR))
+                        .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER)
+                        .append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.OPERATOR_STR))
+                        .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER)
+                        .append(filterValue)
+                        .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER).append(predicate).append("#"); //$NON-NLS-1$
+
+            }
+            foreignKeyField.setForeignKeyFilter(sb.toString());
+            foreignKeyField.getOriginForeignKeyFilter(sb.toString());
+        }
         ItemsDetailPanel detailPanel = itemsMainTabPanel.getCurrentViewTabItem();
         detailPanel.setOutMost(false);
         ItemPanel itemPanel = (ItemPanel) detailPanel.getPrimaryKeyTabWidget();
@@ -439,14 +486,16 @@ public class BrowseRecordsView extends View {
         for (String xpath : fkFieldwithFilterMap.keySet()) {
             ForeignKeyCellField foreignKeyCellField = fkFieldwithFilterMap.get(xpath);
             Map<Integer, Map<String, Field<?>>> targetFieldMap = new HashMap<Integer, Map<String, Field<?>>>();
-            String[] criterias = org.talend.mdm.webapp.base.shared.util.CommonUtil
-                    .getCriteriasByForeignKeyFilter(dataTypes.get(xpath).getForeignKeyFilter());
+            Set<String> notInViewFieldSet = new HashSet<String>();
+            Map<String, String> relativePathMapping = new HashMap<String, String>();
+            String[] criterias = org.talend.mdm.webapp.base.shared.util.CommonUtil.getCriteriasByForeignKeyFilter(dataTypes.get(
+                    xpath).getForeignKeyFilter());
             for (int i = 0; i < criterias.length; i++) {
                 Map<String, String> conditionMap = org.talend.mdm.webapp.base.shared.util.CommonUtil
                         .buildConditionByCriteria(criterias[i]);
                 String filterValue = conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.VALUE_STR);
-                if (filterValue != null && !filterValue.isEmpty() && !org.talend.mdm.webapp.base.shared.util.CommonUtil
-                        .isFilterValue(filterValue)) {
+                if (filterValue != null && !filterValue.isEmpty()
+                        && !org.talend.mdm.webapp.base.shared.util.CommonUtil.isFilterValue(filterValue)) {
                     String targetPath;
                     if (org.talend.mdm.webapp.base.shared.util.CommonUtil.isRelativePath(filterValue)) {
                         targetPath = ForeignKeyUtil.findTargetRelativePathForCellFK(xpath, filterValue);
@@ -456,7 +505,15 @@ public class BrowseRecordsView extends View {
                         } else {
                             xpathFieldMap = new HashMap<String, Field<?>>();
                         }
-                        xpathFieldMap.put(targetPath, fieldMap.get(targetPath));
+
+                        if (!fieldMap.containsKey(targetPath)) {
+                            notInViewFieldSet.add(targetPath);
+                            if (!relativePathMapping.containsKey(targetPath)) {
+                                relativePathMapping.put(targetPath, filterValue);
+                            }
+                        } else {
+                            xpathFieldMap.put(targetPath, fieldMap.get(targetPath));
+                        }
                         targetFieldMap.put(i, xpathFieldMap);
                     } else if (org.talend.mdm.webapp.base.shared.util.CommonUtil.isFunction(filterValue)) {
                         if (org.talend.mdm.webapp.base.shared.util.CommonUtil.containsXPath(filterValue)) {
@@ -471,15 +528,29 @@ public class BrowseRecordsView extends View {
                             for (Map.Entry<String, String> entry : xpathMap.entrySet()) {
                                 if (org.talend.mdm.webapp.base.shared.util.CommonUtil.isRelativePath(entry.getValue())) {
                                     targetPath = ForeignKeyUtil.findTargetRelativePathForCellFK(xpath, entry.getValue());
-                                    xpathFieldMap.put(entry.getKey(), fieldMap.get(targetPath));
+                                    if (!fieldMap.containsKey(targetPath)) {
+                                        notInViewFieldSet.add(targetPath);
+                                        if (!relativePathMapping.containsKey(targetPath)) {
+                                            relativePathMapping.put(targetPath, filterValue);
+                                        }
+                                    } else {
+                                        xpathFieldMap.put(entry.getKey(), fieldMap.get(targetPath));
+                                    }
                                 } else {
-                                    xpathFieldMap.put(entry.getKey(), fieldMap.get(entry.getValue()));
+                                    if (!fieldMap.containsKey(entry.getValue())) {
+                                        notInViewFieldSet.add(entry.getValue());
+                                    } else {
+                                        xpathFieldMap.put(entry.getKey(), fieldMap.get(entry.getValue()));
+                                    }
                                 }
                             }
                             targetFieldMap.put(i, xpathFieldMap);
                         }
                     } else {
                         targetPath = filterValue;
+                        if (!fieldMap.containsKey(targetPath)) {
+                            notInViewFieldSet.add(targetPath);
+                        }
                     }
                     if (filterValue != null && entityModel.getConceptName().equals(filterValue.split("/")[0])) { //$NON-NLS-1$
                         Map<String, Field<?>> xpathFieldMap = null;
@@ -494,6 +565,8 @@ public class BrowseRecordsView extends View {
                 }
             }
             foreignKeyCellField.setTargetField(targetFieldMap);
+            foreignKeyCellField.setNotInViewFieldSet(notInViewFieldSet);
+            foreignKeyCellField.setRelativePathMapping(relativePathMapping);
         }
 
         ItemsListPanel.getInstance().updateGrid(sm, ccList);
@@ -549,24 +622,30 @@ public class BrowseRecordsView extends View {
         String[] criterias = org.talend.mdm.webapp.base.shared.util.CommonUtil.getCriteriasByForeignKeyFilter(foreignKeyFilter);
         StringBuilder sb = new StringBuilder();
         for (String criteria : criterias) {
+            boolean isValue = false;
             Map<String, String> conditionMap = org.talend.mdm.webapp.base.shared.util.CommonUtil
                     .buildConditionByCriteria(criteria);
             String returnFilterValue = conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.VALUE_STR);
             if (returnFilterValue.contains(org.talend.mdm.webapp.base.shared.util.CommonUtil.FN_PREFIX)) {
                 conditionMap.put(org.talend.mdm.webapp.base.shared.util.CommonUtil.VALUE_STR, filterValue.poll());
+                isValue = true;
             }
             String predicate = conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.PREDICATE_STR);
             predicate = predicate == null ? org.talend.mdm.webapp.base.shared.util.CommonUtil.EMPTY : predicate;
 
-            //the content like: Product/Name$$Contains$$"Hat"$$#
+            // the content like: Product/Name$$Contains$$"Hat"$$#
             sb.append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.XPATH_STR))
                     .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER)
                     .append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.OPERATOR_STR))
-                    .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER).append("\"") //$NON-NLS-1$
-                    .append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.VALUE_STR))
-                    .append("\"") //$NON-NLS-1$
-                    .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER).append(predicate)
-                    .append("#"); //$NON-NLS-1$
+                    .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER);
+            if (isValue) {
+                sb.append("\""); //$NON-NLS-1$
+            }
+            sb.append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.VALUE_STR));
+            if (isValue) {
+                sb.append("\""); //$NON-NLS-1$
+            }
+            sb.append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER).append(predicate).append("#"); //$NON-NLS-1$
         }
         ForeignKeyField foreignKeyField = event.getData(BrowseRecords.FOREIGN_KEY_FIELD);
         foreignKeyField.setForeignKeyFilter(sb.toString());

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsView.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/mvc/BrowseRecordsView.java
@@ -286,12 +286,13 @@ public class BrowseRecordsView extends View {
             }
         }
         List<Field> fkFieldList = event.getData("FKFieldList");
-        for(Field field : fkFieldList){
-            ForeignKeyCellField foreignKeyField = (ForeignKeyCellField)field;
+        for (Field field : fkFieldList) {
+            ForeignKeyCellField foreignKeyField = (ForeignKeyCellField) field;
             String foreignKeyFilter = foreignKeyField.getDataType().getForeignKeyFilter();
             Set<String> notInViewFieldSet = foreignKeyField.getNotInViewFieldSet();
             Map<String, String> relativePathMapping = foreignKeyField.getRelativePathMapping();
-            String[] criterias = org.talend.mdm.webapp.base.shared.util.CommonUtil.getCriteriasByForeignKeyFilter(foreignKeyFilter);
+            String[] criterias = org.talend.mdm.webapp.base.shared.util.CommonUtil
+                    .getCriteriasByForeignKeyFilter(foreignKeyFilter);
             StringBuilder sb = new StringBuilder();
 
             Map<String, String> result = new HashMap<String, String>();
@@ -320,8 +321,7 @@ public class BrowseRecordsView extends View {
                 sb.append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.XPATH_STR))
                         .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER)
                         .append(conditionMap.get(org.talend.mdm.webapp.base.shared.util.CommonUtil.OPERATOR_STR))
-                        .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER)
-                        .append(filterValue)
+                        .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER).append(filterValue)
                         .append(org.talend.mdm.webapp.base.shared.util.CommonUtil.DOLLAR_DELIMITER).append(predicate).append("#"); //$NON-NLS-1$
 
             }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyCellField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyCellField.java
@@ -12,6 +12,7 @@ package org.talend.mdm.webapp.browserecords.client.widget.ForeignKey;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.talend.mdm.webapp.base.shared.util.CommonUtil;
 import org.talend.mdm.webapp.base.client.model.ForeignKeyBean;
@@ -22,9 +23,9 @@ public class ForeignKeyCellField extends ForeignKeyField {
 
     private Map<Integer, Map<String, Field<?>>> targetFields;
 
-    public Map<Integer, Map<String, Field<?>>> getTargetFields() {
-        return targetFields;
-    }
+    private Set<String> notInViewFieldSet;
+
+    private Map<String, String> relativePathMapping;
 
     public ForeignKeyCellField(ForeignKeyField foreignKeyField, String foreignKeyFilter) {
         super(foreignKeyField.getDataType());
@@ -77,5 +78,25 @@ public class ForeignKeyCellField extends ForeignKeyField {
         } else {
             return CommonUtil.EMPTY;
         }
+    }
+
+    public Set<String> getNotInViewFieldSet() {
+        return notInViewFieldSet;
+    }
+
+    public void setNotInViewFieldSet(Set<String> notInViewFieldSet) {
+        this.notInViewFieldSet = notInViewFieldSet;
+    }
+
+    public Map<String, String> getRelativePathMapping() {
+        return relativePathMapping;
+    }
+
+    public void setRelativePathMapping(Map<String, String> relativePathMapping) {
+        this.relativePathMapping = relativePathMapping;
+    }
+
+    public Map<Integer, Map<String, Field<?>>> getTargetFields() {
+        return targetFields;
     }
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
@@ -333,8 +333,9 @@ public class ForeignKeyField extends TextField<ForeignKeyBean> {
             @Override
             public void onClick(ClickEvent ce) {
                 if (foreignConceptName != null) {
+
                     String foreignKeyFilter = getOriginForeignKeyFilter();
-                    if (foreignKeyFilter.contains(CommonUtil.FN_PREFIX)) {
+                    if (foreignKeyFilter.contains(CommonUtil.FN_PREFIX) ) {
                         AppEvent event = new AppEvent(BrowseRecordsEvents.TransformFkFilterItem, foreignKeyFilter);
                         event.setData(BrowseRecords.FOREIGN_KEY_FIELD, _this);
                         event.setData(BrowseRecords.FOREIGN_KEY_FILTER, foreignKeyFilter);
@@ -406,11 +407,18 @@ public class ForeignKeyField extends TextField<ForeignKeyBean> {
         this.foreignKeyFilter = foreignKeyFilter;
     }
 
+    public String getForeignKeyFilter() {
+        return this.foreignKeyFilter;
+    }
+
     public String getOriginForeignKeyFilter() {
         return this.originForeignKeyFilter == null ? CommonUtil.EMPTY : this.originForeignKeyFilter;
     }
 
     public boolean isWithTextInput() {
         return withTextInput;
+    }
+    public void getOriginForeignKeyFilter(String originForeignKeyFilter) {
+        this.originForeignKeyFilter = originForeignKeyFilter;
     }
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
@@ -333,12 +333,10 @@ public class ForeignKeyField extends TextField<ForeignKeyBean> {
             @Override
             public void onClick(ClickEvent ce) {
                 if (foreignConceptName != null) {
-
                     String foreignKeyFilter = getOriginForeignKeyFilter();
                     if (foreignKeyFilter.contains(CommonUtil.FN_PREFIX)) {
                         AppEvent event = new AppEvent(BrowseRecordsEvents.TransformFkFilterItem, foreignKeyFilter);
                         event.setData(BrowseRecords.FOREIGN_KEY_FIELD, _this);
-                        event.setData(BrowseRecords.FOREIGN_KEY_FILTER, foreignKeyFilter);
                         Dispatcher.forwardEvent(event);
                     }
 

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
@@ -335,7 +335,7 @@ public class ForeignKeyField extends TextField<ForeignKeyBean> {
                 if (foreignConceptName != null) {
 
                     String foreignKeyFilter = getOriginForeignKeyFilter();
-                    if (foreignKeyFilter.contains(CommonUtil.FN_PREFIX) ) {
+                    if (foreignKeyFilter.contains(CommonUtil.FN_PREFIX)) {
                         AppEvent event = new AppEvent(BrowseRecordsEvents.TransformFkFilterItem, foreignKeyFilter);
                         event.setData(BrowseRecords.FOREIGN_KEY_FIELD, _this);
                         event.setData(BrowseRecords.FOREIGN_KEY_FILTER, foreignKeyFilter);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsListPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsListPanel.java
@@ -48,6 +48,7 @@ import org.talend.mdm.webapp.browserecords.client.util.DateUtil;
 import org.talend.mdm.webapp.browserecords.client.util.Locale;
 import org.talend.mdm.webapp.browserecords.client.util.MessageUtil;
 import org.talend.mdm.webapp.browserecords.client.util.UserSession;
+import org.talend.mdm.webapp.browserecords.client.widget.inputfield.celleditor.FKCellEditor;
 import org.talend.mdm.webapp.browserecords.client.widget.treedetail.ForeignKeyTreeDetail;
 import org.talend.mdm.webapp.browserecords.client.widget.treedetail.TreeDetailUtil;
 import org.talend.mdm.webapp.browserecords.shared.ViewBean;
@@ -85,6 +86,7 @@ import com.extjs.gxt.ui.client.widget.Dialog;
 import com.extjs.gxt.ui.client.widget.Html;
 import com.extjs.gxt.ui.client.widget.MessageBox;
 import com.extjs.gxt.ui.client.widget.TabItem;
+import com.extjs.gxt.ui.client.widget.form.Field;
 import com.extjs.gxt.ui.client.widget.grid.CheckBoxSelectionModel;
 import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
 import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
@@ -782,6 +784,14 @@ public class ItemsListPanel extends ContentPanel {
             BrowseRecords.getSession().put(UserSession.CURRENT_CACHED_FKTABS, null);
             AppEvent event = new AppEvent(BrowseRecordsEvents.ViewItem, item);
             event.setData("isStaging", isStaging()); //$NON-NLS-1$
+            List<ColumnConfig> columnConfigList = grid.getColumnModel().getColumns();
+            List<Field> fkFieldList = new ArrayList<Field>();
+            for (ColumnConfig columnConfig : columnConfigList) {
+                if (columnConfig.getEditor() != null && (columnConfig.getEditor() instanceof FKCellEditor)) {
+                    fkFieldList.add(columnConfig.getEditor().getField());
+                }
+            }
+            event.setData("FKFieldList", fkFieldList);
             Dispatcher.forwardEvent(event);
             gridUpdateLock = false;
         }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/SuggestComboBoxField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/SuggestComboBoxField.java
@@ -164,7 +164,6 @@ public class SuggestComboBoxField extends ComboBoxEx<ForeignKeyBean> {
                         if (foreignKeyFilter.contains(org.talend.mdm.webapp.base.shared.util.CommonUtil.FN_PREFIX)) {
                             AppEvent event = new AppEvent(BrowseRecordsEvents.TransformFkFilterItem, foreignKeyFilter);
                             event.setData(BrowseRecords.FOREIGN_KEY_FIELD, foreignKeyField);
-                            event.setData(BrowseRecords.FOREIGN_KEY_FILTER, foreignKeyFilter);
                             Dispatcher.forwardEvent(event);
                         }
                         task.delay(getListDelay);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
@@ -2494,7 +2494,6 @@ public class BrowseRecordsAction implements BrowseRecordsService {
     }
 
     public List<String> transformFunctionValue(List<String> functionList) throws ServiceException {
-        List<String> result = new ArrayList<>();
         try {
             Document doc = XMLUtils.parse("<result></result>"); //$NON-NLS-1$;
             Element element = doc.getDocumentElement();
@@ -2511,26 +2510,5 @@ public class BrowseRecordsAction implements BrowseRecordsService {
             LOG.error(e.getMessage(), e);
             throw new ServiceException(e.getLocalizedMessage());
         }
-    }
-
-    public Map<String, String> getFieldValuesByIds(String concept, String ids, Set<String> fieldPatSet, String language) {
-        Map<String, String> result = new HashMap<String, String>();
-        try {
-            MetadataRepository repository = CommonUtil.getCurrentRepository();
-            String[] idsArray = CommonUtil.getItemId(repository, ids, concept);
-
-            WSItem wsItem = CommonUtil.getPort().getItem(
-                    new WSGetItem(new WSItemPK(new WSDataClusterPK(this.getCurrentDataCluster()), concept, idsArray)));
-
-            org.dom4j.Document doc = org.talend.mdm.webapp.base.server.util.XmlUtil.parseText(wsItem.getContent());
-            EntityModel entityModel = getEntityModel(concept, language);
-            for (String fieldPath : fieldPatSet) {
-                org.dom4j.Node node = doc.selectSingleNode(fieldPath);
-                result.put(fieldPath, node.getText());
-            }
-        } catch (Exception e) {
-
-        }
-        return result;
     }
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
@@ -2496,10 +2496,10 @@ public class BrowseRecordsAction implements BrowseRecordsService {
     public List<String> transformFunctionValue(List<String> functionList) throws ServiceException {
         List<String> result = new ArrayList<>();
         try {
-            Document doc = XMLUtils.parse("<result></result>"); //$NON-NLS-1$);
+            Document doc = XMLUtils.parse("<result></result>"); //$NON-NLS-1$;
             Element element = doc.getDocumentElement();
             for (String function : functionList) {
-                element.appendChild(doc.createElement("functionName")); //$NON-NLS-1$);
+                element.appendChild(doc.createElement("functionName")); //$NON-NLS-1$;
             }
 
             org.dom4j.Document doc4j = XmlUtil.parseDocument(doc);
@@ -2511,5 +2511,26 @@ public class BrowseRecordsAction implements BrowseRecordsService {
             LOG.error(e.getMessage(), e);
             throw new ServiceException(e.getLocalizedMessage());
         }
+    }
+
+    public Map<String, String> getFieldValuesByIds(String concept, String ids, Set<String> fieldPatSet, String language) {
+        Map<String, String> result = new HashMap<String, String>();
+        try {
+            MetadataRepository repository = CommonUtil.getCurrentRepository();
+            String[] idsArray = CommonUtil.getItemId(repository, ids, concept);
+
+            WSItem wsItem = CommonUtil.getPort().getItem(
+                    new WSGetItem(new WSItemPK(new WSDataClusterPK(this.getCurrentDataCluster()), concept, idsArray)));
+
+            org.dom4j.Document doc = org.talend.mdm.webapp.base.server.util.XmlUtil.parseText(wsItem.getContent());
+            EntityModel entityModel = getEntityModel(concept, language);
+            for (String fieldPath : fieldPatSet) {
+                org.dom4j.Node node = doc.selectSingleNode(fieldPath);
+                result.put(fieldPath, node.getText());
+            }
+        } catch (Exception e) {
+
+        }
+        return result;
     }
 }

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/ForeignKeyUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/ForeignKeyUtilTest.java
@@ -10,6 +10,11 @@
 
 package org.talend.mdm.webapp.browserecords.client.widget.treedetail;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import com.google.gwt.junit.client.GWTTestCase;
 import org.talend.mdm.webapp.browserecords.client.model.ItemNodeModel;
 
@@ -90,6 +95,73 @@ public class ForeignKeyUtilTest extends GWTTestCase {
 
     public void testFindTargetRelativePathForCellFK() {
         assertEquals("Product/Name", ForeignKeyUtil.findTargetRelativePathForCellFK("Product/Family", "../Name"));
+    }
+
+    public void testParseFilterValue() {
+        Map<String, String> result = new HashMap<String, String>();
+        result.put("Product/Name", "Talend Dog T-Shirt");
+        Set<String> notInViewFieldSet = new HashSet<String>();
+        notInViewFieldSet.add("Product/Name");
+        Map<String, String> relativePathMapping = new HashMap<String, String>();
+        relativePathMapping.put("Product/Name", "../Name");
+
+        //Not exist in viewable
+        //1. two XSI function xpath not exist in viewable
+        String filter = "fn:concat(&quot;xpath:/Product/Name&quot;, &quot;xpath:/Product/Name&quot;)";
+        String expectedFilter = "fn:concat(&quot;Talend Dog T-Shirt&quot;, &quot;Talend Dog T-Shirt&quot;)";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //2. one XSI function xpath not exist in viewable
+        filter = "fn:concat(&quot;xpath:/Product/Name&quot;, &quot;s&quot;)";
+        expectedFilter = "fn:concat(&quot;Talend Dog T-Shirt&quot;, &quot;s&quot;)";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //3. one xpath not exist in viewable
+        filter = "Product/Name";
+        expectedFilter = "\"Talend Dog T-Shirt\"";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //4. one relative path not exist in viewable
+        filter = "../Name";
+        expectedFilter = "\"Talend Dog T-Shirt\"";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //5. one XSI function relative xpath not exist in viewable
+        filter = "fn:concat(&quot;xpath:../Name&quot;, &quot;s&quot;)";
+        expectedFilter = "fn:concat(&quot;Talend Dog T-Shirt&quot;, &quot;s&quot;)";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //Exist in viewable
+        //6. one xpath exist in viewable
+        filter = "Product/Description";
+        expectedFilter = "Product/Description";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //7. one XSI function xpath exist in viewable
+        filter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;s&quot;)";
+        expectedFilter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;s&quot;)";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //8. ../Description
+        filter = "../Description";
+        expectedFilter = "../Description";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //9. fn:concat("xpath:../Description", "s")
+        filter = "fn:concat(&quot;xpath:../Description&quot;, &quot;s&quot;)";
+        expectedFilter = "fn:concat(&quot;xpath:../Description&quot;, &quot;s&quot;)";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //10. fn:concat("xpath:/Product/Description", "xpath:/Product/Description")
+        filter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;xpath:/Product/Description&quot;)";
+        expectedFilter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;xpath:/Product/Description&quot;)";
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
+
+        //11. One Exist in viewable, one don't exist in viewable
+        filter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;xpath:/Product/Name&quot;)";
+        expectedFilter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;Talend Dog T-Shirt&quot;)";
+        String aa = ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter);
+        assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
     }
 
     /**

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/ForeignKeyUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/ForeignKeyUtilTest.java
@@ -105,59 +105,59 @@ public class ForeignKeyUtilTest extends GWTTestCase {
         Map<String, String> relativePathMapping = new HashMap<String, String>();
         relativePathMapping.put("Product/Name", "../Name");
 
-        //Not exist in viewable
-        //1. two XSI function xpath not exist in viewable
+        // Not exist in viewable
+        // 1. two XSI function xpath not exist in viewable
         String filter = "fn:concat(&quot;xpath:/Product/Name&quot;, &quot;xpath:/Product/Name&quot;)";
         String expectedFilter = "fn:concat(&quot;Talend Dog T-Shirt&quot;, &quot;Talend Dog T-Shirt&quot;)";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //2. one XSI function xpath not exist in viewable
+        // 2. one XSI function xpath not exist in viewable
         filter = "fn:concat(&quot;xpath:/Product/Name&quot;, &quot;s&quot;)";
         expectedFilter = "fn:concat(&quot;Talend Dog T-Shirt&quot;, &quot;s&quot;)";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //3. one xpath not exist in viewable
+        // 3. one xpath not exist in viewable
         filter = "Product/Name";
         expectedFilter = "\"Talend Dog T-Shirt\"";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //4. one relative path not exist in viewable
+        // 4. one relative path not exist in viewable
         filter = "../Name";
         expectedFilter = "\"Talend Dog T-Shirt\"";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //5. one XSI function relative xpath not exist in viewable
+        // 5. one XSI function relative xpath not exist in viewable
         filter = "fn:concat(&quot;xpath:../Name&quot;, &quot;s&quot;)";
         expectedFilter = "fn:concat(&quot;Talend Dog T-Shirt&quot;, &quot;s&quot;)";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //Exist in viewable
-        //6. one xpath exist in viewable
+        // Exist in viewable
+        // 6. one xpath exist in viewable
         filter = "Product/Description";
         expectedFilter = "Product/Description";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //7. one XSI function xpath exist in viewable
+        // 7. one XSI function xpath exist in viewable
         filter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;s&quot;)";
         expectedFilter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;s&quot;)";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //8. ../Description
+        // 8. ../Description
         filter = "../Description";
         expectedFilter = "../Description";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //9. fn:concat("xpath:../Description", "s")
+        // 9. fn:concat("xpath:../Description", "s")
         filter = "fn:concat(&quot;xpath:../Description&quot;, &quot;s&quot;)";
         expectedFilter = "fn:concat(&quot;xpath:../Description&quot;, &quot;s&quot;)";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //10. fn:concat("xpath:/Product/Description", "xpath:/Product/Description")
+        // 10. fn:concat("xpath:/Product/Description", "xpath:/Product/Description")
         filter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;xpath:/Product/Description&quot;)";
         expectedFilter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;xpath:/Product/Description&quot;)";
         assertEquals(expectedFilter, ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter));
 
-        //11. One Exist in viewable, one don't exist in viewable
+        // 11. One Exist in viewable, one don't exist in viewable
         filter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;xpath:/Product/Name&quot;)";
         expectedFilter = "fn:concat(&quot;xpath:/Product/Description&quot;, &quot;Talend Dog T-Shirt&quot;)";
         String aa = ForeignKeyUtil.parseFilterValue(result, notInViewFieldSet, relativePathMapping, filter);


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-13997

**What is the current behavior?** (You should also link to an open issue here)
In the foreign key filter, if the value is a xpath and this xpath is not exist in the viewable elements, when edit this fk in the grid, contains some issue.


**What is the new behavior?**
when query the current row details, set value for the field which is not exist in the gird viewable.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
