### PR TITLE
TMDM-14089 WebUI frozen when clicking FK picker if FK filter contains special character '&'

### DIFF
--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/shared/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/shared/util/CommonUtil.java
@@ -317,6 +317,9 @@ public class CommonUtil {
                     } else if (value.startsWith("&gt;", i)) { //$NON-NLS-1$
                         result.append('>');
                         i += 4;
+                    } else {
+                        result.append(charAt);
+                        i++;
                     }
                 }
             }

--- a/org.talend.mdm.webapp.base/src/test/java/org/talend/mdm/webapp/base/shared/util/CommonUtilTest.java
+++ b/org.talend.mdm.webapp.base/src/test/java/org/talend/mdm/webapp/base/shared/util/CommonUtilTest.java
@@ -177,4 +177,16 @@ public class CommonUtilTest extends TestCase {
         assertTrue(CommonUtil.containsXPath("fn:abs(xpath:/Product/Name)"));
         assertTrue(CommonUtil.containsXPath("fn:abs(/Product/Name)"));
     }
+
+    public void testUnescapeXml() {
+        assertEquals("a&b", CommonUtil.unescapeXml("a&b"));
+        assertEquals("a&b", CommonUtil.unescapeXml("a&amp;b"));
+        assertEquals("a'b", CommonUtil.unescapeXml("a&apos;b"));
+        assertEquals("a\"b", CommonUtil.unescapeXml("a&quot;b"));
+        assertEquals("a<b", CommonUtil.unescapeXml("a&lt;b"));
+        assertEquals("a>b", CommonUtil.unescapeXml("a&gt;b"));
+        assertEquals("a&yen;b", CommonUtil.unescapeXml("a&yen;b"));
+        assertEquals("Talend Shirt", CommonUtil.unescapeXml("Talend Shirt"));
+        assertEquals("a￥b￡", CommonUtil.unescapeXml("a￥b￡"));
+    }
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsAction.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
 
@@ -2495,16 +2496,20 @@ public class BrowseRecordsAction implements BrowseRecordsService {
 
     public List<String> transformFunctionValue(List<String> functionList) throws ServiceException {
         try {
+            List<String> escapedFunctionList = functionList.stream().map((String functionName) -> {
+                return XmlUtil.escapeXml(XmlUtil.unescapeXml(functionName));
+            }).collect(Collectors.toList());
+
             Document doc = XMLUtils.parse("<result></result>"); //$NON-NLS-1$;
             Element element = doc.getDocumentElement();
-            for (String function : functionList) {
+            for (String function : escapedFunctionList) {
                 element.appendChild(doc.createElement("functionName")); //$NON-NLS-1$;
             }
 
             org.dom4j.Document doc4j = XmlUtil.parseDocument(doc);
 
             DisplayRuleEngine ruleEngine = new DisplayRuleEngine(null, null);
-            ruleEngine.setFuncitonList(functionList);
+            ruleEngine.setFuncitonList(escapedFunctionList);
             return ruleEngine.execFKFilterRule(doc4j);
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsActionTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsActionTest.java
@@ -1370,6 +1370,10 @@ public class BrowseRecordsActionTest extends TestCase {
         filter.add("fn:starts-with(&quot;Herbert&quot;,&quot;s&quot;)");
         filter.add("fn:string-length(&quot;Herbert&quot;) > 3");
         filter.add("fn:matches(&quot;&quot; ,&quot;test&quot;)");
+        filter.add("fn:concat(&quot;a&amp;b&quot;, &quot;s&quot;)");
+        filter.add("fn:concat(&quot;a&b&quot;, &quot;s&quot;)");
+        filter.add("fn:concat(&quot;a&&quot;, &quot;s&quot;)");
+        filter.add("fn:concat(&quot;a&amp;&quot;, &quot;s&quot;)");
         List<String> result = null;
         try {
             result = action.transformFunctionValue(filter);
@@ -1377,7 +1381,7 @@ public class BrowseRecordsActionTest extends TestCase {
             fail();
         }
 
-        assertEquals(16, result.size());
+        assertEquals(20, result.size());
         assertEquals("aas", result.get(0));
         assertEquals("This is a Test", result.get(1));
         assertEquals("true", result.get(2));
@@ -1394,6 +1398,10 @@ public class BrowseRecordsActionTest extends TestCase {
         assertEquals("false", result.get(13));
         assertEquals("true", result.get(14));
         assertEquals("false", result.get(15));
+        assertEquals("a&bs", result.get(16));
+        assertEquals("a&bs", result.get(17));
+        assertEquals("a&s", result.get(18));
+        assertEquals("a&s", result.get(19));
     }
 
     /**

--- a/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/XmlUtil.java
+++ b/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/XmlUtil.java
@@ -26,17 +26,23 @@ public class XmlUtil {
     public static String escapeXml(String value) {
         if (value == null)
             return null;
-        boolean isEscaped=false;
+        boolean isEscaped = false;
         if (value.contains("&quot;") || //$NON-NLS-1$
                 value.contains("&amp;") || //$NON-NLS-1$
                 value.contains("&lt;") || //$NON-NLS-1$
                 value.contains("&gt;")) { //$NON-NLS-1$
             isEscaped = true;
         }
-        if(!isEscaped) {
-            value=StringEscapeUtils.escapeXml(value);
+        if (!isEscaped) {
+            value = StringEscapeUtils.escapeXml(value);
         }
         return value;
     }
 
+    public static String unescapeXml(String value) {
+        if (value == null) {
+            return null;
+        }
+        return StringEscapeUtils.unescapeXml(value);
+    }
 }

--- a/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/XmlUtilTest.java
+++ b/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/XmlUtilTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ *  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+
+package com.amalto.webapp.core.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+@SuppressWarnings("nls")
+public class XmlUtilTest {
+
+    @Test
+    public void escapeXml() {
+        assertEquals(null, XmlUtil.escapeXml(null));
+        assertEquals("fn:concat(&quot;a&b&quot;, &quot;s&quot;)", XmlUtil.escapeXml("fn:concat(&quot;a&b&quot;, &quot;s&quot;)"));
+        assertEquals("fn:concat(&quot;a&amp;b&quot;, &quot;s&quot;)",
+                XmlUtil.escapeXml("fn:concat(&quot;a&amp;b&quot;, &quot;s&quot;)"));
+        assertEquals("fn:concat(&quot;a&amp;b&quot;, &quot;s&quot;)", XmlUtil.escapeXml("fn:concat(\"a&b\", \"s\")"));
+    }
+
+    @Test
+    public void unescapeXML() {
+        assertEquals(null, XmlUtil.unescapeXml(null));
+        assertEquals("fn:concat(\"a&b\", \"s\")", XmlUtil.unescapeXml("fn:concat(&quot;a&b&quot;, &quot;s&quot;)"));
+        assertEquals("fn:concat(\"a&b\", \"s\")", XmlUtil.unescapeXml("fn:concat(&quot;a&amp;b&quot;, &quot;s&quot;)"));
+    }
+}


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-14089

**What is the current behavior?** (You should also link to an open issue here)
endless-loop when unescaping the FK filter which contains the character '&'


**What is the new behavior?**
add the condition when the character is '&'.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
