### PR TITLE
TMDM-14192 AUTO_INCREMENT value for NOT Primary Key reset to 0 after MDM restart

### DIFF
--- a/org.talend.mdm.core.storage.sql/pom.xml
+++ b/org.talend.mdm.core.storage.sql/pom.xml
@@ -84,6 +84,11 @@
             <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     
     <profiles>

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/delegator/MockILocalUser.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/delegator/MockILocalUser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ *  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+
+package com.amalto.core.delegator;
+
+import com.amalto.core.util.XtentisException;
+
+import java.util.HashSet;
+
+@SuppressWarnings("nls")
+public class MockILocalUser extends ILocalUser {
+
+    @Override
+    public ILocalUser getILocalUser() throws XtentisException {
+        return this;
+    }
+
+    @Override
+    public HashSet<String> getRoles() {
+        HashSet<String> roleSet = new HashSet<>();
+        roleSet.add("Demo_Manager");
+        return roleSet;
+    }
+
+    @Override
+    public String getUsername() {
+        return "Admin";
+    }
+
+    @Override
+    public boolean isAdmin(Class<?> objectTypeClass) throws XtentisException {
+        return true;
+    }
+}

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
@@ -1,0 +1,839 @@
+/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ *  %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+
+package com.amalto.core.load;
+
+import com.amalto.core.delegator.BaseSecurityCheck;
+import com.amalto.core.delegator.BeanDelegatorContainer;
+import com.amalto.core.delegator.MockILocalUser;
+import com.amalto.core.load.action.LoadAction;
+import com.amalto.core.load.action.OptimizedLoadAction;
+import com.amalto.core.server.MockMetadataRepositoryAdmin;
+import com.amalto.core.server.MockServerLifecycle;
+import com.amalto.core.server.ServerContext;
+import com.amalto.core.server.api.XmlServer;
+import com.amalto.core.servlet.LoadServlet;
+import com.amalto.core.storage.record.DataRecord;
+import com.amalto.core.util.Util;
+import com.amalto.core.util.XSDKey;
+import org.apache.log4j.Logger;
+import org.dom4j.Document;
+import org.dom4j.DocumentHelper;
+import org.dom4j.Element;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.FieldMetadata;
+import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@SuppressWarnings("nls")
+public class LoadServletForAutoIncrementTest {
+
+    private static final Logger LOG = Logger.getLogger(LoadServletForAutoIncrementTest.class);
+
+    private static boolean beanDelegatorContainerFlag = false;
+
+    private static LoadServlet loadServlet;
+
+    private static class MockISecurityCheck extends BaseSecurityCheck {
+
+    }
+
+    private static void createBeanDelegatorContainer() {
+        if (!beanDelegatorContainerFlag) {
+            BeanDelegatorContainer.createInstance();
+            beanDelegatorContainerFlag = true;
+        }
+    }
+
+    @BeforeClass
+    public static void setUp() {
+        LOG.info("Setting up MDM server environment...");
+        ServerContext.INSTANCE.get(new MockServerLifecycle());
+        MDMConfiguration.getConfiguration().setProperty("xmlserver.class", "com.amalto.core.storage.DispatchWrapper");
+        LOG.info("MDM server environment set.");
+
+        Map<String, Object> delegatorInstancePool = new HashMap<>();
+        delegatorInstancePool.put("LocalUser", new MockILocalUser());
+        delegatorInstancePool.put("SecurityCheck", new MockISecurityCheck());
+        createBeanDelegatorContainer();
+        BeanDelegatorContainer.getInstance().setDelegatorInstancePool(delegatorInstancePool);
+
+        loadServlet = new LoadServlet();
+    }
+
+    @Test
+    public void test_01_BulkLoadGeneratePK() throws Exception {
+        String dataClusterName = "AutoInc";
+        String typeName = "Person";
+        String dataModelName = "AutoInc";
+        boolean needAutoGenPK = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata01.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("AutoInc", repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(("<Person><Name>T-Shirt</Name></Person>").getBytes(
+                StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod.invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, null);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".1");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        assertEquals(2, xmlDocument.getRootElement().element("p").element("Person").elements().size());
+        assertEquals(1,
+                Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("Id").getText()));
+        assertEquals("T-Shirt", xmlDocument.getRootElement().element("p").element("Person").element("Name").getText());
+    }
+
+    @Test
+    public void test_02_BulkLoadNotGeneratePK() throws Exception {
+        String dataClusterName = "AutoInc";
+        String typeName = "Person";
+        String dataModelName = "AutoInc";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata01.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("AutoInc", repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(("<Person><Name>T-Shirt</Name></Person>").getBytes(
+                StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+        try {
+            bulkLoadSaveMethod
+                    .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+            fail("Failed to save the autoincrement field.");
+        } catch (Exception e) {
+            assertNotNull(e);
+        }
+    }
+
+    @Test
+    public void test_03_BulkLoadGenerateAutoField() throws Exception {
+        String dataClusterName = "AutoInc";
+        String typeName = "Person";
+        String dataModelName = "AutoInc";
+        boolean needAutoGenPK = true;
+        boolean needAutoGenAutoFields = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata01.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("AutoInc", repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(("<Person><Name>T-Shirt</Name></Person>").getBytes(
+                StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod
+                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".2");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        assertEquals(7, xmlDocument.getRootElement().element("p").element("Person").elements().size());
+        assertEquals(2,
+                Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("Id").getText()));
+        assertEquals("T-Shirt", xmlDocument.getRootElement().element("p").element("Person").element("Name").getText());
+        assertEquals(1,
+                Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("AA").getText()));
+        assertEquals(1,
+                Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("BB").getText()));
+        assertEquals(1,
+                Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("CC").getText()));
+        assertEquals(36, xmlDocument.getRootElement().element("p").element("Person").element("DD").getText().length());
+        assertEquals(36, xmlDocument.getRootElement().element("p").element("Person").element("EE").getText().length());
+    }
+
+    @Test
+    public void test_04_BulkLoadNotGenerateAutoField() throws Exception {
+        String dataClusterName = "AutoInc";
+        String typeName = "Person";
+        String dataModelName = "AutoInc";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = false;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata01.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("AutoInc", repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Person><Id>100</Id><Name>T-Shirt</Name><AA>1</AA><BB>1</BB><CC>1</CC></Person>").getBytes(
+                        StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod.invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, null);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".100");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        assertEquals(5, xmlDocument.getRootElement().element("p").element("Person").elements().size());
+        assertEquals(100, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("Id").getText()));
+        assertEquals("T-Shirt", xmlDocument.getRootElement().element("p").element("Person").element("Name").getText());
+        assertEquals(1, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("AA").getText()));
+        assertEquals(1, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("BB").getText()));
+        assertEquals(1, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("CC").getText()));
+    }
+
+    @Test
+    public void test_05_BulkLoadNotGenerateAutoField2() throws Exception {
+        String dataClusterName = "AutoInc";
+        String typeName = "Person";
+        String dataModelName = "AutoInc";
+        boolean needAutoGenPK = true;
+        boolean needAutoGenAutoFields = false;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata01.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("AutoInc", repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Person><Name>T-Shirt</Name><AA>1</AA><BB>1</BB><CC>1</CC></Person>").getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod.invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, null);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".3");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        assertEquals(5, xmlDocument.getRootElement().element("p").element("Person").elements().size());
+        assertEquals(3,
+                Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("Id").getText()));
+        assertEquals("T-Shirt", xmlDocument.getRootElement().element("p").element("Person").element("Name").getText());
+        assertEquals(1, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("AA").getText()));
+        assertEquals(1, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("BB").getText()));
+        assertEquals(1, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Person").element("CC").getText()));
+    }
+
+    @Test
+    public void test_06_BulkLoadDefaultLoad() throws Exception {
+        String dataClusterName = "Product";
+        String typeName = "Product";
+        String dataModelName = "Product";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = false;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata02.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Product><Id>1</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price><Support>1</Support></Product>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod.invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, null);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".1");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        assertEquals(7, xmlDocument.getRootElement().element("p").element("Product").elements().size());
+        assertEquals(1, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Product").element("Id").getText()));
+        assertEquals("T-Shirt", xmlDocument.getRootElement().element("p").element("Product").element("Name").getText());
+        assertEquals("Talend T-Shirt",
+                xmlDocument.getRootElement().element("p").element("Product").element("Description").getText());
+        assertEquals("12.30", xmlDocument.getRootElement().element("p").element("Product").element("Price").getText());
+        assertEquals("1", xmlDocument.getRootElement().element("p").element("Product").element("Support").getText());
+    }
+
+    @Test
+    public void test_07_BulkLoadDefaultLoadGenerate() throws Exception {
+        String dataClusterName = "Product";
+        String typeName = "Product";
+        String dataModelName = "Product";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata02.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Product><Id>2</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price></Product>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod
+                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".2");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        assertEquals(8, xmlDocument.getRootElement().element("p").element("Product").elements().size());
+        assertEquals(2, Integer.parseInt(xmlDocument.getRootElement().element("p").element("Product").element("Id").getText()));
+        assertEquals("T-Shirt", xmlDocument.getRootElement().element("p").element("Product").element("Name").getText());
+        assertEquals("Talend T-Shirt",
+                xmlDocument.getRootElement().element("p").element("Product").element("Description").getText());
+        assertEquals("12.30", xmlDocument.getRootElement().element("p").element("Product").element("Price").getText());
+        assertEquals("1", xmlDocument.getRootElement().element("p").element("Product").element("Support").getText());
+        assertEquals(36, xmlDocument.getRootElement().element("p").element("Product").element("Supply").getText().length());
+    }
+
+    @Test
+    public void test_08_BulkLoadForComplexType() throws Exception {
+        String dataClusterName = "Student";
+        String typeName = "Student";
+        String dataModelName = "Student";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = false;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata03.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Student><Id>1</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod
+                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".1");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
+        assertEquals(4, typeElement.elements().size());
+        assertEquals(1, Integer.parseInt(typeElement.element("Id").getText()));
+        assertEquals("John", typeElement.element("Name").getText());
+        assertEquals("23", typeElement.element("Age").getText());
+        Element courseElement = typeElement.element("Course");
+        assertNotNull(courseElement);
+        assertEquals("English", courseElement.element("Id").getText());
+        assertEquals("Mike", courseElement.element("Teacher").getText());
+    }
+
+    @Test
+    public void test_09_BulkLoadForComplexTypeGenerate() throws Exception {
+        String dataClusterName = "Student";
+        String typeName = "Student";
+        String dataModelName = "Student";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata03.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Student><Id>2</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod
+                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".2");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
+        assertEquals(6, typeElement.elements().size());
+        assertEquals(2, Integer.parseInt(typeElement.element("Id").getText()));
+        assertEquals("John", typeElement.element("Name").getText());
+        assertEquals("23", typeElement.element("Age").getText());
+        assertEquals(36, typeElement.element("Account").getText().length());
+        assertEquals("1", typeElement.element("Site").getText());
+        Element courseElement = typeElement.element("Course");
+        assertNotNull(courseElement);
+        assertEquals(4, courseElement.elements().size());
+        assertEquals("English", courseElement.element("Id").getText());
+        assertEquals("Mike", courseElement.element("Teacher").getText());
+        assertEquals("1", courseElement.element("Score").getText());
+        assertEquals(36, courseElement.element("Like").getText().length());
+    }
+
+    @Test
+    public void test_10_BulkLoadForComplexTypeGeneratePartial() throws Exception {
+        String dataClusterName = "Student";
+        String typeName = "Student";
+        String dataModelName = "Student";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata03.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Student><Id>3</Id><Name>John</Name><Age>23</Age><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher><Score>10</Score></Course></Student>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod
+                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".3");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
+        assertEquals(6, typeElement.elements().size());
+        assertEquals(3, Integer.parseInt(typeElement.element("Id").getText()));
+        assertEquals("John", typeElement.element("Name").getText());
+        assertEquals("23", typeElement.element("Age").getText());
+        assertEquals(36, typeElement.element("Account").getText().length());
+        assertEquals("20", typeElement.element("Site").getText());
+        Element courseElement = typeElement.element("Course");
+        assertNotNull(courseElement);
+        assertEquals(4, courseElement.elements().size());
+        assertEquals("English", courseElement.element("Id").getText());
+        assertEquals("Mike", courseElement.element("Teacher").getText());
+        assertEquals("10", courseElement.element("Score").getText());
+        assertEquals(36, courseElement.element("Like").getText().length());
+    }
+
+    @Test
+    public void test_11_BulkLoadForComplexTypeNotGenerated() throws Exception {
+        String dataClusterName = "Student";
+        String typeName = "Student";
+        String dataModelName = "Student";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata03.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Student><Id>4</Id><Name>John</Name><Age>23</Age><Site>10</Site></Student>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod
+                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".4");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
+        assertEquals(5, typeElement.elements().size());
+        assertEquals(4, Integer.parseInt(typeElement.element("Id").getText()));
+        assertEquals("John", typeElement.element("Name").getText());
+        assertEquals("23", typeElement.element("Age").getText());
+        assertEquals(36, typeElement.element("Account").getText().length());
+        assertEquals("10", typeElement.element("Site").getText());
+        Element courseElement = typeElement.element("Course");
+        assertNull(courseElement);
+    }
+
+    @Test
+    public void test_12_BulkLoadForComplexTypeGenerateMultipleRecords() throws Exception {
+        String dataClusterName = "Student";
+        String typeName = "Student";
+        String dataModelName = "Student";
+        boolean needAutoGenPK = false;
+        boolean needAutoGenAutoFields = true;
+        boolean insertOnly = false;
+
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata03.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK,
+                needAutoGenAutoFields);
+
+        DataRecord.CheckExistence.set(!insertOnly);
+        InputStream recordXml = new ByteArrayInputStream(
+                ("<Student><Id>5</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>6</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>7</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
+                        .getBytes(StandardCharsets.UTF_8));
+
+        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        getTypeKeyMethod.setAccessible(true);
+
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey autoFieldMetadata = null;
+        if (needAutoGenAutoFields) {
+            Collection<FieldMetadata> fields = type.getFields();
+            Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+            Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+            getTypeAutoFieldMethod.setAccessible(true);
+            autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+        }
+
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
+        Method bulkLoadSaveMethod = loadServlet.getClass()
+                .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
+                        XSDKey.class);
+        bulkLoadSaveMethod.setAccessible(true);
+
+        bulkLoadSaveMethod
+                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldMetadata);
+        String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".5");
+        Document xmlDocument = DocumentHelper.parseText(result);
+        Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
+        assertEquals(6, typeElement.elements().size());
+        assertEquals(5, Integer.parseInt(typeElement.element("Id").getText()));
+        assertEquals("John", typeElement.element("Name").getText());
+        assertEquals("23", typeElement.element("Age").getText());
+        assertEquals(36, typeElement.element("Account").getText().length());
+        assertEquals("2", typeElement.element("Site").getText());
+        Element courseElement = typeElement.element("Course");
+        assertNotNull(courseElement);
+        assertEquals(4, courseElement.elements().size());
+        assertEquals("English", courseElement.element("Id").getText());
+        assertEquals("Mike", courseElement.element("Teacher").getText());
+        assertEquals("2", courseElement.element("Score").getText());
+        assertEquals(36, courseElement.element("Like").getText().length());
+
+        result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".6");
+        xmlDocument = DocumentHelper.parseText(result);
+        typeElement = xmlDocument.getRootElement().element("p").element(typeName);
+        assertEquals(6, typeElement.elements().size());
+        assertEquals(6, Integer.parseInt(typeElement.element("Id").getText()));
+        assertEquals("John", typeElement.element("Name").getText());
+        assertEquals("23", typeElement.element("Age").getText());
+        assertEquals(36, typeElement.element("Account").getText().length());
+        assertEquals("3", typeElement.element("Site").getText());
+        courseElement = typeElement.element("Course");
+        assertNotNull(courseElement);
+        assertEquals(4, courseElement.elements().size());
+        assertEquals("English", courseElement.element("Id").getText());
+        assertEquals("Mike", courseElement.element("Teacher").getText());
+        assertEquals("3", courseElement.element("Score").getText());
+        assertEquals(36, courseElement.element("Like").getText().length());
+
+        result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".7");
+        xmlDocument = DocumentHelper.parseText(result);
+        typeElement = xmlDocument.getRootElement().element("p").element(typeName);
+        assertEquals(6, typeElement.elements().size());
+        assertEquals(7, Integer.parseInt(typeElement.element("Id").getText()));
+        assertEquals("John", typeElement.element("Name").getText());
+        assertEquals("23", typeElement.element("Age").getText());
+        assertEquals(36, typeElement.element("Account").getText().length());
+        assertEquals("4", typeElement.element("Site").getText());
+        courseElement = typeElement.element("Course");
+        assertNotNull(courseElement);
+        assertEquals(4, courseElement.elements().size());
+        assertEquals("English", courseElement.element("Id").getText());
+        assertEquals("Mike", courseElement.element("Teacher").getText());
+        assertEquals("4", courseElement.element("Score").getText());
+        assertEquals(36, courseElement.element("Like").getText().length());
+    }
+
+    @Test
+    public void testGetTypeAutoField() throws Exception {
+        String dataClusterName = "AutoInc";
+        String typeName = "Person";
+        String dataModelName = "AutoInc";
+        MetadataRepository repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata01.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        ComplexTypeMetadata type = repository.getComplexType(typeName);
+
+        Collection<FieldMetadata> fields = type.getFields();
+        Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getTypeAutoField", Collection.class);
+        getTypeAutoFieldMethod.setAccessible(true);
+        XSDKey autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+
+        assertNotNull(autoFieldMetadata);
+        assertEquals(5, autoFieldMetadata.getFields().length);
+        assertEquals("AA", autoFieldMetadata.getFields()[0]);
+        assertEquals("BB", autoFieldMetadata.getFields()[1]);
+        assertEquals("CC", autoFieldMetadata.getFields()[2]);
+        assertEquals("DD", autoFieldMetadata.getFields()[3]);
+        assertEquals("EE", autoFieldMetadata.getFields()[4]);
+
+        assertEquals(5, autoFieldMetadata.getFieldTypes().length);
+        assertEquals("AUTO_INCREMENT", autoFieldMetadata.getFieldTypes()[0]);
+        assertEquals("AUTO_INCREMENT", autoFieldMetadata.getFieldTypes()[1]);
+        assertEquals("AUTO_INCREMENT", autoFieldMetadata.getFieldTypes()[2]);
+        assertEquals("UUID", autoFieldMetadata.getFieldTypes()[3]);
+        assertEquals("UUID", autoFieldMetadata.getFieldTypes()[4]);
+
+        dataClusterName = "Product";
+        typeName = "Product";
+        repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata02.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        type = repository.getComplexType(typeName);
+
+        fields = type.getFields();
+        autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+
+        autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+
+        assertNotNull(autoFieldMetadata);
+        assertEquals(2, autoFieldMetadata.getFields().length);
+        assertEquals("Support", autoFieldMetadata.getFields()[0]);
+        assertEquals("Supply", autoFieldMetadata.getFields()[1]);
+
+        assertEquals(2, autoFieldMetadata.getFieldTypes().length);
+        assertEquals("AUTO_INCREMENT", autoFieldMetadata.getFieldTypes()[0]);
+        assertEquals("UUID", autoFieldMetadata.getFieldTypes()[1]);
+
+        dataClusterName = "Student";
+        typeName = "Student";
+        repository = new MetadataRepository();
+        repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata03.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
+        type = repository.getComplexType(typeName);
+
+        fields = type.getFields();
+        autoFields = fields.stream().filter(filed -> (!filed.isKey())).collect(Collectors.toList());
+
+        autoFieldMetadata = (XSDKey) getTypeAutoFieldMethod.invoke(loadServlet, autoFields);
+
+        assertNotNull(autoFieldMetadata);
+        assertEquals(4, autoFieldMetadata.getFields().length);
+        assertEquals("Account", autoFieldMetadata.getFields()[0]);
+        assertEquals("Site", autoFieldMetadata.getFields()[1]);
+        assertEquals("Course/Score", autoFieldMetadata.getFields()[2]);
+        assertEquals("Course/Like", autoFieldMetadata.getFields()[3]);
+
+        assertEquals(4, autoFieldMetadata.getFieldTypes().length);
+        assertEquals("UUID", autoFieldMetadata.getFieldTypes()[0]);
+        assertEquals("AUTO_INCREMENT", autoFieldMetadata.getFieldTypes()[1]);
+        assertEquals("AUTO_INCREMENT", autoFieldMetadata.getFieldTypes()[2]);
+        assertEquals("UUID", autoFieldMetadata.getFieldTypes()[3]);
+    }
+}

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -16,6 +16,7 @@ import static com.amalto.core.query.user.UserQueryBuilder.from;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
 import javax.xml.namespace.NamespaceContext;
@@ -32,13 +34,24 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import com.amalto.core.delegator.MockILocalUser;
+import com.amalto.core.load.action.LoadAction;
+import com.amalto.core.load.action.OptimizedLoadAction;
+import com.amalto.core.objects.datacluster.DataClusterPOJO;
+import com.amalto.core.server.MetadataRepositoryAdmin;
+import com.amalto.core.server.api.XmlServer;
+import com.amalto.core.servlet.LoadServlet;
+import com.amalto.core.util.XSDKey;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.util.core.EUUIDCustomType;
 import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.core.MDMXMLUtils;
+import org.talend.mdm.commmon.util.webapp.XSystemObjects;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -549,6 +562,81 @@ public class DocumentSaveTest extends TestCase {
         assertEquals(2, Integer.valueOf(idAddressThree).intValue());
         // these two from the mock TestSaverSource
         assertEquals(3, Integer.valueOf(idAddressFour).intValue());
+    }
+
+    public void testAutoIncrementForNormalField() throws Exception {
+        final MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata24.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("PersonAddress", repository);
+
+        TestSaverSource source = new TestSaverSource(repository, false, "", "metadata24.xsd");
+
+        SaverSession session = SaverSession.newSession(source);
+        // 1. Entity Person: normal field is autoincrement
+        InputStream recordXml = DocumentSaveTest.class.getResourceAsStream("test79.xml");
+        DocumentSaverContext context = session.getContextFactory()
+                .create("MDM", "PersonAddress", "Source", recordXml, true, true, true, true, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        // Id is expected to be overwritten in case of creation
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+
+        // 2. Entity Address, key field Id and normal field, Port is autoincrement, Create
+        source = new TestSaverSource(repository, false, "", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test80.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true, true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Address/Id"));
+        assertEquals("1", evaluate(committedElement, "/Address/Port"));
+
+        // 3. Entity Address, key field Id and normal field, Port is autoincrement, Update
+        source = new TestSaverSource(repository, false, "test81_original.xml", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test81.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true, true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+
+        // 4. Entity Address, key field Id and normal field, Port is autoincrement, Update
+        source = new TestSaverSource(repository, false, "test82_original.xml", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test82.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true, true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Address/Id"));
+        assertEquals("1", evaluate(committedElement, "/Address/Port"));
     }
 
     public void testUpdateWithUUID() throws Exception {
@@ -3869,31 +3957,6 @@ public class DocumentSaveTest extends TestCase {
             // nothing to do
         }
 
-    }
-
-    private static class MockILocalUser extends ILocalUser {
-
-        @Override
-        public ILocalUser getILocalUser() throws XtentisException {
-            return this;
-        }
-
-        @Override
-        public HashSet<String> getRoles() {
-            HashSet<String> roleSet = new HashSet<String>();
-            roleSet.add("Demo_Manager");
-            return roleSet;
-        }
-
-        @Override
-        public String getUsername() {
-            return "Admin";
-        }
-
-        @Override
-        public boolean isAdmin(Class<?> objectTypeClass) throws XtentisException {
-            return true;
-        }
     }
 
     private static class TestSaverSource implements SaverSource {

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata01.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata01.xsd
@@ -1,0 +1,26 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
+    <xsd:element name="Person">
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="AA" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" name="BB" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="unbounded" minOccurs="1" name="CC" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="DD" type="UUID"/>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" name="EE" type="UUID"/>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="Person">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="AUTO_INCREMENT">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="UUID">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata02.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata02.xsd
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
+    <xsd:element name="Product">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Label_EN">Product</xsd:appinfo>
+            <xsd:appinfo source="X_Label_FR">Produit</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+            <xsd:appinfo source="X_Lookup_Field">Product/Availability</xsd:appinfo>
+            <xsd:appinfo source="X_PrimaryKeyInfo">Product/Name</xsd:appinfo>
+            <xsd:appinfo source="X_PrimaryKeyInfo">Product/Description</xsd:appinfo>
+            <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+            <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all maxOccurs="1" minOccurs="1">
+                <xsd:element maxOccurs="1" minOccurs="0" name="Picture" type="PICTURE">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Picture</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Image</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Unique Id</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Id unique</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Name</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Nom</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Description" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Description</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Description</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Features">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Features</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Caractéristiques</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Sizes">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Label_EN">Sizes</xsd:appinfo>
+                                    <xsd:appinfo source="X_Label_FR">Tailles</xsd:appinfo>
+                                    <xsd:appinfo source="X_Description_EN">A product may be available in more than one size.</xsd:appinfo>
+                                    <xsd:appinfo source="X_Description_FR">Un produit peut être disponible dans plusieurs tailles.</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                    <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                                    <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="unbounded" name="Size" type="Size">
+                                            <xsd:annotation>
+                                                <xsd:appinfo source="X_Label_EN">Size</xsd:appinfo>
+                                                <xsd:appinfo source="X_Label_FR">Taille</xsd:appinfo>
+                                                <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                                <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                                <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                                                <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                                            </xsd:annotation>
+                                        </xsd:element>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Colors">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Label_EN">Colors</xsd:appinfo>
+                                    <xsd:appinfo source="X_Label_FR">Couleurs</xsd:appinfo>
+                                    <xsd:appinfo source="X_Description_EN">A product can be available in more than one color.</xsd:appinfo>
+                                    <xsd:appinfo source="X_Description_FR">Un produit peut être disponible dans plusieurs couleurs.</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                    <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                                    <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                                </xsd:annotation>
+                                <xsd:complexType>
+                                    <xsd:sequence>
+                                        <xsd:element maxOccurs="unbounded" name="Color" type="Color">
+                                            <xsd:annotation>
+                                                <xsd:appinfo source="X_Label_EN">Color</xsd:appinfo>
+                                                <xsd:appinfo source="X_Label_FR">Couleur</xsd:appinfo>
+                                                <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                                <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                                <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                                                <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                                            </xsd:annotation>
+                                        </xsd:element>
+                                    </xsd:sequence>
+                                </xsd:complexType>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Availability" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Availability</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Disponibilité</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Price" type="xsd:decimal">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Price</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Prix</xsd:appinfo>
+                        <xsd:appinfo source="X_Description_EN">Run a price request to change this price</xsd:appinfo>
+                        <xsd:appinfo source="X_Description_FR">Faites une demande de changement de prix pour modifier</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Writable</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Writable</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Family" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_ForeignKey">ProductFamily/Id</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_EN">Family</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Famille</xsd:appinfo>
+                        <xsd:appinfo source="X_ForeignKeyInfo">ProductFamily/Name</xsd:appinfo>
+                        <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="OnlineStore" type="URL">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Stores">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Stores</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Magasins</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:sequence>
+                            <xsd:element maxOccurs="unbounded" minOccurs="0" name="Store" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Label_EN">Store</xsd:appinfo>
+                                    <xsd:appinfo source="X_Label_FR">Magasin</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKey">Store/Id</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKeyInfo">Store/Address</xsd:appinfo>
+                                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                                    <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                                    <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:sequence>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Support" type="AUTO_INCREMENT">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Supply" type="UUID">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_User#Product_Product_1.0#Read-only</xsd:appinfo>
+                        <xsd:appinfo source="X_Workflow">Demo_Manager#Product_Product_1.0#Read-only</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Product">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="Size">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Small"/>
+            <xsd:enumeration value="Medium"/>
+            <xsd:enumeration value="Large"/>
+            <xsd:enumeration value="X-Large"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="Color">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="White"/>
+            <xsd:enumeration value="Light Blue"/>
+            <xsd:enumeration value="Light Pink"/>
+            <xsd:enumeration value="Lemon"/>
+            <xsd:enumeration value="Khaki"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:simpleType name="PICTURE">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:element name="ProductFamily">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Label_EN">Product Family</xsd:appinfo>
+            <xsd:appinfo source="X_Label_FR">Famille Produit</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+            <xsd:appinfo source="X_PrimaryKeyInfo">ProductFamily/Name</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all maxOccurs="1" minOccurs="1">
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="AUTO_INCREMENT">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Id (sequence)</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Id (séquence)</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Name" type="AUTO_INCREMENT">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Name</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Nom</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="ChangeStatus" type="Status">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Hide">Demo_User</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_User</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="ProductFamily">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="AUTO_INCREMENT">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="URL">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="UUID">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="Status">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Pending"/>
+            <xsd:enumeration value="Rejected"/>
+            <xsd:enumeration value="Approved"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:element name="Store">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Label_EN">Store</xsd:appinfo>
+            <xsd:appinfo source="X_Label_FR">Magasin</xsd:appinfo>
+            <xsd:appinfo source="X_PrimaryKeyInfo">Store/Address</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Store Id</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Id Magasin</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Address</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Addresse</xsd:appinfo>
+                        <xsd:appinfo source="X_Description_EN">Enter the complete address of the store</xsd:appinfo>
+                        <xsd:appinfo source="X_Description_FR">Entrer l'adresse complète du magasin</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Lat" type="xsd:double">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Latitude</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Latitude</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Long" type="xsd:double">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Longitude</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Longitude</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Map" type="URL">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Label_EN">Location</xsd:appinfo>
+                        <xsd:appinfo source="X_Label_FR">Localisation</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Store">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata03.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata03.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="Student">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Age" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Account" type="UUID"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Site" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Course" type="Course"/>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Student">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="UUID">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="AUTO_INCREMENT">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:complexType name="Course">
+        <xsd:all>
+            <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+            <xsd:element maxOccurs="1" minOccurs="0" name="Teacher" type="xsd:string"/>
+            <xsd:element maxOccurs="1" minOccurs="0" name="Score" type="AUTO_INCREMENT"/>
+            <xsd:element maxOccurs="1" minOccurs="0" name="Like" type="UUID"/>
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/metadata24.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/metadata24.xsd
@@ -1,0 +1,32 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
+    <xsd:element name="Person">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="1" name="N_Index" type="AUTO_INCREMENT"/>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Person">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="Address">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Port" type="AUTO_INCREMENT"/>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Address">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="AUTO_INCREMENT">
+        <xsd:restriction base="xsd:string" />
+    </xsd:simpleType>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test79.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test79.xml
@@ -1,0 +1,4 @@
+<Person xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Id>1</Id>
+    <Name>John</Name>
+</Person>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test80.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test80.xml
@@ -1,0 +1,4 @@
+<Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Name>Beijing</Name>
+</Address>
+

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test81.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test81.xml
@@ -1,0 +1,5 @@
+<Person xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Id>1</Id>
+    <Name>John</Name>
+</Person>
+

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test81_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test81_original.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<ii>
+    <c>PersonAddress</c>
+    <n>PersonAddress</n>
+    <dmn>PersonAddress</dmn>
+    <i>231035933</i>
+    <t>1327653438644</t>
+    <p>
+        <Person xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <Id>1</Id>
+            <Name>John</Name>
+        </Person>
+    </p>
+</ii>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test82.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test82.xml
@@ -1,0 +1,4 @@
+<Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Name>Beijing</Name>
+</Address>
+

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test82_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test82_original.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<ii>
+    <c>PersonAddress</c>
+    <n>PersonAddress</n>
+    <dmn>PersonAddress</dmn>
+    <i>231035933</i>
+    <t>1327653438644</t>
+    <p>
+        <Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <Id>1</Id>
+            <Name>Beijing</Name>
+        </Address>
+    </p>
+</ii>

--- a/org.talend.mdm.core/pom.xml
+++ b/org.talend.mdm.core/pom.xml
@@ -344,6 +344,23 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- MDM dependencies -->
         <dependency>
             <groupId>org.talend.mdm</groupId>
@@ -494,23 +511,6 @@
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
             <version>3.7.4</version>
-        </dependency>
-        <dependency>
-        	<groupId>org.mockito</groupId>
-        	<artifactId>mockito-all</artifactId>
-        	<version>1.9.0</version>
-        	<scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
     

--- a/org.talend.mdm.core/src/com/amalto/core/load/LoadParser.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/LoadParser.java
@@ -116,11 +116,15 @@ public class LoadParser {
                 }
             }
 
-            StateContext context = new DefaultStateContext(config.getPayLoadElementName(), config.getIdPaths(), config.getDataClusterName(), config.getDataModelName(), limit, callback);
+            StateContext context = new DefaultStateContext(config.getPayLoadElementName(), config.getIdPaths(),
+                    config.getNormalFieldPaths(), config.getDataClusterName(), config.getDataModelName(), limit, callback,
+                    config.getNormalFieldGenerator());
             if (config.isAutoGenPK()) {
                 AutoIdGenerator autoIdGenerator = config.getIdGenerator();
                 // Change the context to auto-generate metadata
-                context = AutoGenStateContext.decorate(context, config.getIdPaths(), autoIdGenerator);
+                context = AutoGenStateContext
+                        .decorate(context, config.getIdPaths(), autoIdGenerator, config.getNormalFieldPaths(),
+                                config.getNormalFieldGenerator());
             }
 
             while (!context.hasFinished()) {
@@ -146,18 +150,34 @@ public class LoadParser {
     public static class Configuration {
         private final String payLoadElementName;
         private final String[] idPaths;
+        private final String[] normalFieldPaths;
         private final boolean autoGenPK;
         private final String dataClusterName;
         private final String dataModelName;
         private final AutoIdGenerator idGenerator;
+        private final AutoIdGenerator[] normalFieldGenerator;
 
-        public Configuration(String payLoadElementName, String[] idPaths, boolean autoGenPK, String dataClusterName, String dataModelName, AutoIdGenerator idGenerator) {
+        public Configuration(String payLoadElementName, String[] idPaths, String[] normalFieldPaths, boolean autoGenPK,
+                String dataClusterName, String dataModelName, AutoIdGenerator idGenerator,
+                AutoIdGenerator[] normalFieldGenerator) {
             this.payLoadElementName = payLoadElementName;
             this.idPaths = idPaths;
+            this.normalFieldPaths = normalFieldPaths;
             this.autoGenPK = autoGenPK;
             this.dataClusterName = dataClusterName;
             this.dataModelName = dataModelName;
             this.idGenerator = idGenerator;
+            this.normalFieldGenerator = normalFieldGenerator;
+        }
+
+        public Configuration(String payLoadElementName, String[] idPaths, String[] normalFieldPaths, boolean autoGenPK,
+                String dataClusterName, String dataModelName, AutoIdGenerator idGenerator) {
+            this(payLoadElementName, idPaths, normalFieldPaths, autoGenPK, dataClusterName, dataModelName, idGenerator, null);
+        }
+
+        public Configuration(String payLoadElementName, String[] idPaths, boolean autoGenPK, String dataClusterName,
+                String dataModelName, AutoIdGenerator idGenerator) {
+            this(payLoadElementName, idPaths, new String[] {}, autoGenPK, dataClusterName, dataModelName, idGenerator, null);
         }
 
         /**
@@ -178,6 +198,10 @@ public class LoadParser {
             return idPaths;
         }
 
+        public String[] getNormalFieldPaths() {
+            return normalFieldPaths;
+        }
+
         public boolean isAutoGenPK() {
             return autoGenPK;
         }
@@ -192,6 +216,10 @@ public class LoadParser {
 
         public AutoIdGenerator getIdGenerator() {
             return idGenerator;
+        }
+
+        public AutoIdGenerator[] getNormalFieldGenerator() {
+            return normalFieldGenerator;
         }
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/load/action/DefaultLoadAction.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/action/DefaultLoadAction.java
@@ -12,6 +12,7 @@ package com.amalto.core.load.action;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -49,7 +50,8 @@ public class DefaultLoadAction implements LoadAction {
     }
 
     @Override
-    public void load(InputStream stream, XSDKey keyMetadata, XmlServer server, SaverSession session) {
+    public void load(InputStream stream, XSDKey keyMetadata, XSDKey allAutoMetadata, XmlServer server,
+            SaverSession session) {
         try {
             SaverContextFactory contextFactory = session.getContextFactory();
             // If you wish to debug content sent to server evaluate 'IOUtils.toString(request.getInputStream())'
@@ -60,7 +62,7 @@ public class DefaultLoadAction implements LoadAction {
                     // Note: in case you wish to change the "replace" behavior, also check
                     // com.amalto.core.save.context.BulkLoadContext.isReplace()
                     DocumentSaverContext context = contextFactory.create(dataClusterName, dataModelName, StringUtils.EMPTY,
-                            new ByteArrayInputStream(xmlData.getBytes("UTF-8")), //$NON-NLS-1$
+                            new ByteArrayInputStream(xmlData.getBytes(StandardCharsets.UTF_8)),
                             true, // Always replace in this case (bulk load).
                             needValidate, false, false, XSystemObjects.DC_PROVISIONING.getName().equals(dataClusterName)); // Enforce
                                                                                                                            // auto

--- a/org.talend.mdm.core/src/com/amalto/core/load/action/LoadAction.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/action/LoadAction.java
@@ -32,10 +32,11 @@ public interface LoadAction {
      * Loads XML documents from <code>request</code> in <code>server</code>.
      * @param stream      The stream that contains all XML documents to be loaded in MDM.
      * @param keyMetadata Key metadata <b>or <code>null</code> in case of autoGenPK</b>.
+     * @param autoFieldMetadata All auto increment or UUID field metadata <b>or <code>null</code> in case of autoGenAutoField</b>.
      * @param server      The database where the documents must be persisted.
      * @param session     The {@link SaverSession} to be used for saving records.
      */
-    void load(InputStream stream, XSDKey keyMetadata, XmlServer server, SaverSession session);
+    void load(InputStream stream, XSDKey keyMetadata, XSDKey autoFieldMetadata, XmlServer server, SaverSession session);
 
     /**
      * End load and perform all post-load actions (such as save counter state in case of autogen pk).

--- a/org.talend.mdm.core/src/com/amalto/core/load/context/AutoGenStateContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/context/AutoGenStateContext.java
@@ -15,6 +15,7 @@ import com.amalto.core.load.LoadParserCallback;
 import com.amalto.core.load.Metadata;
 import com.amalto.core.load.State;
 import com.amalto.core.load.exception.ParserCallbackException;
+import com.amalto.core.load.path.PathMatcher;
 import com.amalto.core.load.payload.EndPayload;
 import com.amalto.core.load.payload.StartPayload;
 import com.amalto.core.load.xml.Selector;
@@ -23,6 +24,9 @@ import com.amalto.core.server.api.XmlServer;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
 
 /**
  * Load parser context implementation that has 2 main features:
@@ -45,10 +49,26 @@ public class AutoGenStateContext implements StateContext {
 
     private final AutoIdGenerator generator;
 
-    private AutoGenStateContext(StateContext delegate, String[] idPaths, AutoIdGenerator generator) {
+    private List<PathMatcher> normalFieldPaths;
+
+    private List<String> normalFieldInXML;
+
+    private Stack<String> readElementPath;
+
+    private final AutoIdGenerator[] normalFieldGenerator;
+
+    private AutoGenStateContext(StateContext delegate, String[] idPaths, AutoIdGenerator generator, String[] normalFieldPaths,
+            AutoIdGenerator[] normalFieldGenerator) {
         this.delegate = delegate;
         this.idPaths = idPaths;
         this.generator = generator;
+        this.readElementPath = new Stack<>();
+        this.normalFieldInXML = new ArrayList<>();
+        this.normalFieldPaths = new ArrayList<>();
+        this.normalFieldGenerator = normalFieldGenerator;
+        for (String idPath : normalFieldPaths) {
+            getNormalFieldPaths().add(new PathMatcher(idPath));
+        }
         metadata = new AutoGenMetadata(this.delegate.getMetadata(), idPaths, this.generator);
     }
 
@@ -59,8 +79,9 @@ public class AutoGenStateContext implements StateContext {
      * @param autoIdGenerator Implementation of {@link com.amalto.core.save.generator.AutoIdGenerator} able to generate id in this context.  @return A context that generate metadata automatically.
      * @return A {@link StateContext} implementation able to generate automatic ids.
      */
-    public static StateContext decorate(StateContext context, String[] idPaths, AutoIdGenerator autoIdGenerator) {
-        return new AutoGenStateContext(context, idPaths, autoIdGenerator);
+    public static StateContext decorate(StateContext context, String[] idPaths, AutoIdGenerator autoIdGenerator,
+            String[] normalFieldPaths, AutoIdGenerator[] autoNormalFieldGenerator) {
+        return new AutoGenStateContext(context, idPaths, autoIdGenerator, normalFieldPaths, autoNormalFieldGenerator);
     }
 
     public Metadata getMetadata() {
@@ -98,6 +119,11 @@ public class AutoGenStateContext implements StateContext {
             currentState = new AutoIdGeneration(state, idPaths);
             hasGeneratedAutomaticId = true;
         }
+    }
+
+    @Override
+    public State getCurrent() {
+        return currentState;
     }
 
     public LoadParserCallback getCallback() {
@@ -158,6 +184,26 @@ public class AutoGenStateContext implements StateContext {
         // This line is rather important since the generator might need to persist its state
         // see DefaultAutoIdGenerator for instance.
         generator.saveState(server);
+    }
+
+    @Override
+    public List<PathMatcher> getNormalFieldPaths(){
+        return this.normalFieldPaths;
+    }
+
+    @Override
+    public List<String> getNormalFieldInXML() {
+        return this.normalFieldInXML;
+    }
+
+    @Override
+    public Stack<String> getReadElementPath() {
+        return this.readElementPath;
+    }
+
+    @Override
+    public AutoIdGenerator[] getNormalFieldGenerators() {
+        return normalFieldGenerator;
     }
 
 }

--- a/org.talend.mdm.core/src/com/amalto/core/load/context/StateContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/context/StateContext.java
@@ -11,14 +11,28 @@
 package com.amalto.core.load.context;
 
 import com.amalto.core.load.LoadParserCallback;
+import com.amalto.core.load.path.PathMatch;
+import com.amalto.core.load.path.PathMatcher;
+import com.amalto.core.save.generator.AutoIdGenerator;
 import com.amalto.core.server.api.XmlServer;
 
 import javax.xml.stream.XMLStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
 
-/**
- *
- */
+@SuppressWarnings("nls")
 public interface StateContext {
+
+    /**
+     * @return all AUTO_INCREMENT or UUID fields except the Primary key
+     */
+    List<PathMatcher> getNormalFieldPaths();
+
+    /**
+     * @return all field path which supplied in the xml content.
+     */
+    List<String> getNormalFieldInXML();
 
     void parse(XMLStreamReader reader);
 
@@ -27,6 +41,8 @@ public interface StateContext {
     StateContextWriter getWriter();
 
     void setCurrent(com.amalto.core.load.State state);
+
+    com.amalto.core.load.State getCurrent();
 
     LoadParserCallback getCallback();
 
@@ -59,4 +75,59 @@ public interface StateContext {
     boolean skipElement();
 
     void close(XmlServer server);
+
+    AutoIdGenerator[] getNormalFieldGenerators();
+
+    Stack<String> getReadElementPath();
+
+    /**
+     * judge the AUTO_INCREMENT/UUID field is existed in the supplied xml content.
+     * 1. if the field is in the entity,
+     *   1) supplied the value in the xml content: don't add
+     *   2) not supplied in the xml content: added this field.
+     * 2. the field is existed in one complex type such as Course/Like,
+     *   1). supplied in the xml content, don't add.
+     *   2). not supplied in the xml content:
+     *     I. contains other field's value of this complex type, added this field.
+     *     II. have no any fields'value of this complex type,  don't add.
+     * @return all fields of type are AUTO_INCREMENT or UUID field except PK, which need to generate value.
+     */
+    default String[] getAutoIncrementNormalFields() {
+        List<String> normalFieldPathList = new ArrayList<>(getNormalFieldPaths().size());
+        for (PathMatcher pathMatcher : getNormalFieldPaths()) {
+            boolean isMatched = false; // mark it as  full matched
+            boolean isParentMatched = false; // mark it as partial matched
+            String pathMatchedStr = pathMatcher.toString();
+            for (String path : getNormalFieldInXML()) {
+                if (pathMatchedStr.contains("/") && path.contains("/")) {
+                    int i = 0;
+                    String[] pathArray = path.split("/");
+                    if (isMatched) {
+                        break;
+                    }
+                    for (String s : pathArray) {
+                        PathMatch match = pathMatcher.match(s);
+                        if (match == PathMatch.FULL) {
+                            isMatched = true;
+                            isParentMatched = false;
+                            break;
+                        } else if (match == PathMatch.PARTIAL && i++ == pathArray.length - 2) {
+                            isParentMatched = true;
+                        }
+                    }
+                } else if (!pathMatchedStr.contains("/") && !path.contains("/")) {
+                    if (pathMatcher.match(path) == PathMatch.FULL) {
+                        isMatched = true;
+                        break;
+                    }
+                }
+            }
+            if ((!isMatched && !pathMatchedStr.contains("/")) || isParentMatched) {
+                normalFieldPathList.add(pathMatchedStr);
+            } else {
+                normalFieldPathList.add(null);
+            }
+        }
+        return normalFieldPathList.toArray(new String[normalFieldPathList.size()]);
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/load/payload/FlushXMLReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/payload/FlushXMLReader.java
@@ -14,6 +14,7 @@ import com.amalto.core.load.Constants;
 import com.amalto.core.load.Metadata;
 import com.amalto.core.load.context.StateContext;
 import com.amalto.core.load.context.StateContextSAXWriter;
+import com.amalto.core.load.xml.AutoFieldGeneration;
 import org.apache.commons.lang.StringUtils;
 import org.xml.sax.*;
 
@@ -114,6 +115,14 @@ public class FlushXMLReader implements XMLReader {
             context.getWriter().flush(contentHandler);
             context.setWriter(new StateContextSAXWriter(contentHandler));
             while (!context.hasFinishedPayload()) {
+                context.parse(reader);
+            }
+
+            String[] autoIncrementNormalFields = context.getAutoIncrementNormalFields();
+            if (autoIncrementNormalFields.length > 0) {
+                com.amalto.core.load.State state = context.getCurrent();
+                AutoFieldGeneration autoGenMetadata = new AutoFieldGeneration(state, autoIncrementNormalFields);
+                context.setCurrent(autoGenMetadata);
                 context.parse(reader);
             }
             if (context.getDepth() == 1) {

--- a/org.talend.mdm.core/src/com/amalto/core/load/xml/AutoFieldGeneration.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/xml/AutoFieldGeneration.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2006-2020 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement
+ * along with this program; if not, write to Talend SA
+ * 9 rue Pages 92150 Suresnes, France
+ */
+
+package com.amalto.core.load.xml;
+
+import com.amalto.core.load.State;
+import com.amalto.core.load.context.StateContext;
+import com.amalto.core.load.context.Utils;
+import com.amalto.core.save.generator.AutoIdGenerator;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.util.StringTokenizer;
+
+@SuppressWarnings("nls")
+public class AutoFieldGeneration implements State {
+    private final State previousState;
+
+    private final String[] fieldPaths;
+
+    public AutoFieldGeneration(State previousState, String[] fieldPaths) {
+        this.previousState = previousState;
+        this.fieldPaths = fieldPaths;
+    }
+
+    @Override
+    public void parse(StateContext context, XMLStreamReader reader) throws XMLStreamException {
+        try {
+            AutoIdGenerator[] normalFieldGenerators = context.getNormalFieldGenerators();
+            int i = 0;
+            /*
+            fielldPaths store the all need to generate value the field,  if doesn't existed, it means don't generate the value.
+            if the field path is 'Course/Score', it should be first write '<Course>', and next is '<Score>',
+            but it inverse for the end element, first is '<Score>', first is '<Course>'
+             */
+            for (String idPath : fieldPaths) {
+                if (idPath == null) {
+                    i++;
+                    continue;
+                }
+                if (idPath.contains("/")) {
+                    StringTokenizer tokenizer = new StringTokenizer(idPath, "/");
+                    while (tokenizer.hasMoreTokens()) {
+                        String pathElement = tokenizer.nextToken();
+                        context.getWriter().writeStartElement(pathElement);
+                    }
+                } else {
+                    context.getWriter().writeStartElement(idPath);
+                }
+
+                context.getWriter().writeCharacters(normalFieldGenerators[i++]
+                        .generateId(context.getMetadata().getDataClusterName(), context.getMetadata().getName(), idPath.replaceAll("/", ".")));
+
+                if (idPath.contains("/")) {
+                    String[] idPathArray = idPath.split("/");
+                    for (int j = idPathArray.length - 1; j >= 0; j--) {
+                        context.getWriter().writeEndElement(idPathArray[j]);
+                    }
+                } else {
+                    context.getWriter().writeEndElement(idPath);
+                }
+
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to generate automatic id", e);
+        }
+
+        context.setCurrent(previousState);
+
+        if (!context.isFlushDone()) {
+            Utils.doParserCallback(context, reader, context.getMetadata());
+        }
+    }
+
+    public boolean isFinal() {
+        return false;
+    }
+}

--- a/org.talend.mdm.core/src/com/amalto/core/load/xml/EndElement.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/xml/EndElement.java
@@ -28,6 +28,7 @@ public class EndElement implements State {
 
     public void parse(StateContext context, XMLStreamReader reader) throws XMLStreamException {
         context.leaveElement();
+        context.getReadElementPath().pop();
         try {
             context.getWriter().writeEndElement(reader);
         } catch (Exception e) {

--- a/org.talend.mdm.core/src/com/amalto/core/load/xml/StartElement.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/xml/StartElement.java
@@ -13,10 +13,12 @@ package com.amalto.core.load.xml;
 import com.amalto.core.load.Constants;
 import com.amalto.core.load.State;
 import com.amalto.core.load.context.StateContext;
+import com.google.common.base.Joiner;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.events.XMLEvent;
+import java.util.Iterator;
 
 /**
  *
@@ -30,6 +32,38 @@ public class StartElement implements State {
     public void parse(StateContext context, XMLStreamReader reader) throws XMLStreamException {
         String elementLocalName = reader.getName().getLocalPart();
         context.enterElement(elementLocalName);
+        context.getReadElementPath().push(elementLocalName);
+        /*
+        add the field path into the stack from xml content.
+        eg:
+            <Student>
+              <Id>2</Id>
+              <Name>Mike</Name>
+              <Age>25</Age>
+              <Account>8bf3d65e-8350-4a49-a651-c4cb5fdaf91f</Account>
+              <Site>6</Site>
+              <Course>
+                <Id>Chinese</Id>
+                <Score>6</Score>
+                <Like>1efa8311-3be5-4c42-a015-216780c46ab4</Like>
+              </Course>
+            </Student>
+            stack result like below:
+                Id
+                Name
+                Age
+                Account
+                Site
+                Course/Id
+                Course/Score
+                Course/Like
+         */
+        Iterator<String> iterator = context.getReadElementPath().iterator();
+        if (iterator.hasNext()) {
+            iterator.next();
+        }
+        String name = Joiner.on("/").join(iterator);
+        context.getNormalFieldInXML().add(name);
 
         if (context.skipElement()) {
             while (reader.next() != XMLEvent.END_ELEMENT) {

--- a/org.talend.mdm.core/src/com/amalto/core/save/SaverSession.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/SaverSession.java
@@ -304,12 +304,15 @@ public class SaverSession {
     public void save(String dataCluster, Document document) {
         synchronized (itemsToUpdate) {
             if (!this.hasMetAutoIncrement) {
-                Collection<FieldMetadata> keyFields = document.getType().getKeyFields();
-                boolean hasAutoincrementKey = false;
-                for (FieldMetadata keyField : keyFields) {
-                    hasAutoincrementKey = EUUIDCustomType.AUTO_INCREMENT.getName().equals(keyField.getType().getName());
+                Collection<FieldMetadata> allFields = document.getType().getFields();
+                boolean hasAutoIncrementKey = false;
+                for (FieldMetadata keyField : allFields) {
+                    if (EUUIDCustomType.AUTO_INCREMENT.getName().equals(keyField.getType().getName())) {
+                        hasAutoIncrementKey = true;
+                        break;
+                    }
                 }
-                this.hasMetAutoIncrement = hasAutoincrementKey;
+                this.hasMetAutoIncrement = hasAutoIncrementKey;
             }
 
             List<Document> documentsToSave = itemsToUpdate.get(dataCluster);

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadContext.java
@@ -31,11 +31,11 @@ class BulkLoadContext implements DocumentSaverContext {
 
     private final BulkLoadSaver bulkLoadSaver;
 
-    public BulkLoadContext(String dataCluster, String dataModelName, XSDKey keyMetadata, InputStream documentStream,
-            LoadAction loadAction, XmlServer server) {
+    public BulkLoadContext(String dataCluster, String dataModelName, XSDKey autoKeyMetadata, XSDKey autoFieldMetadata,
+            InputStream documentStream, LoadAction loadAction, XmlServer server) {
         this.dataCluster = dataCluster;
         this.dataModelName = dataModelName;
-        bulkLoadSaver = new BulkLoadSaver(loadAction, documentStream, keyMetadata, server);
+        bulkLoadSaver = new BulkLoadSaver(loadAction, documentStream, autoKeyMetadata, autoFieldMetadata, server);
     }
 
     @Override

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadSaver.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadSaver.java
@@ -25,20 +25,24 @@ class BulkLoadSaver implements DocumentSaver {
 
     private final InputStream documentStream;
 
-    private final XSDKey keyMetadata;
+    private final XSDKey autoKeyMetadata;
+
+    private final XSDKey autoFieldMetadata;
 
     private final XmlServer server;
 
-    BulkLoadSaver(LoadAction loadAction, InputStream documentStream, XSDKey keyMetadata, XmlServer server) {
+    BulkLoadSaver(LoadAction loadAction, InputStream documentStream, XSDKey autoKeyMetadata, XSDKey autoFieldMetadata,
+            XmlServer server) {
         this.loadAction = loadAction;
         this.documentStream = documentStream;
-        this.keyMetadata = keyMetadata;
+        this.autoKeyMetadata = autoKeyMetadata;
+        this.autoFieldMetadata = autoFieldMetadata;
         this.server = server;
     }
 
     public void save(SaverSession session, DocumentSaverContext context) {
         try {
-            loadAction.load(documentStream, keyMetadata, server, session);
+            loadAction.load(documentStream, autoKeyMetadata, autoFieldMetadata, server, session);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/SaverContextFactory.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/SaverContextFactory.java
@@ -101,7 +101,8 @@ public class SaverContextFactory {
      *
      * @param dataCluster    Data container name (must exist).
      * @param dataModelName  Data model name (must exist).
-     * @param keyMetadata    Key for all records contained in <code>documentStream</code>
+     * @param autoKeyMetadata    Key for all records contained in <code>documentStream</code>
+     * @param autoFieldMetadata  All Auto Increment/UUID field in <code>dataModelName</code>
      * @param documentStream AData model name (must exist).
      * @param loadAction     {@link com.amalto.core.load.action.LoadAction} to be used to bulk load records.
      * @param server         Abstraction of the underlying MDM database.
@@ -109,11 +110,13 @@ public class SaverContextFactory {
      */
     public DocumentSaverContext createBulkLoad(String dataCluster,
                                                String dataModelName,
-                                               XSDKey keyMetadata,
+                                               XSDKey autoKeyMetadata,
+                                               XSDKey autoFieldMetadata,
                                                InputStream documentStream,
                                                LoadAction loadAction,
                                                XmlServer server) {
-        return new BulkLoadContext(dataCluster, dataModelName, keyMetadata, documentStream, loadAction, server);
+        return new BulkLoadContext(dataCluster, dataModelName, autoKeyMetadata, autoFieldMetadata, documentStream, loadAction,
+                server);
     }
 
     /**

--- a/org.talend.mdm.core/src/com/amalto/core/servlet/LoadServlet.java
+++ b/org.talend.mdm.core/src/com/amalto/core/servlet/LoadServlet.java
@@ -232,6 +232,11 @@ public class LoadServlet extends HttpServlet {
     }
 
     protected LoadAction getLoadAction(String dataClusterName, String typeName, String dataModelName, boolean needValidate,
+            boolean needAutoGenPK) {
+        return getLoadAction(dataClusterName, typeName, dataModelName, needValidate, needAutoGenPK, false);
+    }
+
+    protected LoadAction getLoadAction(String dataClusterName, String typeName, String dataModelName, boolean needValidate,
             boolean needAutoGenPK, boolean needAutoGenNormalFields) {
         // Test if the data cluster actually exists
         DataClusterPOJO dataCluster = getDataCluster(dataClusterName);

--- a/org.talend.mdm.core/src/com/amalto/core/servlet/LoadServlet.java
+++ b/org.talend.mdm.core/src/com/amalto/core/servlet/LoadServlet.java
@@ -10,13 +10,19 @@
 package com.amalto.core.servlet;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,8 +30,10 @@ import javax.ws.rs.core.Response;
 
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.metadata.SimpleTypeFieldMetadata;
 import org.talend.mdm.commmon.util.core.EUUIDCustomType;
 import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.webapp.XSystemObjects;
@@ -55,7 +63,7 @@ public class LoadServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
-    public static final Map<String, XSDKey> typeNameToKeyDef = new HashMap<String, XSDKey>();
+    public static final Map<String, XSDKey> typeNameToKeyDef = new HashMap<>();
 
     private static final String PARAMETER_CLUSTER = "cluster"; //$NON-NLS-1$
 
@@ -67,9 +75,15 @@ public class LoadServlet extends HttpServlet {
 
     private static final String PARAMETER_SMARTPK = "smartpk"; //$NON-NLS-1$
 
+    private static final String PARAMETER_SMARTFIELDS = "smartfields"; //$NON-NLS-1$
+
     private static final String PARAMETER_INSERTONLY = "insertonly"; //$NON-NLS-1$
 
-    private static final Map<String, AtomicInteger> DB_REQUESTS_MAP = new HashMap<String, AtomicInteger>();
+    private static final String PARAMETER_UPDATEREPORT = "updateReport"; //$NON-NLS-1$
+
+    private static final String PARAMETER_SOURCE = "source"; //$NON-NLS-1$
+
+    private static final Map<String, AtomicInteger> DB_REQUESTS_MAP = new HashMap<>();
 
     private static final Integer MAX_DB_REQUESTS;
 
@@ -101,9 +115,10 @@ public class LoadServlet extends HttpServlet {
         String dataClusterName = request.getParameter(PARAMETER_CLUSTER);
         String typeName = request.getParameter(PARAMETER_CONCEPT);
         String dataModelName = request.getParameter(PARAMETER_DATAMODEL);
-        boolean needValidate = Boolean.valueOf(request.getParameter(PARAMETER_VALIDATE));
-        boolean needAutoGenPK = Boolean.valueOf(request.getParameter(PARAMETER_SMARTPK));
-        boolean insertOnly = Boolean.valueOf(request.getParameter(PARAMETER_INSERTONLY));
+        boolean needValidate = Boolean.parseBoolean(request.getParameter(PARAMETER_VALIDATE));
+        boolean needAutoGenPK = Boolean.parseBoolean(request.getParameter(PARAMETER_SMARTPK));
+        boolean needAutoGenNormalFields = request.getParameter(PARAMETER_SMARTFIELDS) == null ? true : false;
+        boolean insertOnly = Boolean.parseBoolean(request.getParameter(PARAMETER_INSERTONLY));
 
         try {
             if (!LocalUser.getLocalUser().userCanRead(DataClusterPOJO.class, dataClusterName)) {
@@ -116,24 +131,45 @@ public class LoadServlet extends HttpServlet {
             throw new ServletException(message);
         }
 
-        LoadAction loadAction = getLoadAction(dataClusterName, typeName, dataModelName, needValidate, needAutoGenPK);
+        LoadAction loadAction = getLoadAction(dataClusterName, typeName, dataModelName, needValidate, needAutoGenPK, needAutoGenNormalFields);
+
+        boolean updateReport = Boolean.parseBoolean(request.getParameter(PARAMETER_UPDATEREPORT));
+        String source = request.getParameter(PARAMETER_SOURCE);
+        ServletInputStream inputStream = request.getInputStream();
+
         if (needValidate && !loadAction.supportValidation()) {
             throw new ServletException(new UnsupportedOperationException("XML Validation isn't supported")); //$NON-NLS-1$
         }
         // Get xml server and key information
-        XmlServer server;
         XSDKey keyMetadata;
+        XSDKey autoFieldMetadata = null;
         try {
-            keyMetadata = getTypeKey(dataModelName, typeName);
-            server = Util.getXmlServerCtrlLocal();
+            MetadataRepositoryAdmin repositoryAdmin = ServerContext.INSTANCE.get().getMetadataRepositoryAdmin();
+            MetadataRepository repository = repositoryAdmin.get(dataModelName);
+            ComplexTypeMetadata type = repository.getComplexType(typeName);
+            keyMetadata = getTypeKey(type.getKeyFields());
+            if (needAutoGenNormalFields) {
+                Collection<FieldMetadata> fields = type.getFields();
+                Collection<FieldMetadata> autoFields = fields.stream().filter(filed -> (!filed.isKey()))
+                        .collect(Collectors.toList());
+                autoFieldMetadata = getTypeAutoField(autoFields);
+            }
         } catch (Exception e) {
             throw new ServletException(e);
         }
         DataRecord.CheckExistence.set(!insertOnly);
+        bulkLoadSave(dataClusterName, dataModelName, inputStream, loadAction, keyMetadata, autoFieldMetadata);
+        writer.write("</body></html>"); //$NON-NLS-1$
+    }
+
+    protected void bulkLoadSave(String dataClusterName, String dataModelName, InputStream inputStream, LoadAction loadAction,
+            XSDKey keyMetadata, XSDKey autoFieldMetadata) throws ServletException {
+        XmlServer server = Util.getXmlServerCtrlLocal();
+
         SaverSession session = SaverSession.newSession();
         SaverContextFactory contextFactory = session.getContextFactory();
-        DocumentSaverContext context = contextFactory.createBulkLoad(dataClusterName, dataModelName, keyMetadata,
-                request.getInputStream(), loadAction, server);
+        DocumentSaverContext context = contextFactory
+                .createBulkLoad(dataClusterName, dataModelName, keyMetadata, autoFieldMetadata, inputStream, loadAction, server);
         DocumentSaver saver = context.createSaver();
 
         // Wait until less that MAX_THREADS running
@@ -176,7 +212,6 @@ public class LoadServlet extends HttpServlet {
                 LOG.debug("Finish 1 db request, currently " + newDbRequests + " requests left.");
             }
         }
-        writer.write("</body></html>"); //$NON-NLS-1$
     }
 
     protected int increaseDbRequests(String dataClusterName) {
@@ -197,7 +232,7 @@ public class LoadServlet extends HttpServlet {
     }
 
     protected LoadAction getLoadAction(String dataClusterName, String typeName, String dataModelName, boolean needValidate,
-            boolean needAutoGenPK) {
+            boolean needAutoGenPK, boolean needAutoGenNormalFields) {
         // Test if the data cluster actually exists
         DataClusterPOJO dataCluster = getDataCluster(dataClusterName);
         if (dataCluster == null) {
@@ -208,7 +243,7 @@ public class LoadServlet extends HttpServlet {
         if (needValidate || XSystemObjects.DC_PROVISIONING.getName().equals(dataClusterName)) {
             loadAction = new DefaultLoadAction(dataClusterName, dataModelName, needValidate);
         } else {
-            loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK);
+            loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK, needAutoGenNormalFields);
         }
         if (LOG.isDebugEnabled()) {
             LOG.debug("Load action selected for load: " + loadAction.getClass().getName() //$NON-NLS-1$
@@ -229,17 +264,11 @@ public class LoadServlet extends HttpServlet {
         return dataCluster;
     }
 
-    private XSDKey getTypeKey(String dataModelName, String typeName) throws Exception {
-        MetadataRepositoryAdmin repositoryAdmin = ServerContext.INSTANCE.get().getMetadataRepositoryAdmin();
-        MetadataRepository repository = repositoryAdmin.get(dataModelName);
-        ComplexTypeMetadata type = repository.getComplexType(typeName);
-        if (type == null) {
-            throw new IllegalArgumentException("Type '" + typeName + "' does not exist in data model '" + dataModelName + "'.");
-        }
-        String[] fields = new String[type.getKeyFields().size()];
-        String[] fieldTypes = new String[type.getKeyFields().size()];
+    private XSDKey getTypeKey(Collection<FieldMetadata> fieldList) {
+        String[] fields = new String[fieldList.size()];
+        String[] fieldTypes = new String[fieldList.size()];
         int i = 0;
-        for (FieldMetadata keyField : type.getKeyFields()) {
+        for (FieldMetadata keyField : fieldList) {
             fields[i] = keyField.getPath();
             String name = keyField.getType().getName();
             if (EUUIDCustomType.AUTO_INCREMENT.getName().equals(name) || EUUIDCustomType.UUID.getName().equals(name)) { // See
@@ -251,6 +280,40 @@ public class LoadServlet extends HttpServlet {
             i++;
         }
         return new XSDKey(".", fields, fieldTypes); //$NON-NLS-1$
+    }
+
+    /**
+     * Filter the AUTO_INCREMENT/UUID type field from the entity's all list.
+     * if contains the complex type, it also filter.
+     * @param fieldList all field except the PK in one entity
+     * @return all AUTO_INCREMENT/UUID type field, include this type field existed in the complex type
+     */
+    private XSDKey getTypeAutoField(Collection<FieldMetadata> fieldList) {
+        List<String> fieldsList = new ArrayList<>(fieldList.size());
+        List<String> fieldTypesList = new ArrayList<>(fieldList.size());
+        for (FieldMetadata field : fieldList) {
+            List<FieldMetadata> fieldMetadataList = new ArrayList<>();
+            getFieldIntactName(field, fieldMetadataList);
+            for (FieldMetadata subField : fieldMetadataList) {
+                fieldsList.add(subField.getPath());
+                fieldTypesList.add(subField.getType().getName());
+            }
+        }
+        return new XSDKey(".", fieldsList.toArray(new String[] {}), fieldTypesList.toArray(new String[] {})); //$NON-NLS-1$
+    }
+
+    private void getFieldIntactName(FieldMetadata field, List<FieldMetadata> fieldList) {
+        if (field instanceof SimpleTypeFieldMetadata) {
+            String name = field.getType().getName();
+            if (EUUIDCustomType.AUTO_INCREMENT.getName().equals(name) || EUUIDCustomType.UUID.getName().equals(name)) {
+                fieldList.add(field);
+            }
+        } else if (field instanceof ContainedTypeFieldMetadata) {
+            ContainedTypeFieldMetadata containedTypeFieldMetadata = (ContainedTypeFieldMetadata) field;
+            for (FieldMetadata subField : containedTypeFieldMetadata.getContainedType().getFields()) {
+                getFieldIntactName(subField, fieldList);
+            }
+        }
     }
 
     /**

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/XmlSAXDataRecordReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/XmlSAXDataRecordReader.java
@@ -71,11 +71,11 @@ public class XmlSAXDataRecordReader implements DataRecordReader<XmlSAXDataRecord
 
     private static class DataRecordContentHandler implements ContentHandler {
 
-        private final Stack<TypeMetadata> currentType = new Stack<TypeMetadata>();
+        private final Stack<TypeMetadata> currentType = new Stack<>();
 
-        private final Stack<DataRecord> dataRecordStack = new Stack<DataRecord>();
+        private final Stack<DataRecord> dataRecordStack = new Stack<>();
 
-        private final Stack<FieldMetadata> currentField = new Stack<FieldMetadata>();
+        private final Stack<FieldMetadata> currentField = new Stack<>();
 
         private final ResettableStringWriter charactersBuffer = new ResettableStringWriter();
 
@@ -83,7 +83,7 @@ public class XmlSAXDataRecordReader implements DataRecordReader<XmlSAXDataRecord
 
         private final MetadataRepository repository;
 
-        private boolean hasMetUserElement = false;
+        private boolean hasMetUserElement;
 
         private boolean isReadingTimestamp = false;
 
@@ -172,7 +172,12 @@ public class XmlSAXDataRecordReader implements DataRecordReader<XmlSAXDataRecord
                                 }
                             }
                         }
-                        DataRecord containedRecord = new DataRecord(actualType, UnsupportedDataRecordMetadata.INSTANCE);
+                        DataRecord containedRecord;
+                        if (actualType.getContainer() == null || dataRecordStack.peek().get(actualType.getContainer()) == null) {
+                            containedRecord = new DataRecord(actualType, UnsupportedDataRecordMetadata.INSTANCE);
+                        } else {
+                            containedRecord = (DataRecord) dataRecordStack.peek().get(actualType.getContainer());
+                        }
                         dataRecordStack.peek().set(field, containedRecord);
                         dataRecordStack.push(containedRecord);
                         currentType.push(actualType);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/util/MultiOccurrenceManager.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/util/MultiOccurrenceManager.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.talend.mdm.webapp.base.client.model.DataTypeConstants;
 import org.talend.mdm.webapp.base.shared.TypeModel;
 import org.talend.mdm.webapp.browserecords.client.i18n.MessagesFactory;
 import org.talend.mdm.webapp.browserecords.client.model.ItemNodeModel;
@@ -221,7 +222,10 @@ public class MultiOccurrenceManager {
             if (mandatory != null) {
                 multiItem.warnMandatory();
                 childItem.setTitle(mandatory);
-                nodeModel.setValid(false);
+                if (this.metaDataTypes.get(nodeModel.getTypePath()).getType() != DataTypeConstants.AUTO_INCREMENT
+                        && this.metaDataTypes.get(nodeModel.getTypePath()).getType() != DataTypeConstants.UUID) {
+                    nodeModel.setValid(false);
+                }
             }
 
         }


### PR DESCRIPTION
JIRA: https://jira.talendforge.org/browse/TMDM-14192

**What is the current behavior?** (You should also link to an open issue here)
1. For SOAP/REST API, one AUTO_INCREMENT field's value cann't saved after restart MDM server.
2. For Bulkload, don't support the AUTO_INCREMENT field(Not PK).


**What is the new behavior?**
1. Persisted to the database for AUTO_INCREMENT field's value.
2. Support AUTO_INCREMENT field in Bulkload


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
