### PR TITLE
(7.2) TMDM-14507 SOAP/REST API work unexpected when provide value for non-PK autoincrement fields

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/load/LoadServletForAutoIncrementTest.java
@@ -145,7 +145,7 @@ public class LoadServletForAutoIncrementTest {
 
         DataRecord.CheckExistence.set(!insertOnly);
         InputStream recordXml = new ByteArrayInputStream(
-                ("<Person><Name>T-Shirt</Name></Person>").getBytes(StandardCharsets.UTF_8));
+                ("<Person><Name>T-Shirt</Name><AA/><BB/><CC/><DD/><EE/></Person>").getBytes(StandardCharsets.UTF_8));
 
         Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
         getTypeKeyMethod.setAccessible(true);
@@ -202,7 +202,7 @@ public class LoadServletForAutoIncrementTest {
 
         DataRecord.CheckExistence.set(!insertOnly);
         InputStream recordXml = new ByteArrayInputStream(
-                ("<Product><Id>1</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price><Support>1</Support></Product>")
+                ("<Product><Id>1</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price><Support>1</Support><Supply/></Product>")
                         .getBytes(StandardCharsets.UTF_8));
 
         Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
@@ -257,7 +257,7 @@ public class LoadServletForAutoIncrementTest {
 
         DataRecord.CheckExistence.set(!insertOnly);
         InputStream recordXml = new ByteArrayInputStream(
-                ("<Product><Id>2</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price></Product>")
+                ("<Product><Id>2</Id><Name>T-Shirt</Name><Description>Talend T-Shirt</Description><Price>12.3</Price><Supply/></Product>")
                         .getBytes(StandardCharsets.UTF_8));
 
         Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
@@ -313,7 +313,7 @@ public class LoadServletForAutoIncrementTest {
 
         DataRecord.CheckExistence.set(!insertOnly);
         InputStream recordXml = new ByteArrayInputStream(
-                ("<Student><Id>2</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
+                ("<Student><Id>2</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher><Score/><Like/></Course></Student>")
                         .getBytes(StandardCharsets.UTF_8));
 
         Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
@@ -376,7 +376,7 @@ public class LoadServletForAutoIncrementTest {
 
         DataRecord.CheckExistence.set(!insertOnly);
         InputStream recordXml = new ByteArrayInputStream(
-                ("<Student><Id>3</Id><Name>John</Name><Age>23</Age><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher><Score>10</Score></Course></Student>")
+                ("<Student><Id>3</Id><Name>John</Name><Age>23</Age><Account/><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher><Score>10</Score></Course></Student>")
                         .getBytes(StandardCharsets.UTF_8));
 
         Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
@@ -439,7 +439,7 @@ public class LoadServletForAutoIncrementTest {
 
         DataRecord.CheckExistence.set(!insertOnly);
         InputStream recordXml = new ByteArrayInputStream(
-                ("<Student><Id>5</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>6</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>7</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
+                ("<Student><Id>5</Id><Name>John</Name><Age>23</Age><Account/><Course><Id>English</Id><Teacher>Mike</Teacher><Like/></Course></Student><Student><Id>6</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher><Score/></Course></Student><Student><Id>7</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>")
                         .getBytes(StandardCharsets.UTF_8));
 
         Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);
@@ -599,7 +599,7 @@ public class LoadServletForAutoIncrementTest {
 
         DataRecord.CheckExistence.set(!insertOnly);
         InputStream recordXml = new ByteArrayInputStream(
-                ("<StudentM><Id>8</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course><Course><Id>Chinese</Id><Teacher>John</Teacher></Course></StudentM>")
+                ("<StudentM><Id>8</Id><Name>John</Name><Age>23</Age><Site/><Course><Id>English</Id><Teacher>Mike</Teacher><Score/></Course><Course><Id>Chinese</Id><Teacher>John</Teacher><Score/><Like/></Course></StudentM>")
                         .getBytes(StandardCharsets.UTF_8));
 
         Method getTypeKeyMethod = LOAD_SERVLET.getClass().getDeclaredMethod("getTypeKey", Collection.class);

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -659,6 +659,204 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("1", evaluate(committedElement, "/Person/complex/autoIncrement2"));
     }
 
+    /**
+     * TMDM-14507: SOAP/REST API work unexpected when provide value for non-PK autoincrement fields
+     */
+    public void testNormalFieldAutoIncrementValueProvided() throws Exception {
+        final MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("metadata24.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("PersonAddress", repository);
+
+        TestSaverSource source = new TestSaverSource(repository, false, "", "metadata24.xsd");
+
+        SaverSession session = SaverSession.newSession(source);
+        // 1. Entity Person: normal field N_Index is AutoIncrement, Create
+        // Provided value for AutoIncrement normal field
+        InputStream recordXml = DocumentSaveTest.class.getResourceAsStream("test79_1.xml");
+        DocumentSaverContext context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml,
+                true, true, true, true, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        assertEquals("n_index", evaluate(committedElement, "/Person/N_Index"));
+
+        // Not provided value for AutoIncrement normal field
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test79.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+
+        // 2. Entity Person: normal field N_Index is AutoIncrement, Update
+        // Provided value for AutoIncrement normal field
+        source = new TestSaverSource(repository, false, "test81_original.xml", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test79_1.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("n_index", evaluate(committedElement, "/Person/N_Index"));
+
+        // Not provided value for AutoIncrement normal field
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test79.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+
+        // 3. Entity Address, PK Id and normal field Port is AutoIncrement, Create
+        // Provided value for AutoIncrement normal field
+        source = new TestSaverSource(repository, false, "", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test80_1.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Address/Id"));
+        assertEquals("port", evaluate(committedElement, "/Address/Port"));
+
+        // Not provided value for AutoIncrement normal field
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test80.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        committedElement = committer.getCommittedElement();
+        assertEquals("2", evaluate(committedElement, "/Address/Id"));
+        assertEquals("1", evaluate(committedElement, "/Address/Port"));
+
+        // 4. Entity Address, PK Id and normal field Port is AutoIncrement, Update
+        // Provided value for AutoIncrement normal field
+        source = new TestSaverSource(repository, false, "test82_original.xml", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test80_1.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Address/Id"));
+        assertEquals("port", evaluate(committedElement, "/Address/Port"));
+
+        // Not provided value for AutoIncrement normal field
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test80.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        committedElement = committer.getCommittedElement();
+        assertEquals("2", evaluate(committedElement, "/Address/Id"));
+        assertEquals("1", evaluate(committedElement, "/Address/Port"));
+
+        // 5, Entity Person, normal field N_Index and autoIncrement2 in complex type, Create
+        // Provided value for AutoIncrement normal field
+        source = new TestSaverSource(repository, false, "", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test83_1.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+        assertEquals("autoIncrement2", evaluate(committedElement, "/Person/complex/autoIncrement2"));
+
+        // Not provided value for AutoIncrement normal field
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test83.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        committedElement = committer.getCommittedElement();
+        assertEquals("2", evaluate(committedElement, "/Person/N_Index"));
+        assertEquals("1", evaluate(committedElement, "/Person/complex/autoIncrement2"));
+
+        // 6, Entity Person, normal field N_Index and autoIncrement2 in complex type, Update
+        // Provided value for AutoIncrement normal field
+        source = new TestSaverSource(repository, false, "test83_original.xml", "metadata24.xsd");
+        session = SaverSession.newSession(source);
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test83_1.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        assertFalse(source.hasSavedAutoIncrement());
+        committer = new MockCommitter();
+        session.end(committer);
+
+        assertTrue(source.hasSavedAutoIncrement());
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("1", evaluate(committedElement, "/Person/N_Index"));
+        assertEquals("autoIncrement2", evaluate(committedElement, "/Person/complex/autoIncrement2"));
+
+        // Not provided value for AutoIncrement normal field
+        recordXml = DocumentSaveTest.class.getResourceAsStream("test83.xml");
+        context = session.getContextFactory().create("MDM", "PersonAddress", "Source", recordXml, true, true, true,
+                true, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+
+        committedElement = committer.getCommittedElement();
+        assertEquals("2", evaluate(committedElement, "/Person/N_Index"));
+        assertEquals("1", evaluate(committedElement, "/Person/complex/autoIncrement2"));
+    }
+
     public void testUpdateWithUUID() throws Exception {
         final MetadataRepository repository = new MetadataRepository();
         repository.load(DocumentSaveTest.class.getResourceAsStream("personWithAddressOfUUID.xsd"));

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/generator/AutoIncrementUtilTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/generator/AutoIncrementUtilTest.java
@@ -130,23 +130,23 @@ public class AutoIncrementUtilTest {
         normalFields.add("Course/Score");
         normalFields.add("Course/Like");
 
-        String recordXml = "<Student><Id>3</Id><Name>John</Name><Age>23</Age><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher><Score>10</Score></Course></Student>";
+        String recordXml = "<Student><Id>3</Id><Name>John</Name><Age>23</Age><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher><Like/><Score>10</Score></Course></Student>";
 
         String[] result = AutoIncrementUtil.getAutoNormalFieldsToGenerate(normalFields, recordXml);
         assertEquals("Account", result[0]);
         assertEquals("Course/Like", result[1]);
 
-        recordXml ="<Student><Id>3</Id><Name>John</Name><Age>23</Age><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>";
+        recordXml ="<Student><Id>3</Id><Account/><Name>John</Name><Age>23</Age><Site>20</Site><Course><Id>English</Id><Teacher>Mike</Teacher><Score/></Course></Student>";
         result = AutoIncrementUtil.getAutoNormalFieldsToGenerate(normalFields, recordXml);
         assertEquals("Account", result[0]);
         assertEquals("Course/Like", result[1]);
         assertEquals("Course/Score", result[2]);
 
-        recordXml ="<Student><Id>3</Id><Name>John</Name><Age>23</Age><Site>20</Site></Student>";
+        recordXml ="<Student><Id>3</Id><Account/><Name>John</Name><Age>23</Age><Site>20</Site></Student>";
         result = AutoIncrementUtil.getAutoNormalFieldsToGenerate(normalFields, recordXml);
         assertEquals("Account", result[0]);
 
-        recordXml ="<Student><Id>5</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>6</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>7</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>";
+        recordXml ="<Student><Id>5</Id><Account/><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>6</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student><Student><Id>7</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>";
         result = AutoIncrementUtil.getAutoNormalFieldsToGenerate(normalFields, recordXml);
         assertEquals("Site", result[0]);
         assertEquals("Account", result[1]);
@@ -155,7 +155,7 @@ public class AutoIncrementUtilTest {
 
         normalFields.add("Account");
 
-        recordXml ="<Student><Id>5</Id><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>";
+        recordXml ="<Student><Id>5</Id><Account/><Name>John</Name><Age>23</Age><Course><Id>English</Id><Teacher>Mike</Teacher></Course></Student>";
         result = AutoIncrementUtil.getAutoNormalFieldsToGenerate(normalFields, recordXml);
         assertEquals("Account", result[0]);
     }

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test79_1.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test79_1.xml
@@ -1,0 +1,5 @@
+<Person xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Id>1</Id>
+    <Name>John</Name>
+    <N_Index>n_index</N_Index>
+</Person>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test80_1.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test80_1.xml
@@ -1,0 +1,5 @@
+<Address xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Name>Beijing</Name>
+    <Port>port</Port>
+</Address>
+

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test83_1.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/test83_1.xml
@@ -1,0 +1,8 @@
+<Person xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <Id>1</Id>
+    <Name>John</Name>
+    <complex>
+        <autoIncrement2>autoIncrement2</autoIncrement2>
+        <test2>11</test2>
+    </complex>
+</Person>

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/CreateActions.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/CreateActions.java
@@ -247,10 +247,15 @@ class CreateActions extends DefaultMetadataVisitor<List<Action>> {
         // TMDM-3900).
         // Note #2: This code generate values even for non-mandatory fields (but this is expected behavior).
         if (EUUIDCustomType.AUTO_INCREMENT.getName().equalsIgnoreCase(field.getType().getName()) && doCreate) {
-            String conceptName = rootTypeName + "." + field.getPath().replaceAll("/", "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-            String autoIncrementValue = saverSource.nextAutoIncrementId(dataCluster, dataModel, conceptName);
-            actions.add(new FieldUpdateAction(date, source, userName, currentPath, StringUtils.EMPTY, autoIncrementValue,
-                    field, userAction));
+            Accessor accessor = document.createAccessor(currentPath);
+            if (accessor.exist() && !StringUtils.isBlank(accessor.get())) {
+                actions.add(new FieldUpdateAction(date, source, userName, currentPath, StringUtils.EMPTY, accessor.get(), field, userAction));
+            } else {
+                String conceptName = rootTypeName + "." + field.getPath().replaceAll("/", "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                String autoIncrementValue = saverSource.nextAutoIncrementId(dataCluster, dataModel, conceptName);
+                actions.add(new FieldUpdateAction(date, source, userName, currentPath, StringUtils.EMPTY, autoIncrementValue,
+                        field, userAction));
+            }
         } else if (EUUIDCustomType.UUID.getName().equalsIgnoreCase(field.getType().getName()) && doCreate) {
             String uuidValue = UUID.randomUUID().toString();
             actions.add(new FieldUpdateAction(date, source, userName, currentPath, StringUtils.EMPTY, uuidValue, field, userAction));

--- a/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/generator/AutoIncrementUtil.java
@@ -104,25 +104,30 @@ public class AutoIncrementUtil {
             for (String fieldPath : normalFields) {
                 Element element = root;
                 // if the filed is not in one complex type
-                if (!fieldPath.contains("/") && element.element(fieldPath) == null) {
-                    generatedField.add(fieldPath);
+                if (!fieldPath.contains("/")) {
+                    element = element.element(fieldPath);
+                    if (element == null || (
+                            element != null && StringUtils.isBlank(element.getText()))) {
+                        generatedField.add(fieldPath);
+                    }
                 } else if (fieldPath.contains("/")) {
-                    // if field is in one complex type
+                    // if field is in one complex type and parent existed.
                     String[] allFieldPaths = fieldPath.split("/");
                     for (int i = 0; i < allFieldPaths.length; i++) {
-                        element = element.element(allFieldPaths[i]);
                         if (element == null) {
-                            // Address/Id, if Address doesn't exist
-                            if (i == 0) {
-                                break;
-                            }
+                            continue;
+                        }
+                        element = element.element(allFieldPaths[i]);
+                        if (element == null || 
+                                (element != null && element.isTextOnly() && 
+                                StringUtils.isBlank(element.getText()))) {
                             generatedField.add(fieldPath);
                         }
                     }
                 }
             }
         } catch (Exception e) {
-            LOG.error("Failed to parse stream to Document");
+            LOG.error("Failed to parse stream to document.", e);
         }
 
         return generatedField.toArray(new String[generatedField.size()]);


### PR DESCRIPTION
Backport from master.

https://jira.talendforge.org/browse/TMDM-14507

**What is the current behavior?** (You should also link to an open issue here)



**What is the new behavior?**



**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
