### PR TITLE
TMDM-14098 No FK picker in the search bar when no write access on the FK field

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ForeignKey/ForeignKeyField.java
@@ -40,6 +40,10 @@ import com.google.gwt.user.client.ui.Image;
 
 public class ForeignKeyField extends TextField<ForeignKeyBean> {
 
+    public static final String USAGE_SEARCH_FIELD_CREATOR = "SearchFieldCreator"; //$NON-NLS-1$
+
+    public static final String USAGE_FOREIGN_KEY_TABLE_PANEL = "ForeignKeyTablePanel"; //$NON-NLS-1$
+
     private BrowseRecordsServiceAsync service = (BrowseRecordsServiceAsync) Registry.get(BrowseRecords.BROWSERECORDS_SERVICE);
 
     protected TypeModel dataType;
@@ -75,22 +79,27 @@ public class ForeignKeyField extends TextField<ForeignKeyBean> {
     protected boolean withTextInput; // Check if create input field or suggest box
 
     public ForeignKeyField(TypeModel dataType) {
-        init(dataType);
+        init(dataType, null);
         initField(false);
     }
 
-    public ForeignKeyField(TypeModel dataType, boolean withTextInput) {
-        init(dataType);
+    public ForeignKeyField(TypeModel dataType, boolean withTextInput, String usageField) {
+        init(dataType, usageField);
         initField(withTextInput);
     }
 
-    private void init(TypeModel dataType) {
+    private void init(TypeModel dataType, String usageField) {
         this.dataType = dataType;
         this.foreignKeyPath = dataType.getForeignkey();
         this.foreignKeyInfo = dataType.getForeignKeyInfo();
         this.currentPath = dataType.getXpath();
         this.selectButton = new Image(Icons.INSTANCE.link());
-        this.showSelectButton = !dataType.isReadOnly();
+        this.usageField = usageField;
+        if (USAGE_SEARCH_FIELD_CREATOR.equals(usageField)) {
+            this.showSelectButton = true;
+        } else {
+            this.showSelectButton = !dataType.isReadOnly();
+        }
         this.setFireChangeEventOnSetValue(true);
         String[] foreignKeyPathArray = foreignKeyPath.split("/"); //$NON-NLS-1$
         if (foreignKeyPathArray.length > 0) {
@@ -102,7 +111,7 @@ public class ForeignKeyField extends TextField<ForeignKeyBean> {
         // If withTextInput=true, won't initialize suggestBox but will initialize textField
         if (withTextInput) {
             this.textField = new TextField<String>();
-            this.withTextInput = withTextInput;
+            this.withTextInput = true;
             this.showInput = false;
         } else {
             this.suggestBox = new SuggestComboBoxField(this);
@@ -124,13 +133,13 @@ public class ForeignKeyField extends TextField<ForeignKeyBean> {
     @Override
     protected void onResize(int width, int height) {
         if (withTextInput) {
-            if ("SearchFieldCreator".equals(usageField)) { //$NON-NLS-1$
+            if (USAGE_SEARCH_FIELD_CREATOR.equals(usageField)) {
                 textField.setWidth(width - selectButton.getWidth() - 20);
             } else {
                 textField.setWidth(width);
             }
         } else {
-            if ("SearchFieldCreator".equals(usageField)) { //$NON-NLS-1$
+            if (USAGE_SEARCH_FIELD_CREATOR.equals(usageField)) {
                 suggestBox.setWidth(width - selectButton.getWidth() - 20);
             } else {
                 suggestBox.setWidth(width);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/creator/SearchFieldCreator.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/creator/SearchFieldCreator.java
@@ -91,9 +91,7 @@ public class SearchFieldCreator {
     }
 
     private static Field createForeignKeyField(TypeModel typeModel, boolean withTextInput) {
-        ForeignKeyField fkField = new ForeignKeyField(typeModel, withTextInput);
-        fkField.setUsageField("SearchFieldCreator"); //$NON-NLS-1$
-        return fkField;
+        return new ForeignKeyField(typeModel, withTextInput, ForeignKeyField.USAGE_SEARCH_FIELD_CREATOR);
     }
 
     private static void setEnumerationValues(TypeModel typeModel, Widget w) {

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/ForeignKeyTablePanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/treedetail/ForeignKeyTablePanel.java
@@ -31,6 +31,7 @@ import org.talend.mdm.webapp.browserecords.client.model.ItemNodeModel;
 import org.talend.mdm.webapp.browserecords.client.mvc.BrowseRecordsView;
 import org.talend.mdm.webapp.browserecords.client.resources.icon.Icons;
 import org.talend.mdm.webapp.browserecords.client.util.Locale;
+import org.talend.mdm.webapp.browserecords.client.widget.ForeignKey.ForeignKeyField;
 import org.talend.mdm.webapp.browserecords.client.widget.ForeignKeyRowEditor;
 import org.talend.mdm.webapp.browserecords.client.widget.ItemPanel;
 import org.talend.mdm.webapp.browserecords.client.widget.ItemsDetailPanel;
@@ -249,7 +250,7 @@ public class ForeignKeyTablePanel extends ContentPanel implements ReturnCriteria
         columnConfigs.add(sm.getColumn());
 
         foreignKeySelector = new ForeignKeySelector(fkTypeModel, itemsDetailPanel, parent);
-        foreignKeySelector.setUsageField("ForeignKeyTablePanel"); //$NON-NLS-1$
+        foreignKeySelector.setUsageField(ForeignKeyField.USAGE_FOREIGN_KEY_TABLE_PANEL);
         foreignKeySelector.setShowAddButton(false);
         foreignKeySelector.setShowCleanButton(false);
         foreignKeySelector.setShowRelationButton(false);


### PR DESCRIPTION
Jira: https://jira.talendforge.org/browse/TMDM-14168
**What is the current behavior?** (You should also link to an open issue here)
Don't disply the FK Picker if user have no write access on WEB UI.


**What is the new behavior?**
set the ForeignKeyField's attribute *showSelectButton* to true if the useageField is *SearchFieldCreator*


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
