### PR TITLE
AUTO_INCREMENT value for NOT Primary Key reset to 0 after MDM restart

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -623,6 +623,40 @@ public class DocumentSaveTest extends TestCase {
         committedElement = committer.getCommittedElement();
         assertEquals("1", evaluate(committedElement, "/Address/Id"));
         assertEquals("1", evaluate(committedElement, "/Address/Port"));
+
+        //5, for Entity Person, normal field is N_Index, and autoIncrement2 in the complex type Create
+        source = new TestSaverSource(repository, false, "", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test83.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true, true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+        assertEquals("1", evaluate(committedElement, "/Person/complex/autoIncrement2"));
+
+        //6, for Entity Person, normal field is N_Index, and autoIncrement2 in the complex type Update
+        source = new TestSaverSource(repository, false, "test83_original.xml", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test83.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true, true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+        assertEquals("1", evaluate(committedElement, "/Person/complex/autoIncrement2"));
     }
 
     public void testUpdateWithUUID() throws Exception {

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/metadata24.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/metadata24.xsd
@@ -6,6 +6,25 @@
                 <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
                 <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
                 <xsd:element maxOccurs="1" minOccurs="1" name="N_Index" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="complex">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="autoIncrement2" type="AUTO_INCREMENT">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="test2" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
             </xsd:all>
         </xsd:complexType>
         <xsd:unique name="Person">

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test83.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test83.xml
@@ -1,0 +1,7 @@
+<Person xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Id>1</Id>
+    <Name>John</Name>
+    <complex>
+        <test2>11</test2>
+    </complex>
+</Person>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test83_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test83_original.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<ii>
+    <c>PersonAddress</c>
+    <n>PersonAddress</n>
+    <dmn>PersonAddress</dmn>
+    <i>231035933</i>
+    <t>1327653438644</t>
+    <p>
+        <Person xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <Id>1</Id>
+            <Name>John</Name>
+        </Person>
+    </p>
+</ii>

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
@@ -327,7 +327,7 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
                 } else if (EUUIDCustomType.AUTO_INCREMENT.getName().equalsIgnoreCase(comparedField.getType().getName())
                         && isCreateAction == false) {
                     generateNoOp(lastMatchPath);
-                    String conceptName = rootTypeName + "." + comparedField.getName().replaceAll("/", "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                    String conceptName = rootTypeName + "." + comparedField.getPath().replaceAll("/", "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                     String autoIncrementValue = saverSource.nextAutoIncrementId(dataCluster, dataModel, conceptName);
                     actions.add(new FieldUpdateAction(date, source, userName, path, StringUtils.EMPTY, autoIncrementValue, comparedField, userAction));
                     generateNoOp(path);
@@ -406,7 +406,7 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
                             }
                             if (EUUIDCustomType.AUTO_INCREMENT.getName().equalsIgnoreCase(comparedField.getType().getName())
                                     && isCreateAction == false && newObject == null) {
-                                String conceptName = rootTypeName + "." + comparedField.getName().replaceAll("/", "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                                String conceptName = rootTypeName + "." + comparedField.getPath().replaceAll("/", "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                                 newValue = saverSource.nextAutoIncrementId(dataCluster, dataModel, conceptName);
                             } else if (EUUIDCustomType.UUID.getName().equalsIgnoreCase(comparedField.getType().getName())
                                     && isCreateAction == false && newObject == null) {


### PR DESCRIPTION
JIRA: https://jira.talendforge.org/browse/TMDM-14192#
**What is the current behavior?** (You should also link to an open issue here)
have the wrong key path of the autoincrement value in system database for AUTO_INCREMENT type field in the complex type


**What is the new behavior?**
Modify the field path to field,getPath() from field.getName() before generate the value,


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
