### PR TITLE
TMDM-14270 Failed to delete RTE records in MDM Web UI

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StatefulContext.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StatefulContext.java
@@ -131,7 +131,7 @@ public class StatefulContext implements MappingCreatorContext {
             if (topType.getName().equals(rawTypeName) && curName.length() == expectedLength) {
                 return true;
             }
-            Boolean isSameName = null;
+            Boolean isSameName = false;
             boolean isExist = topType.getSubTypes().stream()
                     .anyMatch(action -> action.getUsages().stream().anyMatch(item -> {
                         if (item.getContainer() != null && item.getContainer().getContainingType() != null) {
@@ -142,10 +142,16 @@ public class StatefulContext implements MappingCreatorContext {
                     }));
             if (isExist) {
                 //This logic code only use in RTE DM
-                isSameName = topType.getSubTypes().stream().anyMatch(action -> action.getFields().stream().anyMatch(
-                        item -> !item.equals(field) && !item.getContainingType().equals(field.getContainingType())
-                                && field.getContainingType().getUsages().size() == item.getContainingType().getUsages().size()
-                                && item.getName().equals(field.getName())));
+                Collection<ComplexTypeMetadata> subTypeList = topType.getSubTypes();
+                outLoop: for (ComplexTypeMetadata subTribe : subTypeList) {
+                    for (FieldMetadata subField : subTribe.getFields()) {
+                        if (!subField.equals(field) && !subField.getContainingType().equals(field.getContainingType())
+                                && subField.getName().equals(field.getName())) {
+                            isSameName = true;
+                            break outLoop;
+                        }
+                    }
+                }
             }
             return isExist && !isSameName;
         }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -6402,15 +6402,15 @@ public class StorageQueryTest extends StorageTestCase {
         try {
             storage.delete(from(contrat).getExpression());
             storage.delete(from(eda).getExpression());
-            //storage.delete(from(interlocuteur).getExpression());
-            //storage.delete(from(useUrse).getExpression());
+            storage.delete(from(interlocuteur).getExpression());
+            storage.delete(from(useUrse).getExpression());
         } catch (Exception e) {
             assertNull(e);
         } finally {
             storage.commit();
         }
 
-        /*qb = from(useUrse);
+        qb = from(useUrse);
         results = storage.fetch(qb.getSelect());
         assertEquals(0, results.getCount());
 
@@ -6424,7 +6424,6 @@ public class StorageQueryTest extends StorageTestCase {
 
         qb = from(contrat);
         results = storage.fetch(qb.getSelect());
-        assertEquals(0, results.getCount());*/
-
+        assertEquals(0, results.getCount());
     }
 }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14270
What is the current behavior? (You should also link to an open issue here)
As with Entity Contrat, Exception occurred when deleted operation, the concrete error info like `could not resolve property: x_contratsrp of: org.talend.mdm.storage.hibernate.X_ANONYMOUS29`, message pop up against restart the MDM server to delete data of Contrat.

What is the new behavior?
Modify the corresponding relations of entities, and load field map the correct containing type, then the record will be deleted as expected.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
