### PR TITLE
TMDM-14432 Unexpected error promotion while delete a record referenced to other entity using RTE datamodel

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/integrity/InboundReferencesTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/integrity/InboundReferencesTest.java
@@ -416,6 +416,27 @@ public class InboundReferencesTest extends TestCase {
         assertEquals(FKIntegrityCheckResult.ALLOWED, policy);
     }
 
+    // TMDM-14432 Unexpected error promotion while delete a record referenced to other entity using RTE datamodel
+    public void testModelRTEWithFK() throws Exception {
+        MetadataRepository repository = getMetadataRepository("RTE_3.xsd");
+
+        ComplexTypeMetadata interlocuteur = repository.getComplexType("Interlocuteur");
+        FieldMetadata fieldUse = interlocuteur.getField("use");
+        assertEquals(ReferenceFieldMetadata.class, fieldUse.getClass());
+        ReferenceFieldMetadata referenceFieldMetadata = (ReferenceFieldMetadata) fieldUse;
+        assertTrue(referenceFieldMetadata.isFKIntegrity());
+        assertFalse(referenceFieldMetadata.allowFKIntegrityOverride());
+
+        IntegrityCheckDataSourceMock dataSource = new IntegrityCheckDataSourceMock(repository);
+        FKIntegrityChecker integrityChecker = FKIntegrityChecker.getInstance();
+        String dataCluster = "RTE";
+        String typeName = "Interlocuteur";
+        String[] fkIds = {"1"};
+        assertTrue(integrityChecker.allowDelete(dataCluster, typeName, fkIds, false, dataSource));
+        FKIntegrityCheckResult policy = integrityChecker.getFKIntegrityPolicy(dataCluster, typeName, fkIds, dataSource);
+        assertEquals(FKIntegrityCheckResult.ALLOWED, policy);
+    }
+
     public void testModel15() throws Exception {
         MetadataRepository repository = getMetadataRepository("model15.xsd");
 

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/integrity/IntegrityCheckDataSourceMock.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/integrity/IntegrityCheckDataSourceMock.java
@@ -10,11 +10,17 @@
 
 package com.amalto.core.integrity;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
-import org.talend.mdm.commmon.metadata.*;
+import org.talend.mdm.commmon.metadata.FieldMetadata;
+import org.talend.mdm.commmon.metadata.InboundReferences;
+import org.talend.mdm.commmon.metadata.MetadataRepository;
+import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
+import org.talend.mdm.commmon.metadata.TypeMetadata;
+
 import com.amalto.core.util.XtentisException;
 
 /**
@@ -25,6 +31,8 @@ class IntegrityCheckDataSourceMock implements FKIntegrityCheckDataSource {
     private final MetadataRepository repository;
 
     private boolean hasMetConflict;
+
+    private String[] pkIds = new String[] { "1" };
 
     public IntegrityCheckDataSourceMock(MetadataRepository repository) {
         this.repository = repository;
@@ -41,7 +49,7 @@ class IntegrityCheckDataSourceMock implements FKIntegrityCheckDataSource {
 
     public boolean isFKReferencedBySelf(String clusterName, String[] ids, String fromTypeName,
             ReferenceFieldMetadata fromReference) throws XtentisException {
-        if (fromReference.getReferencedType().getName().equalsIgnoreCase(fromTypeName)) {
+        if (Arrays.equals(ids, pkIds) && fromReference.getReferencedType().getName().equalsIgnoreCase(fromTypeName)) {
             return true;
         }
         return false;

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/integrity/RTE_3.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/integrity/RTE_3.xsd
@@ -1,0 +1,64 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <!-- Objet INTERLOCUTEUR -->
+    <xsd:element name="Interlocuteur" type="InterlocuteurType">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Label_FR">Interlocuteur</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:unique name="Interlocuteur">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="idGrc" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="InterlocuteurType">
+        <xsd:sequence>
+            <xsd:element maxOccurs="1" minOccurs="0" name="titre" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="1" name="idGrc" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Label_FR">Code Partenaire GRC</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="0" name="use" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    <xsd:appinfo source="X_ForeignKey">UseUrse/codeUSE</xsd:appinfo>
+                    <xsd:appinfo source="X_Label_FR">USE</xsd:appinfo>
+                    <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- Objet UseURSE -->
+    <xsd:element name="UseUrse" type="UseUrseType">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Label_FR">USE/URSE</xsd:appinfo>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:unique name="UseUrse">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="codeUSE" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:complexType name="UseUrseType">
+        <xsd:all>
+            <xsd:element maxOccurs="1" minOccurs="1" name="codeUSE" type="xsd:integer">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Label_FR">Code</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element maxOccurs="1" minOccurs="1" name="nomUse" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:appinfo source="X_Label_FR">Nom</xsd:appinfo>
+                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>

--- a/org.talend.mdm.core/src/com/amalto/core/integrity/DefaultCheckDataSource.java
+++ b/org.talend.mdm.core/src/com/amalto/core/integrity/DefaultCheckDataSource.java
@@ -109,7 +109,7 @@ class DefaultCheckDataSource implements FKIntegrityCheckDataSource {
             return false;
         }
         String[] pkIds = getItemPKsByCriteria(clusterName, fkIds, fromTypeName, fromReference);
-        if (Arrays.equals(fkIds, pkIds)) {
+        if (Arrays.equals(fkIds, pkIds) && fromTypeName.equals(fromReference.getReferencedType().getName())) {
             return true;
         }
         return false;


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14432
**What is the current behavior?** (You should also link to an open issue here)
If user want to delete a record that referenced by other entity, after do it, dialog will be pop up that take the source stack info, like `org.hibernate.exception.ConstraintViolationException`. 

**What is the new behavior?**
After modification, dialog still pop up that take the expected prompt info, `You cannot delete this record because there are other records pointing to it, and referential integrity is enforced. Do you want to list the records that prevented this delete?` 

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
