### PR TITLE
TMDM-14506 Set system.cluster=true in mdm.conf the create type of journal tasks don't have Next Report, just have the Previous report

### DIFF
--- a/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/server/service/JournalDBService.java
+++ b/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/server/service/JournalDBService.java
@@ -18,7 +18,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -435,7 +434,6 @@ public class JournalDBService {
             isClusterEnabled = MDMConfiguration.isClusterEnabled();
         } catch (Exception e) {
             LOG.error("Failed to fetch the current server running mode.", e);
-            isClusterEnabled = false;
         }
         return isClusterEnabled;
     }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14506
**What is the current behavior?** (You should also link to an open issue here)
Enable Cluster model, search all of UpdateReport data with default UUID sorting, it's inconsistent with standalone model, so we need to keep the same sorting model with it.

**What is the new behavior?**
Modify sort condition, keep it have the same behavior among Cluster and standalone.
like select * from UpdateReport order by x_time_in_millis asc.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
