### PR TITLE
TMDM-13009 Modify 0-many elements under 0-many complex type elements, redeploy will not delete the old value table in DB

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -2070,6 +2070,13 @@ public class HibernateStorage implements Storage {
                     String tableName = (String) property.getValue().accept(visitor);
                     if (!orderedTableNames.contains(tableName)) {
                         Value value = property.getValue();
+                        if (value instanceof org.hibernate.mapping.Collection) {
+                            orderedTableNames.add(0, tableName);
+                            String middleTableName = value.getTable().getName();
+                            if (StringUtils.isNoneBlank(middleTableName) && !orderedTableNames.contains(middleTableName)) {
+                                orderedTableNames.add(middleTableName);
+                            }
+                        }
                         if (value instanceof ToOne) {
                             PersistentClass referencedEntityClass = configuration
                                     .getClassMapping(((ToOne) value).getReferencedEntityName());

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/TMDM-13009.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/adapt/TMDM-13009.xsd
@@ -1,0 +1,96 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:element name="Product">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Label_EN">Product</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+            <xsd:appinfo source="X_PrimaryKeyInfo">Product/Name</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence maxOccurs="1" minOccurs="1">
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Unique Id</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Name</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Features0">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Features</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Sizes7">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Label_EN">Sizes</xsd:appinfo>
+                                    <xsd:appinfo source="X_Description_EN">A product may be available in
+                                        more than one size.
+                                    </xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="unbounded" minOccurs="0" name="Sizes22">
+                                            <xsd:annotation>
+                                                <xsd:appinfo source="X_Label_EN">Sizes</xsd:appinfo>
+                                                <xsd:appinfo source="X_Description_EN">A product may be available in more than one size.
+                                                </xsd:appinfo>
+                                                <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                                <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                            </xsd:annotation>
+                                            <xsd:complexType>
+                                                <xsd:sequence>
+                                                    <xsd:element maxOccurs="unbounded" minOccurs="0" name="Size8" type="Size">
+                                                        <xsd:annotation>
+                                                            <xsd:appinfo source="X_Label_EN">Size</xsd:appinfo>
+                                                            <xsd:appinfo source="X_Write">Demo_Manager
+                                                            </xsd:appinfo>
+                                                            <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                                        </xsd:annotation>
+                                                    </xsd:element>
+                                                </xsd:sequence>
+                                            </xsd:complexType>
+                                        </xsd:element>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="Product">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="Size">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Small" />
+            <xsd:enumeration value="Medium" />
+            <xsd:enumeration value="Large" />
+            <xsd:enumeration value="X-Large" />
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="AUTO_INCREMENT">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="URL">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+    <xsd:simpleType name="UUID">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+</xsd:schema>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13009
**What is the current behavior?** (You should also link to an open issue here)
As any existing model, after modify, then deploy again, the latest table structure should be reflected from the DB, whereas the previous some as middle table all should be cleaned from DB.

**What is the new behavior?**
Add new snippet of code to drop those inessential table from class HibernateStorage.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
