### PR TITLE
TMDM-14192 AUTO_INCREMENT value for NOT Primary Key reset to 0 after MDM restart

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
@@ -50,26 +50,28 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING) @SuppressWarnings("nls") public class LoadServletForAutoIncrementTest {
+@FixMethodOrder(MethodSorters.NAME_ASCENDING) @SuppressWarnings("nls")
+public class LoadServletForAutoIncrementTest {
 
     private static final Logger LOG = Logger.getLogger(LoadServletForAutoIncrementTest.class);
 
-    private static boolean beanDelegatorContainerFlag = false;
+    private static boolean BEAN_DELEGATOR_CONTAINER_FLAG = false;
 
-    private static LoadServlet loadServlet;
+    private static LoadServlet LOAD_SERVLET;
 
     private static class MockISecurityCheck extends BaseSecurityCheck {
 
     }
 
     private static void createBeanDelegatorContainer() {
-        if (!beanDelegatorContainerFlag) {
+        if (!BEAN_DELEGATOR_CONTAINER_FLAG) {
             BeanDelegatorContainer.createInstance();
-            beanDelegatorContainerFlag = true;
+            BEAN_DELEGATOR_CONTAINER_FLAG = true;
         }
     }
 
-    @BeforeClass public static void setUp() {
+    @BeforeClass
+    public static void setUp() {
         LOG.info("Setting up MDM server environment...");
         ServerContext.INSTANCE.get(new MockServerLifecycle());
         MDMConfiguration.getConfiguration().setProperty("xmlserver.class", "com.amalto.core.storage.DispatchWrapper");
@@ -81,10 +83,11 @@ import static org.junit.Assert.fail;
         createBeanDelegatorContainer();
         BeanDelegatorContainer.getInstance().setDelegatorInstancePool(delegatorInstancePool);
 
-        loadServlet = new LoadServlet();
+        LOAD_SERVLET = new LoadServlet();
     }
 
-    @Test public void test_01_BulkLoadNotGeneratePK() throws Exception {
+    @Test
+    public void test_01_BulkLoadNotGeneratePK() throws Exception {
         String dataClusterName = "AutoInc";
         String typeName = "Person";
         String dataModelName = "AutoInc";
@@ -103,29 +106,30 @@ import static org.junit.Assert.fail;
         InputStream recordXml = new ByteArrayInputStream(
                 ("<Person><Name>T-Shirt</Name></Person>").getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
         try {
             bulkLoadSaveMethod
-                    .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                    .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
             fail("Failed to save the autoincrement field.");
         } catch (Exception e) {
             assertNotNull(e);
         }
     }
 
-    @Test public void test_02_BulkLoadGenerateAutoField() throws Exception {
+    @Test
+    public void test_02_BulkLoadGenerateAutoField() throws Exception {
         String dataClusterName = "AutoInc";
         String typeName = "Person";
         String dataModelName = "AutoInc";
@@ -143,23 +147,23 @@ import static org.junit.Assert.fail;
         InputStream recordXml = new ByteArrayInputStream(
                 ("<Person><Name>T-Shirt</Name></Person>").getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
         bulkLoadSaveMethod
-                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".1");
         Document xmlDocument = DocumentHelper.parseText(result);
         assertEquals(7, xmlDocument.getRootElement().element("p").element("Person").elements().size());
@@ -181,7 +185,8 @@ import static org.junit.Assert.fail;
         assertKeyValue("AutoInc.Person.CC", "1", xml);
     }
 
-    @Test public void test_03_BulkLoadDefaultLoad() throws Exception {
+    @Test
+    public void test_03_BulkLoadDefaultLoad() throws Exception {
         String dataClusterName = "Product";
         String typeName = "Product";
         String dataModelName = "Product";
@@ -201,23 +206,23 @@ import static org.junit.Assert.fail;
                 ("<Product><Id>1</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price><Support>1</Support></Product>")
                         .getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
-        bulkLoadSaveMethod.invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+        bulkLoadSaveMethod.invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".1");
         Document xmlDocument = DocumentHelper.parseText(result);
         assertEquals(8, xmlDocument.getRootElement().element("p").element("Product").elements().size());
@@ -236,7 +241,8 @@ import static org.junit.Assert.fail;
         assertNotKeyValue("Product.Product.Support", xml);
     }
 
-    @Test public void test_04_BulkLoadDefaultLoadGenerate() throws Exception {
+    @Test
+    public void test_04_BulkLoadDefaultLoadGenerate() throws Exception {
         String dataClusterName = "Product";
         String typeName = "Product";
         String dataModelName = "Product";
@@ -256,24 +262,24 @@ import static org.junit.Assert.fail;
                 ("<Product><Id>2</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price></Product>")
                         .getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
         bulkLoadSaveMethod
-                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".2");
         Document xmlDocument = DocumentHelper.parseText(result);
         assertEquals(8, xmlDocument.getRootElement().element("p").element("Product").elements().size());
@@ -292,7 +298,8 @@ import static org.junit.Assert.fail;
         assertKeyValue("Product.Product.Support", "1", xml);
     }
 
-    @Test public void test_05_BulkLoadForComplexTypeGenerate() throws Exception {
+    @Test
+    public void test_05_BulkLoadForComplexTypeGenerate() throws Exception {
         String dataClusterName = "Student";
         String typeName = "Student";
         String dataModelName = "Student";
@@ -312,24 +319,24 @@ import static org.junit.Assert.fail;
                 ("<Student><Id>2</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
                         .getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
         bulkLoadSaveMethod
-                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".2");
         Document xmlDocument = DocumentHelper.parseText(result);
         Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
@@ -355,7 +362,8 @@ import static org.junit.Assert.fail;
         assertKeyValue("Student.Student.Course.Score", "1", xml);
     }
 
-    @Test public void test_06_BulkLoadForComplexTypeGeneratePartial() throws Exception {
+    @Test
+    public void test_06_BulkLoadForComplexTypeGeneratePartial() throws Exception {
         String dataClusterName = "Student";
         String typeName = "Student";
         String dataModelName = "Student";
@@ -375,24 +383,24 @@ import static org.junit.Assert.fail;
                 ("<Student><Id>3</Id><Name>John</Name><Age>23</Age><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher><Score>10</Score></Course></Student>")
                         .getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
         bulkLoadSaveMethod
-                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".3");
         Document xmlDocument = DocumentHelper.parseText(result);
         Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
@@ -418,7 +426,8 @@ import static org.junit.Assert.fail;
         assertKeyValue("Student.Student.Course.Score", "1", xml);
     }
 
-    @Test public void test_07_BulkLoadForComplexTypeGenerateMultipleRecords() throws Exception {
+    @Test
+    public void test_07_BulkLoadForComplexTypeGenerateMultipleRecords() throws Exception {
         String dataClusterName = "Student";
         String typeName = "Student";
         String dataModelName = "Student";
@@ -438,24 +447,25 @@ import static org.junit.Assert.fail;
                 ("<Student><Id>5</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>6</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>7</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
                         .getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod
+                .invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
         bulkLoadSaveMethod
-                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".5");
         Document xmlDocument = DocumentHelper.parseText(result);
         Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
@@ -515,7 +525,8 @@ import static org.junit.Assert.fail;
         assertKeyValue("Student.Student.Course.Score", "4", xml);
     }
 
-    @Test public void test_08_BulkLoadForMultipleLayer() throws Exception {
+    @Test
+    public void test_08_BulkLoadForMultipleLayer() throws Exception {
         String dataClusterName = "Person";
         String typeName = "Person";
         String dataModelName = "Person";
@@ -535,24 +546,25 @@ import static org.junit.Assert.fail;
                 ("<Person><Id>1</Id><Name>John</Name><Habit><Content>Study</Content><Detail><Name>Play game</Name><Description>I want to play basketball</Description></Detail></Habit></Person>")
                         .getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod
+                .invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
         bulkLoadSaveMethod
-                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".1");
         Document xmlDocument = DocumentHelper.parseText(result);
         Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
@@ -579,7 +591,8 @@ import static org.junit.Assert.fail;
         assertKeyValue("Person.Person.Habit.Detail.Count", "1", xml);
     }
 
-    @Test public void test_09_BulkLoadForComplexTypeNoAuto() throws Exception {
+    @Test
+    public void test_09_BulkLoadForComplexTypeNoAuto() throws Exception {
         String dataClusterName = "StudentM";
         String typeName = "StudentM";
         String dataModelName = "StudentM";
@@ -599,24 +612,25 @@ import static org.junit.Assert.fail;
                 ("<StudentM><Id>8</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course><Course><Id>Chinese</Id><Teacher>John</Teacher></Course></StudentM>")
                         .getBytes(StandardCharsets.UTF_8));
 
-        Method getTypeKeyMethod = loadServlet.getClass().getDeclaredMethod("getTypeKey", Collection.class);
+        Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
 
-        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(loadServlet, type.getKeyFields());
+        XSDKey keyMetadata = (XSDKey) getTypeKeyMethod.invoke(LOAD_SERVLET, type.getKeyFields());
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod
+                .invoke(LOAD_SERVLET, type.getFields());
 
         XmlServer server = Util.getXmlServerCtrlLocal();
 
-        Method bulkLoadSaveMethod = loadServlet.getClass()
+        Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
         bulkLoadSaveMethod.setAccessible(true);
 
         bulkLoadSaveMethod
-                .invoke(loadServlet, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
+                .invoke(LOAD_SERVLET, dataClusterName, dataModelName, recordXml, loadAction, keyMetadata, autoFieldTypeMap);
         String result = server.getDocumentAsString(dataClusterName, dataClusterName + "." + typeName + ".8");
         Document xmlDocument = DocumentHelper.parseText(result);
         Element typeElement = xmlDocument.getRootElement().element("p").element(typeName);
@@ -626,19 +640,17 @@ import static org.junit.Assert.fail;
         assertEquals("23", typeElement.element("Age").getText());
         assertEquals(36, typeElement.element("Account").getText().length());
         assertEquals("1", typeElement.element("Site").getText());
-        List<Element>courseElements = typeElement.elements("Course");
+        List<Element> courseElements = typeElement.elements("Course");
         assertNotNull(courseElements);
         assertEquals(4, courseElements.get(0).elements().size());
         assertEquals("English", courseElements.get(0).element("Id").getText());
-        assertEquals("Mike", courseElements.get(0).element("Teacher").
-                getText());
+        assertEquals("Mike", courseElements.get(0).element("Teacher").getText());
         assertEquals("1", courseElements.get(0).element("Score").getText());
         assertEquals(36, courseElements.get(0).element("Like").getText().length());
 
         assertEquals(4, courseElements.get(1).elements().size());
         assertEquals("Chinese", courseElements.get(1).element("Id").getText());
-        assertEquals("John", courseElements.get(1).element("Teacher").
-                getText());
+        assertEquals("John", courseElements.get(1).element("Teacher").getText());
         assertEquals("2", courseElements.get(1).element("Score").getText());
         assertEquals(36, courseElements.get(1).element("Like").getText().length());
 
@@ -650,7 +662,8 @@ import static org.junit.Assert.fail;
         assertKeyValue("StudentM.Student.Course.Score", "1", xml);
     }
 
-    @Test public void testGetTypeAutoField() throws Exception {
+    @Test
+    public void testGetTypeAutoField() throws Exception {
         String dataClusterName = "AutoInc";
         String typeName = "Person";
         String dataModelName = "AutoInc";
@@ -659,9 +672,10 @@ import static org.junit.Assert.fail;
         MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
         ComplexTypeMetadata type = repository.getComplexType(typeName);
 
-        Method getTypeAutoFieldMethod = loadServlet.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
+        Method getTypeAutoFieldMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getAutoFieldTypeMap", Collection.class);
         getTypeAutoFieldMethod.setAccessible(true);
-        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod
+                .invoke(LOAD_SERVLET, type.getFields());
 
         assertNotNull(autoFieldTypeMap);
         assertEquals(5, autoFieldTypeMap.size());
@@ -684,7 +698,7 @@ import static org.junit.Assert.fail;
         MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
         type = repository.getComplexType(typeName);
 
-        autoFieldTypeMap =  (Map<String, String>)getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
         assertNotNull(autoFieldTypeMap);
         assertEquals(2, autoFieldTypeMap.size());
@@ -701,7 +715,7 @@ import static org.junit.Assert.fail;
         MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
         type = repository.getComplexType(typeName);
 
-        autoFieldTypeMap = (Map<String, String>)getTypeAutoFieldMethod.invoke(loadServlet, type.getFields());
+        autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod.invoke(LOAD_SERVLET, type.getFields());
 
         assertNotNull(autoFieldTypeMap);
         assertEquals(4, autoFieldTypeMap.size());

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
@@ -92,7 +92,6 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "Person";
         String dataModelName = "AutoInc";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
@@ -191,7 +190,6 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "Product";
         String dataModelName = "Product";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
@@ -247,7 +245,6 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "Product";
         String dataModelName = "Product";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
@@ -304,7 +301,6 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "Student";
         String dataModelName = "Student";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
@@ -368,7 +364,6 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "Student";
         String dataModelName = "Student";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
@@ -432,7 +427,6 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "Student";
         String dataModelName = "Student";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
@@ -531,7 +525,6 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "Person";
         String dataModelName = "Person";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
@@ -555,9 +548,7 @@ public class LoadServletForAutoIncrementTest {
         getTypeAutoFieldMethod.setAccessible(true);
         Map<String, String> autoFieldTypeMap = (Map<String, String>) getTypeAutoFieldMethod
                 .invoke(LOAD_SERVLET, type.getFields());
-
         XmlServer server = Util.getXmlServerCtrlLocal();
-
         Method bulkLoadSaveMethod = LOAD_SERVLET.getClass()
                 .getDeclaredMethod("bulkLoadSave", String.class, String.class, InputStream.class, LoadAction.class, XSDKey.class,
                         Map.class);
@@ -597,14 +588,12 @@ public class LoadServletForAutoIncrementTest {
         String typeName = "StudentM";
         String dataModelName = "StudentM";
         boolean needAutoGenPK = false;
-
         boolean insertOnly = false;
 
         MetadataRepository repository = new MetadataRepository();
         repository.load(LoadServletForAutoIncrementTest.class.getResourceAsStream("metadata07.xsd"));
         MockMetadataRepositoryAdmin.INSTANCE.register(dataClusterName, repository);
         ComplexTypeMetadata type = repository.getComplexType(typeName);
-
         LoadAction loadAction = new OptimizedLoadAction(dataClusterName, typeName, dataModelName, needAutoGenPK);
 
         DataRecord.CheckExistence.set(!insertOnly);

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
@@ -50,7 +50,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING) @SuppressWarnings("nls")
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@SuppressWarnings("nls")
 public class LoadServletForAutoIncrementTest {
 
     private static final Logger LOG = Logger.getLogger(LoadServletForAutoIncrementTest.class);

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/generator/AutoIncrementUtilTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/generator/AutoIncrementUtilTest.java
@@ -161,40 +161,38 @@ public class AutoIncrementUtilTest {
     }
 
     @Test
-    public void normalAutoIncrementField(){
+    public void testGetNormalAutoIncrementFields(){
         Set<String> normalFields = new HashSet<>();
         normalFields.add("Course/Like");
         normalFields.add("Course/Score");
         normalFields.add("Account");
         normalFields.add("Site");
 
-        Set<String> results = AutoIncrementUtil.normalAutoIncrementField("",normalFields);
+        Set<String> results = AutoIncrementUtil.getNormalAutoIncrementFields("",normalFields);
         assertEquals(2, results.size());
         assertTrue(results.contains("Account"));
         assertTrue(results.contains("Site"));
 
-        results = AutoIncrementUtil.normalAutoIncrementField(null,normalFields);
+        results = AutoIncrementUtil.getNormalAutoIncrementFields(null,normalFields);
         assertEquals(0, results.size());
 
-        results = AutoIncrementUtil.normalAutoIncrementField("Support",null);
+        results = AutoIncrementUtil.getNormalAutoIncrementFields("Support",null);
         assertEquals(0, results.size());
 
-        results = AutoIncrementUtil.normalAutoIncrementField("Course",normalFields);
+        results = AutoIncrementUtil.getNormalAutoIncrementFields("Course",normalFields);
         assertEquals(2, results.size());
         assertTrue(results.contains("Course/Like"));
         assertTrue(results.contains("Course/Score"));
 
-        results = AutoIncrementUtil.normalAutoIncrementField("Support",normalFields);
+        results = AutoIncrementUtil.getNormalAutoIncrementFields("Support",normalFields);
         assertEquals(0, results.size());
 
-        results = AutoIncrementUtil.normalAutoIncrementField("Course/Score",normalFields);
+        results = AutoIncrementUtil.getNormalAutoIncrementFields("Course/Score",normalFields);
         assertEquals(0, results.size());
 
         normalFields.add("Course/Score/Name");
-        results = AutoIncrementUtil.normalAutoIncrementField("Course/Score",normalFields);
+        results = AutoIncrementUtil.getNormalAutoIncrementFields("Course/Score",normalFields);
         assertEquals(1, results.size());
         assertTrue(results.contains("Course/Score/Name"));
     }
-
-
 }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/generator/AutoIncrementUtilTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/generator/AutoIncrementUtilTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("nls")
 public class AutoIncrementUtilTest {
@@ -157,6 +158,43 @@ public class AutoIncrementUtilTest {
         recordXml ="<Student><Id>5</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>";
         result = AutoIncrementUtil.getAutoNormalFieldsToGenerate(normalFields, recordXml);
         assertEquals("Account", result[0]);
-
     }
+
+    @Test
+    public void normalAutoIncrementField(){
+        Set<String> normalFields = new HashSet<>();
+        normalFields.add("Course/Like");
+        normalFields.add("Course/Score");
+        normalFields.add("Account");
+        normalFields.add("Site");
+
+        Set<String> results = AutoIncrementUtil.normalAutoIncrementField("",normalFields);
+        assertEquals(2, results.size());
+        assertTrue(results.contains("Account"));
+        assertTrue(results.contains("Site"));
+
+        results = AutoIncrementUtil.normalAutoIncrementField(null,normalFields);
+        assertEquals(0, results.size());
+
+        results = AutoIncrementUtil.normalAutoIncrementField("Support",null);
+        assertEquals(0, results.size());
+
+        results = AutoIncrementUtil.normalAutoIncrementField("Course",normalFields);
+        assertEquals(2, results.size());
+        assertTrue(results.contains("Course/Like"));
+        assertTrue(results.contains("Course/Score"));
+
+        results = AutoIncrementUtil.normalAutoIncrementField("Support",normalFields);
+        assertEquals(0, results.size());
+
+        results = AutoIncrementUtil.normalAutoIncrementField("Course/Score",normalFields);
+        assertEquals(0, results.size());
+
+        normalFields.add("Course/Score/Name");
+        results = AutoIncrementUtil.normalAutoIncrementField("Course/Score",normalFields);
+        assertEquals(1, results.size());
+        assertTrue(results.contains("Course/Score/Name"));
+    }
+
+
 }

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata07.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/load/metadata07.xsd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:element name="StudentM">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Age" type="xsd:string"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Account" type="UUID"/>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Site" type="AUTO_INCREMENT"/>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" name="Course" type="Course"/>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="Student">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="UUID">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="AUTO_INCREMENT">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+    <xsd:complexType name="Course">
+        <xsd:all>
+            <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string"/>
+            <xsd:element maxOccurs="1" minOccurs="0" name="Teacher" type="xsd:string"/>
+            <xsd:element maxOccurs="1" minOccurs="0" name="Score" type="AUTO_INCREMENT"/>
+            <xsd:element maxOccurs="1" minOccurs="0" name="Like" type="UUID"/>
+        </xsd:all>
+    </xsd:complexType>
+</xsd:schema>

--- a/org.talend.mdm.core/src/com/amalto/core/load/context/AutoGenStateContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/context/AutoGenStateContext.java
@@ -24,6 +24,7 @@ import com.amalto.core.server.api.XmlServer;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.util.Map;
+import java.util.Stack;
 
 /**
  * Load parser context implementation that has 2 main features:
@@ -176,4 +177,7 @@ public class AutoGenStateContext implements StateContext {
         return normalFieldGenerators;
     }
 
+    public Stack<String> getCurrentLocation() {
+        return delegate.getCurrentLocation();
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/load/context/DefaultStateContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/context/DefaultStateContext.java
@@ -176,7 +176,7 @@ public class DefaultStateContext implements StateContext {
             if (!normalFieldGenerators.isEmpty()) {
                 String currentPath = AutoIncrementUtil.getCurrentPath(currentLocation);
                 // If current path is the one complex type or the entity, when leaving, generate the normal field's value
-                if (!AutoIncrementUtil.normalAutoIncrementField(currentPath, normalFieldGenerators.keySet()).isEmpty()) {
+                if (!AutoIncrementUtil.getNormalAutoIncrementFields(currentPath, normalFieldGenerators.keySet()).isEmpty()) {
                     AutoFieldGeneration normalFieldGenerators = new AutoFieldGeneration();
                     try {
                         normalFieldGenerators.parse(this, null);

--- a/org.talend.mdm.core/src/com/amalto/core/load/context/DefaultStateContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/context/DefaultStateContext.java
@@ -175,6 +175,7 @@ public class DefaultStateContext implements StateContext {
         if (!currentLocation.isEmpty()) {
             if (!normalFieldGenerators.isEmpty()) {
                 String currentPath = AutoIncrementUtil.getCurrentPath(currentLocation);
+                // If current path is the one complex type or the entity, when leaving, generate the normal field's value
                 if (!AutoIncrementUtil.normalAutoIncrementField(currentPath, normalFieldGenerators.keySet()).isEmpty()) {
                     AutoFieldGeneration normalFieldGenerators = new AutoFieldGeneration();
                     try {
@@ -189,8 +190,6 @@ public class DefaultStateContext implements StateContext {
         isIdElement = false;
         currentIdElementName = null;
     }
-
-
 
     public void enterElement(String elementLocalName) {
         currentLocation.push(elementLocalName);

--- a/org.talend.mdm.core/src/com/amalto/core/load/context/StateContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/context/StateContext.java
@@ -17,6 +17,7 @@ import com.amalto.core.server.api.XmlServer;
 
 import javax.xml.stream.XMLStreamReader;
 import java.util.Map;
+import java.util.Stack;
 
 public interface StateContext {
 
@@ -63,4 +64,6 @@ public interface StateContext {
     void close(XmlServer server);
 
     Map<String, AutoIdGenerator> getNormalFieldGenerators();
+
+    Stack<String> getCurrentLocation();
 }

--- a/org.talend.mdm.core/src/com/amalto/core/load/payload/FlushXMLReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/payload/FlushXMLReader.java
@@ -13,6 +13,7 @@ package com.amalto.core.load.payload;
 import com.amalto.core.load.Constants;
 import com.amalto.core.load.Metadata;
 import com.amalto.core.load.State;
+import com.amalto.core.load.context.AutoGenStateContext;
 import com.amalto.core.load.context.StateContext;
 import com.amalto.core.load.context.StateContextSAXWriter;
 import com.amalto.core.load.xml.AutoFieldGeneration;
@@ -120,13 +121,6 @@ public class FlushXMLReader implements XMLReader {
                 context.parse(reader);
             }
 
-            Map<String, AutoIdGenerator> normalFieldGenerators = context.getNormalFieldGenerators();
-            if (!normalFieldGenerators.isEmpty()) {
-                State state = context.getCurrent();
-                AutoFieldGeneration generation = new AutoFieldGeneration(state, normalFieldGenerators);
-                context.setCurrent(generation);
-                context.parse(reader);
-            }
             if (context.getDepth() == 1) {
                 context.parse(reader);
             }

--- a/org.talend.mdm.core/src/com/amalto/core/load/payload/FlushXMLReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/payload/FlushXMLReader.java
@@ -12,12 +12,8 @@ package com.amalto.core.load.payload;
 
 import com.amalto.core.load.Constants;
 import com.amalto.core.load.Metadata;
-import com.amalto.core.load.State;
-import com.amalto.core.load.context.AutoGenStateContext;
 import com.amalto.core.load.context.StateContext;
 import com.amalto.core.load.context.StateContextSAXWriter;
-import com.amalto.core.load.xml.AutoFieldGeneration;
-import com.amalto.core.save.generator.AutoIdGenerator;
 import org.apache.commons.lang.StringUtils;
 import org.xml.sax.*;
 

--- a/org.talend.mdm.core/src/com/amalto/core/load/xml/AutoFieldGeneration.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/xml/AutoFieldGeneration.java
@@ -13,61 +13,33 @@ package com.amalto.core.load.xml;
 
 import com.amalto.core.load.State;
 import com.amalto.core.load.context.StateContext;
-import com.amalto.core.load.context.Utils;
-import com.amalto.core.save.generator.AutoIdGenerator;
+import com.amalto.core.save.generator.AutoIncrementUtil;
+import org.apache.commons.lang.StringUtils;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-import java.util.Map;
-import java.util.StringTokenizer;
+import java.util.Set;
 
 @SuppressWarnings("nls")
 public class AutoFieldGeneration implements State {
-    private final State previousState;
-
-    private final Map<String, AutoIdGenerator> normalFieldGenerators;
-
-    public AutoFieldGeneration(State previousState, Map<String, AutoIdGenerator> normalFieldGenerators) {
-        this.previousState = previousState;
-        this.normalFieldGenerators = normalFieldGenerators;
-    }
 
     @Override public void parse(StateContext context, XMLStreamReader reader) throws XMLStreamException {
         try {
-            for (Map.Entry<String, AutoIdGenerator> entry : normalFieldGenerators.entrySet()) {
-                String fieldPath = entry.getKey();
-                if (fieldPath.contains("/")) {
-                    StringTokenizer tokenizer = new StringTokenizer(fieldPath, "/");
-                    while (tokenizer.hasMoreTokens()) {
-                        String pathElement = tokenizer.nextToken();
-                        context.getWriter().writeStartElement(pathElement);
-                    }
-                } else {
-                    context.getWriter().writeStartElement(fieldPath);
-                }
-
-                context.getWriter().writeCharacters(entry.getValue()
+            String currentContainerPath = AutoIncrementUtil.getCurrentPath(context.getCurrentLocation());
+            Set<String> autoFields = AutoIncrementUtil.normalAutoIncrementField(currentContainerPath, context.getNormalFieldGenerators().keySet());
+            for (String path : autoFields) {
+                String normalFieldPath = StringUtils.substringAfter(path, currentContainerPath);
+                normalFieldPath = normalFieldPath.startsWith("/") ? normalFieldPath.substring(1): normalFieldPath;
+                context.getWriter().writeStartElement(normalFieldPath);
+                context.getWriter().writeCharacters(context.getNormalFieldGenerators().get(path)
                         .generateId(context.getMetadata().getDataClusterName(), context.getMetadata().getName(),
-                                fieldPath.replaceAll("/", ".")));
-
-                if (fieldPath.contains("/")) {
-                    String[] idPathArray = fieldPath.split("/");
-                    for (int j = idPathArray.length - 1; j >= 0; j--) {
-                        context.getWriter().writeEndElement(idPathArray[j]);
-                    }
-                } else {
-                    context.getWriter().writeEndElement(fieldPath);
-                }
+                                path.replaceAll("/", ".")));
+                context.getWriter().writeEndElement(normalFieldPath);
             }
         } catch (Exception e) {
             throw new RuntimeException("Unable to generate automatic field", e);
         }
 
-        context.setCurrent(previousState);
-
-        if (!context.isFlushDone()) {
-            Utils.doParserCallback(context, reader, context.getMetadata());
-        }
     }
 
     public boolean isFinal() {

--- a/org.talend.mdm.core/src/com/amalto/core/load/xml/AutoFieldGeneration.java
+++ b/org.talend.mdm.core/src/com/amalto/core/load/xml/AutoFieldGeneration.java
@@ -26,7 +26,7 @@ public class AutoFieldGeneration implements State {
     @Override public void parse(StateContext context, XMLStreamReader reader) throws XMLStreamException {
         try {
             String currentContainerPath = AutoIncrementUtil.getCurrentPath(context.getCurrentLocation());
-            Set<String> autoFields = AutoIncrementUtil.normalAutoIncrementField(currentContainerPath, context.getNormalFieldGenerators().keySet());
+            Set<String> autoFields = AutoIncrementUtil.getNormalAutoIncrementFields(currentContainerPath, context.getNormalFieldGenerators().keySet());
             for (String path : autoFields) {
                 String normalFieldPath = StringUtils.substringAfter(path, currentContainerPath);
                 normalFieldPath = normalFieldPath.startsWith("/") ? normalFieldPath.substring(1): normalFieldPath;

--- a/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
@@ -24,8 +24,10 @@ import com.amalto.core.storage.Storage;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
 
 @SuppressWarnings("nls")
 public class AutoIncrementUtil {
@@ -124,5 +126,44 @@ public class AutoIncrementUtil {
         }
 
         return generatedField.toArray(new String[generatedField.size()]);
+    }
+
+    /**
+     * return the normal auto/uuid field in this container
+     * if {code}currentContainerPath{code} is empty, return the auto/uuid fields in this entity
+     * @param currentContainerPath the container's path
+     * @param allNormalFields all normal auto/uuid fields
+     * @return the normal auto/uuid fields in this container
+     */
+    public static Set<String> normalAutoIncrementField(String currentContainerPath, Set<String> allNormalFields) {
+        Set<String> normalFields = new HashSet<>();
+        if (currentContainerPath == null || allNormalFields == null) {
+            return normalFields;
+        }
+        if (StringUtils.isEmpty(currentContainerPath)) {
+            for (String path : allNormalFields) {
+                if (StringUtils.countMatches(StringUtils.substringAfter(path, currentContainerPath), "/") == 0) {
+                    normalFields.add(path);
+                }
+            }
+            return normalFields;
+        }
+        for (String path : allNormalFields) {
+            if (StringUtils.countMatches(StringUtils.substringAfter(path, currentContainerPath), "/") == 1) {
+                normalFields.add(path);
+            }
+        }
+        return normalFields;
+    }
+
+    public static String getCurrentPath(Stack<String> currentLocation) {
+        StringBuilder currentPathStr = new StringBuilder();
+        for (int i = 1; i < currentLocation.size(); i++) {
+            if (i > 1) {
+                currentPathStr.append("/");
+            }
+            currentPathStr.append(currentLocation.get(i));
+        }
+        return currentPathStr.toString();
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
@@ -130,7 +130,7 @@ public class AutoIncrementUtil {
 
     /**
      * return the normal auto/uuid field in this container
-     * if {code}currentContainerPath{code} is empty, return the auto/uuid fields in this entity
+     * if <code>currentContainerPath</code> is empty, return the auto/uuid fields in this entity
      * @param currentContainerPath the container's path
      * @param allNormalFields all normal auto/uuid fields
      * @return the normal auto/uuid fields in this container

--- a/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
@@ -129,13 +129,13 @@ public class AutoIncrementUtil {
     }
 
     /**
-     * return the normal auto/uuid field in this container
-     * if <code>currentContainerPath</code> is empty, return the auto/uuid fields in this entity
+     * Return the normal auto/uuid field in this container
+     * If <code>currentContainerPath</code> is empty, return the auto/uuid fields in this entity
      * @param currentContainerPath the container's path
      * @param allNormalFields all normal auto/uuid fields
      * @return the normal auto/uuid fields in this container
      */
-    public static Set<String> normalAutoIncrementField(String currentContainerPath, Set<String> allNormalFields) {
+    public static Set<String> getNormalAutoIncrementFields(String currentContainerPath, Set<String> allNormalFields) {
         Set<String> normalFields = new HashSet<>();
         if (currentContainerPath == null || allNormalFields == null) {
             return normalFields;

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/XmlSAXDataRecordReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/XmlSAXDataRecordReader.java
@@ -10,6 +10,7 @@
 
 package com.amalto.core.storage.record;
 
+import java.util.List;
 import java.util.Stack;
 
 import javax.xml.XMLConstants;
@@ -172,13 +173,7 @@ public class XmlSAXDataRecordReader implements DataRecordReader<XmlSAXDataRecord
                                 }
                             }
                         }
-                        DataRecord containedRecord = null;
-                        if (actualType.getContainer() != null) {
-                            containedRecord = (DataRecord) dataRecordStack.peek().get(actualType.getContainer());
-                        }
-                        if (containedRecord == null || actualType.getContainer() == null) {
-                            containedRecord = new DataRecord(actualType, UnsupportedDataRecordMetadata.INSTANCE);
-                        }
+                        DataRecord containedRecord = new DataRecord(actualType, UnsupportedDataRecordMetadata.INSTANCE);;
                         dataRecordStack.peek().set(field, containedRecord);
                         dataRecordStack.push(containedRecord);
                         currentType.push(actualType);

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/XmlSAXDataRecordReader.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/XmlSAXDataRecordReader.java
@@ -173,7 +173,7 @@ public class XmlSAXDataRecordReader implements DataRecordReader<XmlSAXDataRecord
                                 }
                             }
                         }
-                        DataRecord containedRecord = new DataRecord(actualType, UnsupportedDataRecordMetadata.INSTANCE);;
+                        DataRecord containedRecord = new DataRecord(actualType, UnsupportedDataRecordMetadata.INSTANCE);
                         dataRecordStack.peek().set(field, containedRecord);
                         dataRecordStack.push(containedRecord);
                         currentType.push(actualType);


### PR DESCRIPTION
JIRA: https://jira.talendforge.org/browse/TMDM-14192

**What is the current behavior?** (You should also link to an open issue here)
Failed to save the record if contains 0-many complex type


**What is the new behavior?**
- Change the logic generate the normal auto/uuid field value at last to parse the complex type when leaving this complex type.
- Change to get the DataRecord object from stack to new initiation the new DataRecord object.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
