### PR TITLE
TMDM-14257 Throw error while updating a composite FK field and save (7.1)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -694,6 +694,30 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("16.99", evaluate(committedElement, "/Product/Price"));
     }
 
+    public void testUpdateCompositeFK() throws Exception {
+        final MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("TestCompositeFK.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("TestCompositeFK", repository);
+
+        SaverSource source = new TestSaverSource(repository, true, "testCompositeFK_original.xml", "TestCompositeFK.xsd");
+
+        SaverSession session = SaverSession.newSession(source);
+        InputStream recordXml = new ByteArrayInputStream(
+                "<TestMultipleCompositeFK><Id>1</Id><Name>1</Name><FK>[Id2_c][Id1_c]</FK></TestMultipleCompositeFK>"
+                        .getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().create("MDM", "TestCompositeFK", "Source", recordXml, true,
+                true, true, false, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        System.out.print(evaluate(committedElement, "/TestMultipleCompositeFK/FK"));
+        assertEquals("[Id2_c][Id1_c]", evaluate(committedElement, "/TestMultipleCompositeFK/FK"));
+    }
+
     public void testPartialUpdate() throws Exception {
         final MetadataRepository repository = new MetadataRepository();
         repository.load(DocumentSaveTest.class.getResourceAsStream("metadata1.xsd"));

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TestCompositeFK.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TestCompositeFK.xsd
@@ -1,0 +1,68 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">  
+  <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>            
+  <xsd:element name="FK2"> 
+    <xsd:annotation> 
+      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+    </xsd:annotation>  
+    <xsd:complexType> 
+      <xsd:all> 
+        <xsd:element maxOccurs="1" minOccurs="1" name="Id1" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="1" name="Id2" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element> 
+      </xsd:all> 
+    </xsd:complexType>  
+    <xsd:unique name="FK2"> 
+      <xsd:selector xpath="."/>  
+      <xsd:field xpath="Id2"/>  
+      <xsd:field xpath="Id1"/> 
+    </xsd:unique> 
+  </xsd:element>      
+  <xsd:element name="TestMultipleCompositeFK"> 
+    <xsd:annotation>       
+    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+</xsd:annotation>  
+    <xsd:complexType> 
+      <xsd:sequence> 
+        <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"> 
+          <xsd:annotation>              
+          <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+</xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"> 
+          <xsd:annotation>              
+          <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+</xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="unbounded" minOccurs="0" name="FK" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_ForeignKey">FK2</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>               
+          <xsd:appinfo source="X_No_Remove">Demo_User</xsd:appinfo>
+<xsd:appinfo source="X_No_Add">Demo_Manager</xsd:appinfo>
+<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+</xsd:annotation> 
+        </xsd:element> 
+      </xsd:sequence> 
+    </xsd:complexType>  
+    <xsd:unique name="TestMultipleCompositeFK"> 
+      <xsd:selector xpath="."/>  
+      <xsd:field xpath="Id"/> 
+    </xsd:unique> 
+  </xsd:element>   
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TestCompositeFK.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TestCompositeFK.xsd
@@ -1,68 +1,68 @@
-<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">  
-  <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>            
-  <xsd:element name="FK2"> 
-    <xsd:annotation> 
-      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
-    </xsd:annotation>  
-    <xsd:complexType> 
-      <xsd:all> 
-        <xsd:element maxOccurs="1" minOccurs="1" name="Id1" type="xsd:string"> 
-          <xsd:annotation> 
-            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
-          </xsd:annotation> 
-        </xsd:element>  
-        <xsd:element maxOccurs="1" minOccurs="1" name="Id2" type="xsd:string"> 
-          <xsd:annotation> 
-            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
-          </xsd:annotation> 
-        </xsd:element>  
-        <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"> 
-          <xsd:annotation> 
-            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
-          </xsd:annotation> 
-        </xsd:element> 
-      </xsd:all> 
-    </xsd:complexType>  
-    <xsd:unique name="FK2"> 
-      <xsd:selector xpath="."/>  
-      <xsd:field xpath="Id2"/>  
-      <xsd:field xpath="Id1"/> 
-    </xsd:unique> 
-  </xsd:element>      
-  <xsd:element name="TestMultipleCompositeFK"> 
-    <xsd:annotation>       
-    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
-<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
-</xsd:annotation>  
-    <xsd:complexType> 
-      <xsd:sequence> 
-        <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"> 
-          <xsd:annotation>              
-          <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
-<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
-</xsd:annotation> 
-        </xsd:element>  
-        <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"> 
-          <xsd:annotation>              
-          <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
-<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
-</xsd:annotation> 
-        </xsd:element>  
-        <xsd:element maxOccurs="unbounded" minOccurs="0" name="FK" type="xsd:string"> 
-          <xsd:annotation> 
-            <xsd:appinfo source="X_ForeignKey">FK2</xsd:appinfo>  
-            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>               
-          <xsd:appinfo source="X_No_Remove">Demo_User</xsd:appinfo>
-<xsd:appinfo source="X_No_Add">Demo_Manager</xsd:appinfo>
-<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
-<xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
-</xsd:annotation> 
-        </xsd:element> 
-      </xsd:sequence> 
-    </xsd:complexType>  
-    <xsd:unique name="TestMultipleCompositeFK"> 
-      <xsd:selector xpath="."/>  
-      <xsd:field xpath="Id"/> 
-    </xsd:unique> 
-  </xsd:element>   
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
+    <xsd:element name="FK2">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id1" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id2" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="FK2">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id2"/>
+            <xsd:field xpath="Id1"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="TestMultipleCompositeFK">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" name="FK" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_ForeignKey">FK2</xsd:appinfo>
+                        <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>
+                        <xsd:appinfo source="X_No_Remove">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_No_Add">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="TestMultipleCompositeFK">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
 </xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/testCompositeFK_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/testCompositeFK_original.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<!--
+  ~ Copyright (C) 2006-2019 Talend Inc. - www.talend.com
+  ~
+  ~ This source code is available under agreement available at
+  ~ %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+  ~
+  ~ You should have received a copy of the agreement
+  ~ along with this program; if not, write to Talend SA
+  ~ 9 rue Pages 92150 Suresnes, France
+  -->
+
+<ii>
+    <c>TestCompositeFK</c>
+    <n>TestCompositeFK</n>
+    <dmn>TestCompositeFK</dmn>
+    <i>231035933</i>
+    <t>1327653438644</t>
+    <p>
+        <TestMultipleCompositeFK xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	        <Id>1</Id>
+	        <Name>1</Name>
+	        <FK>[Id2_a][Id1_a]</FK>
+        </TestMultipleCompositeFK>
+    </p>
+</ii>

--- a/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/ManyValue.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/ManyValue.java
@@ -11,13 +11,18 @@
 
 package com.amalto.core.history.accessor.record;
 
-import com.amalto.core.storage.StorageMetadataUtils;
-import com.amalto.core.storage.record.DataRecord;
-import org.apache.commons.lang.StringUtils;
-import org.talend.mdm.commmon.metadata.*;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.CompoundFieldMetadata;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
+import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
+
+import com.amalto.core.storage.StorageMetadataUtils;
+import com.amalto.core.storage.record.DataRecord;
 
 class ManyValue implements Setter, Getter {
 
@@ -44,7 +49,10 @@ class ManyValue implements Setter, Getter {
             boolean needResetValue = true;
             if (oldRecord != null) {
                 String oldValue = String.valueOf(oldRecord.get(fieldMetadata.getReferencedField()));
-                needResetValue = !value.equals('[' + oldValue + ']');
+                if (!(fieldMetadata.getReferencedField() instanceof CompoundFieldMetadata)) {
+                    oldValue = '[' + oldValue + ']';
+                }
+                needResetValue = !value.equals(oldValue);
             }
             if (needResetValue) {
                 ComplexTypeMetadata referencedType = fieldMetadata.getReferencedType();

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/DataRecord.java
@@ -13,6 +13,7 @@ package com.amalto.core.storage.record;
 import java.util.*;
 
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.CompoundFieldMetadata;
 import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
@@ -167,6 +168,15 @@ public class DataRecord {
             }
             return null; // Not found.
         } else {
+            if (field instanceof CompoundFieldMetadata) {
+                StringBuilder keyValue = new StringBuilder();
+                for (Object keyField : this.type.getKeyFields()) {
+                    if (fieldToValue.containsKey(keyField)) {
+                        keyValue.append('[').append(fieldToValue.get(keyField)).append(']');
+                    }
+                }
+                return keyValue.toString();
+            }
             if (fieldToValue.containsKey(field)) {
                 return fieldToValue.get(field);
             } else if (recordMetadata.getRecordProperties().containsKey(field.getName())) { // Try to read from metadata
@@ -385,6 +395,7 @@ public class DataRecord {
 
         private static ThreadLocal<Boolean> threadLocal = new ThreadLocal<Boolean>() {
 
+            @Override
             public Boolean initialValue() {
                 return Boolean.TRUE;
             }
@@ -414,6 +425,7 @@ public class DataRecord {
 
         private static ThreadLocal<Boolean> threadLocal = new ThreadLocal<Boolean>() {
 
+            @Override
             public Boolean initialValue() {
                 return Boolean.FALSE;
             }


### PR DESCRIPTION
What is the current behavior? (You should also link to an open issue here)
Error in getting old value when updating referenced field is compound type

What is the new behavior?

Update composite FK field and save successfully

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
