### PR TITLE
TMDM-14289 tMDMRollback somtimes let transactions "opened" 

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
@@ -13,6 +13,7 @@ package com.amalto.core.storage.transaction;
 
 import com.amalto.core.server.ServerContext;
 import com.amalto.core.storage.task.staging.SerializableList;
+import com.amalto.core.util.Util;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -61,10 +62,15 @@ public class TransactionService {
     @ApiOperation("Commits the transaction identified by the provided id")
     public void commit(
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
-        TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
-        Transaction transaction = transactionManager.get(transactionId);
-        if (transaction != null) {
-            transaction.commit();
+        try {
+            Util.beginTransactionLimit();
+            TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
+            Transaction transaction = transactionManager.get(transactionId);
+            if (transaction != null) {
+                transaction.commit();
+            }
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 
@@ -77,10 +83,15 @@ public class TransactionService {
     @ApiOperation("Rollbacks the transaction identified by the provided id")
     public void rollback(
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
-        TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
-        Transaction transaction = transactionManager.get(transactionId);
-        if (transaction != null) {
-            transaction.rollback();
+        try {
+            Util.beginTransactionLimit();
+            TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
+            Transaction transaction = transactionManager.get(transactionId);
+            if (transaction != null) {
+                transaction.rollback();
+            }
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
@@ -62,9 +62,9 @@ public class TransactionService {
     @ApiOperation("Commits the transaction identified by the provided id")
     public void commit(
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
+        TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
+        Transaction transaction = transactionManager.get(transactionId);
         try {
-            TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
-            Transaction transaction = transactionManager.get(transactionId);
             if (transaction != null) {
                 Util.beginTransactionLimit();
                 transaction.commit();
@@ -83,9 +83,9 @@ public class TransactionService {
     @ApiOperation("Rollbacks the transaction identified by the provided id")
     public void rollback(
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
+        TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
+        Transaction transaction = transactionManager.get(transactionId);
         try {
-            TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
-            Transaction transaction = transactionManager.get(transactionId);
             if (transaction != null) {
                 Util.beginTransactionLimit();
                 transaction.rollback();

--- a/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
@@ -63,10 +63,10 @@ public class TransactionService {
     public void commit(
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
         try {
-            Util.beginTransactionLimit();
             TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
             Transaction transaction = transactionManager.get(transactionId);
             if (transaction != null) {
+                Util.beginTransactionLimit();
                 transaction.commit();
             }
         } finally {
@@ -84,10 +84,10 @@ public class TransactionService {
     public void rollback(
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
         try {
-            Util.beginTransactionLimit();
             TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
             Transaction transaction = transactionManager.get(transactionId);
             if (transaction != null) {
+                Util.beginTransactionLimit();
                 transaction.rollback();
             }
         } finally {

--- a/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
@@ -64,13 +64,13 @@ public class TransactionService {
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
         TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
         Transaction transaction = transactionManager.get(transactionId);
-        try {
-            if (transaction != null) {
+        if (transaction != null) {
+            try {
                 Util.beginTransactionLimit();
                 transaction.commit();
+            } finally {
+                Util.endTransactionLimit();
             }
-        } finally {
-            Util.endTransactionLimit();
         }
     }
 
@@ -85,13 +85,13 @@ public class TransactionService {
             @ApiParam("Transaction id") @PathParam("id") String transactionId) {
         TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
         Transaction transaction = transactionManager.get(transactionId);
-        try {
-            if (transaction != null) {
+        if (transaction != null) {
+            try {
                 Util.beginTransactionLimit();
                 transaction.rollback();
+            } finally {
+                Util.endTransactionLimit();
             }
-        } finally {
-            Util.endTransactionLimit();
         }
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -1312,7 +1312,7 @@ public class Util {
                     TRANSACTION_CURRENT_REQUESTS.incrementAndGet();
                 } catch (InterruptedException e) {
                     if (LOGGER.isDebugEnabled()) {
-                        LOGGER.debug("Failed to wait thread.", e);
+                        LOGGER.debug("Failed to sleep thread.", e);
                     }
                 }
             }

--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -173,12 +173,12 @@ public class Util {
 
     private static final AtomicInteger TRANSACTION_CURRENT_REQUESTS = new AtomicInteger();
 
-    private static final int MAX_TRANSACTION_REQUESTS;
+    private static final int TRANSACTION_MAX_REQUESTS;
 
     private static final long TRANSACTION_WAIT_MILLISECONDS;
 
     static {
-        MAX_TRANSACTION_REQUESTS = Integer.valueOf(MDMConfiguration.getTransactionConcurrent());
+        TRANSACTION_MAX_REQUESTS = Integer.valueOf(MDMConfiguration.getTransactionMaxRequests());
         TRANSACTION_WAIT_MILLISECONDS = Long.valueOf(MDMConfiguration.getTransactionWaitMilliseconds());
     }
 
@@ -1303,10 +1303,10 @@ public class Util {
     }
 
     public static void beginTransactionLimit() {
-        if (MAX_TRANSACTION_REQUESTS > 0) {
+        if (TRANSACTION_MAX_REQUESTS > 0) {
             synchronized (Util.class) {
                 try {
-                    while (TRANSACTION_CURRENT_REQUESTS.get() >= MAX_TRANSACTION_REQUESTS) {
+                    while (TRANSACTION_CURRENT_REQUESTS.get() >= TRANSACTION_MAX_REQUESTS) {
                         Thread.sleep(TRANSACTION_WAIT_MILLISECONDS);
                     }
                     TRANSACTION_CURRENT_REQUESTS.incrementAndGet();
@@ -1320,7 +1320,7 @@ public class Util {
     }
 
     public static void endTransactionLimit() {
-        if (MAX_TRANSACTION_REQUESTS > 0) {
+        if (TRANSACTION_MAX_REQUESTS > 0) {
             TRANSACTION_CURRENT_REQUESTS.decrementAndGet();
         }
     }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14289
**What is the current behavior?** (You should also link to an open issue here)

A job that fails (exception) and calls tMDMRollback sometimes let a transaction "opened" (not commited , not rollbacked). It was found that storage begin may not completed with storage commit or storage rollback in a request if there are many requests from a loop Studio Job.

**What is the new behavior?**

Added request number limit, this will ensure that a request can complete the whole process of transaction.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
