### PR TITLE
TMDM-14289 tMDMRollback somtimes let transactions "opened"

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/delegator/IXtentisWSDelegator.java
@@ -883,6 +883,7 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     @Override
     public WSItemPK partialPutItem(WSPartialPutItem partialPutItem) throws RemoteException {
         try {
+            Util.beginTransactionLimit();
             SaverSession session = SaverSession.newSession();
             DocumentSaver saver;
             try {
@@ -909,6 +910,8 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
                 throw new RemoteException((cause.getCause() == null ? cause.getLocalizedMessage() : cause.getCause()
                         .getLocalizedMessage()), e);
             }
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 
@@ -920,6 +923,7 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     @Override
     public WSItemPK putItem(WSPutItem wsPutItem) throws RemoteException {
         try {
+            Util.beginTransactionLimit();
             WSDataClusterPK dataClusterPK = wsPutItem.getWsDataClusterPK();
             WSDataModelPK dataModelPK = wsPutItem.getWsDataModelPK();
             String dataClusterName = dataClusterPK.getPk();
@@ -952,6 +956,8 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
                 throw new RemoteException((cause.getCause() == null ? cause.getLocalizedMessage() : cause.getCause()
                         .getLocalizedMessage()), e);
             }
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 
@@ -964,6 +970,7 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     public WSItemPKArray putItemArray(WSPutItemArray wsPutItemArray) throws RemoteException {
         WSPutItem[] items = wsPutItemArray.getWsPutItem();
         try {
+            Util.beginTransactionLimit();
             List<WSItemPK> pks = new LinkedList<WSItemPK>();
             SaverSession session = SaverSession.newSession();
             for (WSPutItem item : items) {
@@ -989,6 +996,8 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
         } catch (Exception e) {
             LOGGER.error("Error during save.", e); //$NON-NLS-1$
             throw new RemoteException((e.getCause() == null ? e.getLocalizedMessage() : e.getCause().getLocalizedMessage()), e);
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 
@@ -1001,6 +1010,7 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     public WSItemPKArray putItemWithReportArray(com.amalto.core.webservice.WSPutItemWithReportArray wsPutItemWithReportArray)
             throws RemoteException {
         try {
+            Util.beginTransactionLimit();
             WSPutItemWithReport[] items = wsPutItemWithReportArray.getWsPutItem();
             List<WSItemPK> pks = new LinkedList<WSItemPK>();
             SaverSession session = SaverSession.newSession();
@@ -1041,6 +1051,8 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
         } catch (Exception e) {
             LOGGER.error("Error during save.", e); //$NON-NLS-1$
             throw handleException(e, SAVE_EXCEPTION_MESSAGE);
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 
@@ -1052,6 +1064,7 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     @Override
     public WSItemPK putItemWithReport(com.amalto.core.webservice.WSPutItemWithReport wsPutItemWithReport) throws RemoteException {
         try {
+            Util.beginTransactionLimit();
             WSPutItem wsPutItem = wsPutItemWithReport.getWsPutItem();
             WSDataClusterPK dataClusterPK = wsPutItem.getWsDataClusterPK();
             WSDataModelPK dataModelPK = wsPutItem.getWsDataModelPK();
@@ -1088,6 +1101,8 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
         } catch (Exception e) {
             LOGGER.error("Error during save.", e); //$NON-NLS-1$
             throw handleException(e, SAVE_EXCEPTION_MESSAGE);
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 
@@ -1100,6 +1115,7 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
     public WSItemPK putItemWithCustomReport(com.amalto.core.webservice.WSPutItemWithCustomReport wsPutItemWithCustomReport)
             throws RemoteException {
         try {
+            Util.beginTransactionLimit();
             WSPutItemWithReport wsPutItemWithReport = wsPutItemWithCustomReport.getWsPutItemWithReport();
             WSPutItem wsPutItem = wsPutItemWithReport.getWsPutItem();
             WSDataClusterPK dataClusterPK = wsPutItem.getWsDataClusterPK();
@@ -1133,6 +1149,8 @@ public abstract class IXtentisWSDelegator implements IBeanDelegator, XtentisPort
         } catch (Exception e) {
             LOGGER.error("Error during save.", e); //$NON-NLS-1$
             throw new RemoteException((e.getCause() == null ? e.getLocalizedMessage() : e.getCause().getLocalizedMessage()), e);
+        } finally {
+            Util.endTransactionLimit();
         }
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/save/SaverSession.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/SaverSession.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.apache.log4j.Logger;
 
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.util.core.EUUIDCustomType;
@@ -31,8 +32,10 @@ import com.amalto.core.save.context.StorageDocument;
 import com.amalto.core.save.context.StorageSaverSource;
 import com.amalto.core.save.generator.AutoIncrementGenerator;
 import com.amalto.core.storage.record.DataRecord;
+import com.amalto.core.util.Util;
 
 public class SaverSession {
+    private static final Logger LOGGER = Logger.getLogger(SaverSession.class);
 
     private static final String AUTO_INCREMENT_TYPE_NAME = "AutoIncrement"; //$NON-NLS-1$
 
@@ -210,6 +213,13 @@ public class SaverSession {
                         throw new MultiRecordsSaveException(getCauseMessage(e), e.getCause(), recordId, itemCounter);
                     }
                     throw e;
+                }
+                if (Util.TRANSACTION_WAIT_MILLISECONDS_VALUE > 0) {
+                    try {
+                        Thread.sleep(Util.TRANSACTION_WAIT_MILLISECONDS_VALUE);
+                    } catch (InterruptedException e) {
+                        LOGGER.warn("Update process has been interrupted.", e); //$NON-NLS-1$
+                    }
                 }
             }
             // If any change was made to data cluster "UpdateReport", route committed update reports.

--- a/org.talend.mdm.core/src/com/amalto/core/save/SaverSession.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/SaverSession.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
 
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.util.core.EUUIDCustomType;
@@ -34,7 +33,6 @@ import com.amalto.core.save.generator.AutoIncrementGenerator;
 import com.amalto.core.storage.record.DataRecord;
 
 public class SaverSession {
-    private static final Logger LOGGER = Logger.getLogger(SaverSession.class);
 
     private static final String AUTO_INCREMENT_TYPE_NAME = "AutoIncrement"; //$NON-NLS-1$
 
@@ -55,28 +53,6 @@ public class SaverSession {
     private final SaverSource dataSource;
 
     private boolean hasMetAutoIncrement = false;
-
-    private static final String TRANSACTION_WAIT_MILLISECONDS = "transaction.concurrent.wait.milliseconds"; //$NON-NLS-1$
-
-    private static final String TRANSACTION_WAIT_MILLISECONDS_CONFIG;
-
-    static {
-        TRANSACTION_WAIT_MILLISECONDS_CONFIG = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_WAIT_MILLISECONDS);
-    }
-
-    private static long getTransactionWaitMilliseconds() {
-        if (TRANSACTION_WAIT_MILLISECONDS_CONFIG != null) {
-            try {
-                return Long.valueOf(TRANSACTION_WAIT_MILLISECONDS_CONFIG);
-            } catch (Exception e) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Failed to read configuration: " + TRANSACTION_WAIT_MILLISECONDS, e); //$NON-NLS-1$
-                }
-                return 0L;
-            }
-        }
-        return 0L;
-    }
 
     public SaverSession(SaverSource dataSource) {
         this.dataSource = dataSource;
@@ -203,7 +179,6 @@ public class SaverSession {
         }
         // Items to update
         synchronized (itemsToUpdate) {
-            long transactionWaitMilliseconds = getTransactionWaitMilliseconds();
             boolean needResetAutoIncrement = false;
             for (Map.Entry<String, List<Document>> currentTransaction : itemsToUpdate.entrySet()) {
                 String dataCluster = currentTransaction.getKey();
@@ -235,11 +210,6 @@ public class SaverSession {
                         throw new MultiRecordsSaveException(getCauseMessage(e), e.getCause(), recordId, itemCounter);
                     }
                     throw e;
-                }
-                try {
-                    Thread.sleep(transactionWaitMilliseconds);
-                } catch (InterruptedException e) {
-                    LOGGER.warn("Update process has been interrupted.", e); //$NON-NLS-1$
                 }
             }
             // If any change was made to data cluster "UpdateReport", route committed update reports.

--- a/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/transaction/TransactionService.java
@@ -11,20 +11,16 @@
 
 package com.amalto.core.storage.transaction;
 
-import java.util.List;
-
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-
 import com.amalto.core.server.ServerContext;
 import com.amalto.core.storage.task.staging.SerializableList;
+import com.amalto.core.util.Util;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
+import javax.ws.rs.*;
+
+import java.util.List;
 
 @Path("/transactions")
 @Api("Transactions")
@@ -69,7 +65,12 @@ public class TransactionService {
         TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
         Transaction transaction = transactionManager.get(transactionId);
         if (transaction != null) {
-            transaction.commit();
+            try {
+                Util.beginTransactionLimit();
+                transaction.commit();
+            } finally {
+                Util.endTransactionLimit();
+            }
         }
     }
 
@@ -85,7 +86,12 @@ public class TransactionService {
         TransactionManager transactionManager = ServerContext.INSTANCE.get().getTransactionManager();
         Transaction transaction = transactionManager.get(transactionId);
         if (transaction != null) {
-            transaction.rollback();
+            try {
+                Util.beginTransactionLimit();
+                transaction.rollback();
+            } finally {
+                Util.endTransactionLimit();
+            }
         }
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.MissingResourceException;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -169,6 +170,26 @@ public class Util {
     private static RoutingOrder defaultRoutingOrder;
 
     private static com.amalto.core.server.api.Transformer defaultTransformer;
+
+    private static final AtomicInteger TRANSACTION_CURRENT_REQUESTS = new AtomicInteger();
+
+    private static final String TRANSACTION_WAIT_MILLISECONDS_KEY = "transaction.concurrent.wait.milliseconds"; //$NON-NLS-1$
+
+    private static long TRANSACTION_WAIT_MILLISECONDS_VALUE = 0L;
+
+    static {
+        String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_WAIT_MILLISECONDS_KEY);
+        if (config != null) {
+            try {
+                TRANSACTION_WAIT_MILLISECONDS_VALUE = Long.valueOf(config);
+            } catch (Exception e) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Failed to read configuration: " + TRANSACTION_WAIT_MILLISECONDS_KEY, e); //$NON-NLS-1$
+                }
+                TRANSACTION_WAIT_MILLISECONDS_VALUE = 0L;
+            }
+        }
+    }
 
     private static synchronized DocumentBuilderFactory getDocumentBuilderFactory() {
         if (nonValidatingDocumentBuilderFactory == null) {
@@ -1288,5 +1309,28 @@ public class Util {
             path = path.replaceAll("\\[\\d+\\]", "");
         }
         return path;
+    }
+
+    public static void beginTransactionLimit() {
+        if (TRANSACTION_WAIT_MILLISECONDS_VALUE > 0) {
+            synchronized (Util.class) {
+                try {
+                    while (TRANSACTION_CURRENT_REQUESTS.get() >= 1) {
+                        Thread.sleep(TRANSACTION_WAIT_MILLISECONDS_VALUE);
+                    }
+                    TRANSACTION_CURRENT_REQUESTS.incrementAndGet();
+                } catch (InterruptedException e) {
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("Failed to sleep thread.", e);
+                    }
+                }
+            }
+        }
+    }
+
+    public static void endTransactionLimit() {
+        if (TRANSACTION_WAIT_MILLISECONDS_VALUE > 0) {
+            TRANSACTION_CURRENT_REQUESTS.decrementAndGet();
+        }
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -1328,6 +1328,10 @@ public class Util {
         }
     }
 
+    /*
+     * It is needed to invoked a pair of beginTransactionLimit and endTransactionLimit.
+     * And they shouldn't be nested invoked in the same thread. otherwise, the second calling will be blocked.
+     */
     public static void endTransactionLimit() {
         if (TRANSACTION_WAIT_MILLISECONDS_VALUE > 0) {
             TRANSACTION_CURRENT_REQUESTS.decrementAndGet();

--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -175,7 +175,7 @@ public class Util {
 
     private static final String TRANSACTION_WAIT_MILLISECONDS_KEY = "transaction.concurrent.wait.milliseconds"; //$NON-NLS-1$
 
-    private static long TRANSACTION_WAIT_MILLISECONDS_VALUE = 0L;
+    public static long TRANSACTION_WAIT_MILLISECONDS_VALUE = 0L;
 
     static {
         String config = MDMConfiguration.getConfiguration().getProperty(TRANSACTION_WAIT_MILLISECONDS_KEY);

--- a/org.talend.mdm.core/test/com/amalto/core/ejb/ItemPOJOTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/ejb/ItemPOJOTestCase.java
@@ -9,6 +9,8 @@
  */
 package com.amalto.core.ejb;
 
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
+
 import com.amalto.core.objects.ItemPOJO;
 import junit.framework.TestCase;
 
@@ -20,6 +22,14 @@ import com.amalto.core.util.XtentisException;
  */
 @SuppressWarnings("nls")
 public class ItemPOJOTestCase extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     /**
      * 

--- a/org.talend.mdm.core/test/com/amalto/core/history/UniqueIdTransformerTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/UniqueIdTransformerTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 
@@ -24,6 +25,14 @@ import junit.framework.TestCase;
 
 @SuppressWarnings("nls")
 public class UniqueIdTransformerTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     public void testAddIds() throws Exception {        
         String beforeXML = file2String(this.getClass().getResourceAsStream("before.xml"));

--- a/org.talend.mdm.core/test/com/amalto/core/history/accessor/ManyFieldAccessorTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/history/accessor/ManyFieldAccessorTest.java
@@ -15,11 +15,20 @@ import java.io.IOException;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang.StringUtils;
 import org.junit.Test;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.xml.sax.SAXException;
 import com.amalto.core.save.DOMDocument;
 import com.amalto.core.util.Util;
 
 public class ManyFieldAccessorTest {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     @Test
     public void testCreateEmptyChildNode() throws Exception {

--- a/org.talend.mdm.core/test/com/amalto/core/save/DOMDocumentTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/save/DOMDocumentTest.java
@@ -17,6 +17,7 @@ import java.io.InputStreamReader;
 import javax.xml.parsers.DocumentBuilder;
 
 import org.apache.commons.lang.StringUtils;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.core.MDMXMLUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
@@ -29,6 +30,14 @@ import junit.framework.TestCase;
 
 @SuppressWarnings("nls")
 public class DOMDocumentTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     public void testExportToString() throws Exception {
         BufferedReader in = new BufferedReader(new InputStreamReader(DOMDocumentTest.class.getResourceAsStream("test1.xml")));

--- a/org.talend.mdm.core/test/com/amalto/core/save/context/BeforeSavingTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/save/context/BeforeSavingTest.java
@@ -9,10 +9,20 @@
  */
 package com.amalto.core.save.context;
 
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
+
 import junit.framework.TestCase;
 
 @SuppressWarnings("nls")
 public class BeforeSavingTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     public void testValidateFormat() throws Exception {
         BeforeSaving bs = new BeforeSaving(null);

--- a/org.talend.mdm.core/test/com/amalto/core/server/DefaultCustomFormTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/server/DefaultCustomFormTest.java
@@ -20,6 +20,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.talend.mdm.commmon.util.core.ICoreConstants;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 
 import com.amalto.core.delegator.ILocalUser;
 import com.amalto.core.objects.ObjectPOJO;
@@ -38,6 +39,14 @@ import junit.framework.TestCase;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ ObjectPOJO.class, LocalUser.class })
 public class DefaultCustomFormTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     private static final String DEMO_USER = "Demo_user";
 

--- a/org.talend.mdm.core/test/com/amalto/core/server/DefaultRoleTest.java
+++ b/org.talend.mdm.core/test/com/amalto/core/server/DefaultRoleTest.java
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 
 import com.amalto.core.objects.ObjectPOJO;
 import com.amalto.core.objects.ObjectPOJOPK;
@@ -29,7 +30,15 @@ import junit.framework.TestCase;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ com.amalto.core.objects.ObjectPOJO.class })
 public class DefaultRoleTest extends TestCase {
-    
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
+
     @Override
     public void setUp() throws Exception {
     }

--- a/org.talend.mdm.core/test/com/amalto/core/util/UtilTestCase.java
+++ b/org.talend.mdm.core/test/com/amalto/core/util/UtilTestCase.java
@@ -22,6 +22,7 @@ import javax.xml.xpath.XPathFactory;
 import junit.framework.TestCase;
 
 import org.apache.log4j.Logger;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -49,7 +50,15 @@ import com.amalto.xmlserver.interfaces.WhereLogicOperator;
 public class UtilTestCase extends TestCase {
 
     IValidation validation = new IValidation();
-    
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
+
     public void testDefaultValidate() throws IOException, ParserConfigurationException, SAXException {
         // missing mandontory field cvc-complex-type.2.4.b
         InputStream in = UtilTestCase.class.getResourceAsStream("Agency_ME02.xml");

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/CommonUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/client/util/CommonUtilTest.java
@@ -18,6 +18,7 @@ import java.util.Stack;
 import junit.framework.Assert;
 import junit.framework.TestCase;
 
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.webapp.base.client.model.Criteria;
 import org.talend.mdm.webapp.base.client.model.DataTypeConstants;
 import org.talend.mdm.webapp.base.client.model.MultipleCriteria;
@@ -37,6 +38,14 @@ import com.extjs.gxt.ui.client.data.ModelData;
 
 @SuppressWarnings("nls")
 public class CommonUtilTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     public void testParseSimpleSearchExpression() throws Exception {
         String s = "(foo/bar EQUALS 3/4)";

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsActionTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/actions/BrowseRecordsActionTest.java
@@ -37,6 +37,7 @@ import org.powermock.reflect.Whitebox;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadataImpl;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.datamodel.management.DataModelID;
 import org.talend.mdm.webapp.base.client.exception.ServiceException;
 import org.talend.mdm.webapp.base.client.model.ForeignKeyBean;
@@ -115,6 +116,14 @@ import junit.framework.TestSuite;
         BrowseRecordsAction.class, Configuration.class })
 @SuppressWarnings("nls")
 public class BrowseRecordsActionTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     private final Messages MESSAGES = MessagesFactory.getMessages(
             "org.talend.mdm.webapp.browserecords.client.i18n.BrowseRecordsMessages", this.getClass().getClassLoader()); //$NON-NLS-1$

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/bizhelpers/DataModelHelperTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/bizhelpers/DataModelHelperTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit3.PowerMockSuite;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.datamodel.management.BusinessConcept;
 import org.talend.mdm.commmon.util.datamodel.management.DataModelID;
 import org.talend.mdm.webapp.base.client.model.DataTypeCustomized;
@@ -47,6 +48,14 @@ import com.sun.xml.xsom.util.DomAnnotationParserFactory;
 @PrepareForTest({ Util.class })
 @SuppressWarnings("nls")
 public class DataModelHelperTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     @SuppressWarnings("unchecked")
     public static TestSuite suite() throws Exception {

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
@@ -30,6 +30,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit3.PowerMockSuite;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.datamodel.management.DataModelID;
 import org.talend.mdm.webapp.base.client.exception.ServiceException;
 import org.talend.mdm.webapp.base.client.model.DataTypeConstants;
@@ -55,6 +56,14 @@ import com.google.gwt.user.client.rpc.core.java.util.Collections;
 @PrepareForTest({ Util.class })
 @SuppressWarnings("nls")
 public class CommonUtilTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     private static final Logger LOG = Logger.getLogger(CommonUtilTest.class);
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/DynamicLabelUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/DynamicLabelUtilTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit3.PowerMockSuite;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.datamodel.management.DataModelID;
 import org.talend.mdm.webapp.base.client.model.ForeignKeyBean;
 import org.talend.mdm.webapp.base.server.util.XmlUtil;
@@ -46,6 +47,14 @@ import com.extjs.gxt.ui.client.data.ModelData;
 @PrepareForTest({ Util.class })
 @SuppressWarnings("nls")
 public class DynamicLabelUtilTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     @SuppressWarnings("unchecked")
     public static TestSuite suite() throws Exception {

--- a/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
+++ b/org.talend.mdm.webapp.core/src/test/java/com/amalto/webapp/core/util/UtilTest.java
@@ -14,6 +14,7 @@ import junit.framework.TestCase;
 
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONObject;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
@@ -23,6 +24,14 @@ import com.amalto.core.webservice.WSWhereOperator;
 
 @SuppressWarnings("nls")
 public class UtilTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     private String foreignKeyInfo = "ProductFamily/Name";
 

--- a/org.talend.mdm.webapp.journal/src/test/java/org/talend/mdm/webapp/journal/server/ForeignKeyInfoTransformerTest.java
+++ b/org.talend.mdm.webapp.journal/src/test/java/org/talend/mdm/webapp/journal/server/ForeignKeyInfoTransformerTest.java
@@ -27,6 +27,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit3.PowerMockSuite;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.core.MDMXMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -50,6 +51,14 @@ import junit.framework.TestSuite;
 @SuppressWarnings("nls")
 @PrepareForTest({ DefaultItem.class, Util.class })
 public class ForeignKeyInfoTransformerTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     final String clusterName = "TestFKs";
 

--- a/org.talend.mdm.webapp.journal/src/test/java/org/talend/mdm/webapp/journal/server/service/JournalDBServiceTest.java
+++ b/org.talend.mdm.webapp.journal/src/test/java/org/talend/mdm/webapp/journal/server/service/JournalDBServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit3.PowerMockSuite;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.webapp.base.shared.EntityModel;
 import org.talend.mdm.webapp.browserecords.server.bizhelpers.DataModelHelper;
 import org.talend.mdm.webapp.journal.shared.JournalGridModel;
@@ -48,6 +49,14 @@ import com.sun.xml.xsom.XSElementDecl;
 @SuppressWarnings("nls")
 @PrepareForTest({ Util.class, XtentisPort.class, WSDataModelPKArray.class, WSRegexDataModelPKs.class})
 public class JournalDBServiceTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     private WebServiceMock mock = new WebServiceMock();
 

--- a/org.talend.mdm.webapp.recyclebin/src/test/java/org/talend/mdm/webapp/recyclebin/server/actions/UtilTest.java
+++ b/org.talend.mdm.webapp.recyclebin/src/test/java/org/talend/mdm/webapp/recyclebin/server/actions/UtilTest.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilder;
 
 import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.util.core.MDMConfiguration;
 import org.talend.mdm.commmon.util.core.MDMXMLUtils;
 import org.w3c.dom.Document;
 
@@ -23,6 +24,14 @@ import junit.framework.TestCase;
 
 @SuppressWarnings("nls")
 public class UtilTest extends TestCase {
+
+    static {
+        try {
+            MDMConfiguration.createConfiguration("", true);
+        } catch (IllegalStateException e) {
+            // already configured;
+        }
+    }
 
     private String getXSDModel(String filename) throws Exception {
         InputStream is = getClass().getClassLoader().getResourceAsStream(filename);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14289
**What is the current behavior?** (You should also link to an open issue here)

A job that fails (exception) and calls tMDMRollback sometimes let a transaction "opened" (not commited , not rollbacked). It was found that storage begin may not completed with storage commit or storage rollback in a request if there are many requests from a loop Studio Job.

**What is the new behavior?**

Added transaction process limitation, this will ensure that a request can complete the whole process of transaction.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
