### PR TITLE
TMDM-14289 tMDMRollback somtimes let transactions "opened"

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
@@ -963,11 +963,11 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     }
 
     private static int getMaxDBRequests(String dataModelName) {
-        String putItemConfig = "putitem.concurrent.database.requests."; //$NON-NLS-1$
+        String putItemConfig = "putitem.concurrent.database.requests." + dataModelName; //$NON-NLS-1$
         try {
-            return Integer.valueOf(MDMConfiguration.getConfiguration().getProperty(putItemConfig + dataModelName));
+            return Integer.valueOf(MDMConfiguration.getConfiguration().getProperty(putItemConfig));
         } catch (Exception e) {
-            LOGGER.error("Invalid configuration for: " + putItemConfig + dataModelName, e); //$NON-NLS-1$
+            LOGGER.error("Invalid configuration for: " + putItemConfig, e); //$NON-NLS-1$
             return 0;
         }
     }
@@ -975,16 +975,16 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     private static void beginRequestLimitation(String dataModelName) {
         int maxDBRequests = getMaxDBRequests(dataModelName);
         if (maxDBRequests > 0) {
-            long WAIT_MILLISECONDS = Long.valueOf(MDMConfiguration.getConfiguration().getProperty("putitem.concurrent.wait.milliseconds." + dataModelName, "10")); //$NON-NLS-1$ //$NON-NLS-2$
+            long waitMilliSeconds = Long.valueOf(MDMConfiguration.getConfiguration().getProperty("putitem.concurrent.wait.milliseconds." + dataModelName, "10")); //$NON-NLS-1$ //$NON-NLS-2$
             // Wait until less that MAX_THREADS running
             synchronized (IXtentisWSDelegator.class) {
                 AtomicInteger dbRequests = getDBRequests(dataModelName);
                 try {
                     while (dbRequests.get() >= maxDBRequests) {
                         if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("Up to " + dbRequests + " putitem requests, wait for " + WAIT_MILLISECONDS + " ms.");  //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
+                            LOGGER.debug("Up to " + dbRequests + " putitem requests, wait for " + waitMilliSeconds + " ms.");  //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$
                         }
-                        Thread.sleep(WAIT_MILLISECONDS);
+                        Thread.sleep(waitMilliSeconds);
                     }
                     int newDbRequests = DB_REQUESTS_MAP.get(dataModelName).incrementAndGet();
                     if (LOGGER.isDebugEnabled()) {

--- a/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
@@ -972,10 +972,20 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
         }
     }
 
+    private static long getWaitMilliSeconds(String dataModelName) {
+        String putItemConfig = "putitem.concurrent.wait.milliseconds." + dataModelName; //$NON-NLS-1$
+        try {
+            return Long.valueOf(MDMConfiguration.getConfiguration().getProperty(putItemConfig, "10")); //$NON-NLS-1$
+        } catch (Exception e) {
+            LOGGER.error("Invalid configuration for: " + putItemConfig, e); //$NON-NLS-1$
+            return 10;
+        }
+    }
+
     private static void beginRequestLimitation(String dataModelName) {
         int maxDBRequests = getMaxDBRequests(dataModelName);
         if (maxDBRequests > 0) {
-            long waitMilliSeconds = Long.valueOf(MDMConfiguration.getConfiguration().getProperty("putitem.concurrent.wait.milliseconds." + dataModelName, "10")); //$NON-NLS-1$ //$NON-NLS-2$
+            long waitMilliSeconds = getWaitMilliSeconds(dataModelName);
             // Wait until less that MAX_THREADS running
             synchronized (IXtentisWSDelegator.class) {
                 AtomicInteger dbRequests = getDBRequests(dataModelName);

--- a/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
@@ -192,8 +192,6 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
 
     private static final Map<String, AtomicInteger> DB_REQUESTS_MAP = new HashMap<String, AtomicInteger>();
 
-    private static Long WAIT_MILLISECONDS;
-
     @Override
     public WSVersion getComponentVersion(WSGetComponentVersion wsGetComponentVersion) throws RemoteException {
         try {
@@ -965,12 +963,11 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     }
 
     private static int getMaxDBRequests(String dataModelName) {
+        String putItemConfig = "putitem.concurrent.database.requests."; //$NON-NLS-1$
         try {
-            return Integer.valueOf(MDMConfiguration.getConfiguration().getProperty("putitem.concurrent.database.requests." + dataModelName)); //$NON-NLS-1$
+            return Integer.valueOf(MDMConfiguration.getConfiguration().getProperty(putItemConfig + dataModelName));
         } catch (Exception e) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("Invalid configuration of putitem request limitation.", e); //$NON-NLS-1$
-            }
+            LOGGER.error("Invalid configuration for: " + putItemConfig + dataModelName, e); //$NON-NLS-1$
             return 0;
         }
     }
@@ -978,7 +975,7 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     private static void beginRequestLimitation(String dataModelName) {
         int maxDBRequests = getMaxDBRequests(dataModelName);
         if (maxDBRequests > 0) {
-            WAIT_MILLISECONDS = Long.valueOf(MDMConfiguration.getConfiguration().getProperty("putitem.concurrent.wait.milliseconds." + dataModelName, "10")); //$NON-NLS-1$ //$NON-NLS-2$
+            long WAIT_MILLISECONDS = Long.valueOf(MDMConfiguration.getConfiguration().getProperty("putitem.concurrent.wait.milliseconds." + dataModelName, "10")); //$NON-NLS-1$ //$NON-NLS-2$
             // Wait until less that MAX_THREADS running
             synchronized (IXtentisWSDelegator.class) {
                 AtomicInteger dbRequests = getDBRequests(dataModelName);

--- a/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
@@ -31,8 +31,6 @@ public class DefaultCommitter implements SaverSession.Committer {
 
     private final XmlServer xmlServerCtrlLocal;
 
-    private final Object lock = new Object();
-
     public DefaultCommitter() {
         xmlServerCtrlLocal = Util.getXmlServerCtrlLocal();
     }
@@ -40,9 +38,17 @@ public class DefaultCommitter implements SaverSession.Committer {
     public void begin(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
-                synchronized (lock) {
-                    xmlServerCtrlLocal.start(dataCluster);
-                }
+                xmlServerCtrlLocal.start(dataCluster);
+            }
+        } catch (XtentisException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void end(String dataCluster) {
+        try {
+            if (xmlServerCtrlLocal.supportTransaction()) {
+                xmlServerCtrlLocal.end(dataCluster);
             }
         } catch (XtentisException e) {
             throw new RuntimeException(e);
@@ -52,9 +58,7 @@ public class DefaultCommitter implements SaverSession.Committer {
     public void commit(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
-                synchronized (lock) {
-                    xmlServerCtrlLocal.commit(dataCluster);
-                }
+                xmlServerCtrlLocal.commit(dataCluster);
             }
         } catch (XtentisException e) {
             throw new RuntimeException(e);
@@ -64,9 +68,7 @@ public class DefaultCommitter implements SaverSession.Committer {
     public void rollback(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
-                synchronized (lock) {
-                    xmlServerCtrlLocal.rollback(dataCluster);
-                }
+                xmlServerCtrlLocal.rollback(dataCluster);
             }
         } catch (XtentisException e) {
             throw new RuntimeException(e);

--- a/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
@@ -35,7 +35,7 @@ public class DefaultCommitter implements SaverSession.Committer {
         xmlServerCtrlLocal = Util.getXmlServerCtrlLocal();
     }
 
-    public void begin(String dataCluster) {
+    public synchronized void begin(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
                 xmlServerCtrlLocal.start(dataCluster);
@@ -45,7 +45,7 @@ public class DefaultCommitter implements SaverSession.Committer {
         }
     }
 
-    public void commit(String dataCluster) {
+    public synchronized void commit(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
                 xmlServerCtrlLocal.commit(dataCluster);
@@ -55,7 +55,7 @@ public class DefaultCommitter implements SaverSession.Committer {
         }
     }
 
-    public void rollback(String dataCluster) {
+    public synchronized void rollback(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
                 xmlServerCtrlLocal.rollback(dataCluster);
@@ -65,7 +65,7 @@ public class DefaultCommitter implements SaverSession.Committer {
         }
     }
 
-    public void save(Document document) {
+    public synchronized void save(Document document) {
         try {
             ComplexTypeMetadata type = document.getType();
             boolean putInCache = type.getSuperTypes().isEmpty() && type.getSubTypes().isEmpty();
@@ -93,7 +93,7 @@ public class DefaultCommitter implements SaverSession.Committer {
     }
 
     @Override
-    public void delete(Document document, DeleteType deleteType) {
+    public synchronized void delete(Document document, DeleteType deleteType) {
         try {
             ComplexTypeMetadata type = document.getType();
             boolean putInCache = type.getSuperTypes().isEmpty() && type.getSubTypes().isEmpty();

--- a/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
@@ -31,41 +31,49 @@ public class DefaultCommitter implements SaverSession.Committer {
 
     private final XmlServer xmlServerCtrlLocal;
 
+    private final Object lock = new Object();
+
     public DefaultCommitter() {
         xmlServerCtrlLocal = Util.getXmlServerCtrlLocal();
     }
 
-    public synchronized void begin(String dataCluster) {
+    public void begin(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
-                xmlServerCtrlLocal.start(dataCluster);
+                synchronized (lock) {
+                    xmlServerCtrlLocal.start(dataCluster);
+                }
             }
         } catch (XtentisException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public synchronized void commit(String dataCluster) {
+    public void commit(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
-                xmlServerCtrlLocal.commit(dataCluster);
+                synchronized (lock) {
+                    xmlServerCtrlLocal.commit(dataCluster);
+                }
             }
         } catch (XtentisException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public synchronized void rollback(String dataCluster) {
+    public void rollback(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {
-                xmlServerCtrlLocal.rollback(dataCluster);
+                synchronized (lock) {
+                    xmlServerCtrlLocal.rollback(dataCluster);
+                }
             }
         } catch (XtentisException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public synchronized void save(Document document) {
+    public void save(Document document) {
         try {
             ComplexTypeMetadata type = document.getType();
             boolean putInCache = type.getSuperTypes().isEmpty() && type.getSubTypes().isEmpty();
@@ -93,7 +101,7 @@ public class DefaultCommitter implements SaverSession.Committer {
     }
 
     @Override
-    public synchronized void delete(Document document, DeleteType deleteType) {
+    public void delete(Document document, DeleteType deleteType) {
         try {
             ComplexTypeMetadata type = document.getType();
             boolean putInCache = type.getSuperTypes().isEmpty() && type.getSubTypes().isEmpty();

--- a/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
@@ -45,16 +45,6 @@ public class DefaultCommitter implements SaverSession.Committer {
         }
     }
 
-    public void end(String dataCluster) {
-        try {
-            if (xmlServerCtrlLocal.supportTransaction()) {
-                xmlServerCtrlLocal.end(dataCluster);
-            }
-        } catch (XtentisException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public void commit(String dataCluster) {
         try {
             if (xmlServerCtrlLocal.supportTransaction()) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14289
**What is the current behavior?** (You should also link to an open issue here)

A job that fails (exception) and calls tMDMRollback sometimes let a transaction "opened" (not commited , not rollbacked). It was found that storage begin may not completed with storage commit or storage rollback in a request if there are many requests from a loop Studio Job.

**What is the new behavior?**

Added request number limit in PutItem, this will ensure that a request can complete the whole process of transaction.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
