### PR TITLE
TMDM-13569 [REST] Failed query on composite FK field

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ProjectionIterator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ProjectionIterator.java
@@ -392,7 +392,7 @@ class ProjectionIterator implements CloseableIterator<DataRecord> {
                 Object[] fieldValues = new Object[length];
                 System.arraycopy(values, currentIndex, fieldValues, 0, length);
                 // Only include composite FK value if there's an actual key value.
-                currentElement.value = isNullValue(fieldValues) ? null : fieldValues;
+                currentElement.value = convertCompositeFKToString(fieldValues);
                 currentIndex += length;
             } else if (fieldMetadata.getType().getData(TypeMapping.SQL_TYPE) != null
                     && TypeMapping.SQL_TYPE_CLOB.equals(fieldMetadata.getType().getData(TypeMapping.SQL_TYPE))) {
@@ -410,6 +410,20 @@ class ProjectionIterator implements CloseableIterator<DataRecord> {
                 currentElement.value = values[currentIndex++];
             }
             return currentElement;
+        }
+
+        /*
+         * If entity refer to a composite FK, format it to expected character string, like "[11][22]"
+         */
+        private String convertCompositeFKToString(Object[] fieldValues) {
+            if (isNullValue(fieldValues)) {
+                return null;
+            }
+            StringBuilder sb = new StringBuilder();
+            for (Object item : fieldValues) {
+                sb.append("[".intern()).append(item).append("]".intern());
+            }
+            return sb.toString();
         }
 
         private boolean isNullValue(Object[] fieldValues) {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -3178,10 +3178,7 @@ public class StorageQueryTest extends StorageTestCase {
             assertEquals(1, results.getCount());
             for (DataRecord result : results) {
                 Object b2Value = result.get("b2");
-                assertTrue(b2Value instanceof Object[]);
-                Object[] b2Values = (Object[]) b2Value;
-                assertEquals("1", b2Values[0]);
-                assertEquals("10", b2Values[1]);
+                assertEquals("[1][10]", b2Value);
             }
         } finally {
             storage.commit();


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13569
What is the current behavior? (You should also link to an open issue here)
If an Entity refer to another entity with composite PK, get a array address information when invoking REST query API. expected return each value of array, like "[11][22]".

What is the new behavior?
Add corresponding piece of code to parse the array of resultset, then format it to specific character.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
