### PR TITLE
TMDM-14546 [REST]: PUT /data/{containerName}/query : order_by on a Foreign Key (FK) : result not sorted

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -1772,13 +1772,20 @@ class StandardQueryHandler extends AbstractQueryHandler {
     }
 
     private void addCondition(FieldCondition condition, String alias, FieldMetadata fieldMetadata) {
-        if (fieldMetadata instanceof CompoundFieldMetadata) {
-            FieldMetadata[] fields = ((CompoundFieldMetadata) fieldMetadata).getFields();
-            for (FieldMetadata subFieldMetadata : fields) {
-                condition.criterionFieldNames.add(alias + '.' + subFieldMetadata.getName());
+        boolean isCompoundField = fieldMetadata instanceof CompoundFieldMetadata;
+        boolean isReferenceField = fieldMetadata instanceof ReferenceFieldMetadata;
+        boolean isContainedInMain = mainType.equals(fieldMetadata.getContainingType());
+        boolean isSelfReference = isSelfReference(fieldMetadata);
+        if (isCompoundField) {
+            addConditionForCompoundField(condition, alias, fieldMetadata);
+        } else if (isReferenceField && isContainedInMain) {
+            if (isSelfReference) {
+                addConditionForSelfReferenceField(condition, alias, ((ReferenceFieldMetadata) fieldMetadata).getReferencedField());
+            } else {
+                condition.criterionFieldNames.add(getFieldName(fieldMetadata, true));
             }
-        } else if (fieldMetadata instanceof ReferenceFieldMetadata && mainType.equals(fieldMetadata.getContainingType())) {
-            condition.criterionFieldNames.add(getFieldName(fieldMetadata, true));
+        } else if (isReferenceField && !isContainedInMain && isSelfReference) {
+            addConditionForSelfReferenceField(condition, alias, ((ReferenceFieldMetadata) fieldMetadata).getReferencedField());
         } else {
             String language = OrderBy.SortLanguage.get();
             if (StringUtils.isNotBlank(language) && Types.MULTI_LINGUAL.equals(fieldMetadata.getType().getName())) {
@@ -1787,6 +1794,28 @@ class StandardQueryHandler extends AbstractQueryHandler {
                 condition.criterionFieldNames.add(alias + '.' + fieldMetadata.getName());
             }
         }
+    }
+
+    private void addConditionForCompoundField(FieldCondition condition, String alias, FieldMetadata referencedField) {
+        FieldMetadata[] fields = ((CompoundFieldMetadata) referencedField).getFields();
+        for (FieldMetadata subFieldMetadata : fields) {
+            condition.criterionFieldNames.add(alias + '.' + subFieldMetadata.getName());
+        }
+    }
+
+    private void addConditionForSelfReferenceField(FieldCondition condition, String alias, FieldMetadata referencedField) {
+        if (referencedField instanceof CompoundFieldMetadata) {
+            addConditionForCompoundField(condition, alias, referencedField);
+        } else {
+            condition.criterionFieldNames.add(alias + '.' + referencedField.getName());
+        }
+    }
+
+    private boolean isSelfReference(FieldMetadata fieldMetadata) {
+        if (fieldMetadata instanceof ReferenceFieldMetadata) {
+            return mainType.equals(((ReferenceFieldMetadata) fieldMetadata).getReferencedType());
+        }
+        return false;
     }
 
     private void addCondition(FieldCondition condition, FieldMetadata fieldMetadata) {
@@ -1901,10 +1930,11 @@ class StandardQueryHandler extends AbstractQueryHandler {
             // condition.criterionFieldNames = field.getFieldMetadata().isMany() ? "elements" : getFieldName(field,
             // StandardQueryHandler.this.mappingMetadataRepository);
             Set<String> aliases = getAliases(mainType, field);
+            boolean isSelfReference = isSelfReference(field.getFieldMetadata());
             if (aliases.size() > 0) {
                 for (String alias : aliases) {
                     List<FieldMetadata> path = field.getPath();
-                    if (path.size() > 1) {
+                    if (path.size() > 1 && !isSelfReference) {
                         // For path with more than 1 element, the alias for the criterion is the *containing* one(s).
                         String containerAlias = getRealAlias(pathToAlias, mainType.getName() + "/" + path.get(path.size() - 2).getPath()); //$NON-NLS-1$
                         addCondition(condition, containerAlias, field.getFieldMetadata());

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -1778,14 +1778,10 @@ class StandardQueryHandler extends AbstractQueryHandler {
         boolean isSelfReference = isSelfReference(fieldMetadata);
         if (isCompoundField) {
             addConditionForCompoundField(condition, alias, fieldMetadata);
-        } else if (isReferenceField && isContainedInMain) {
-            if (isSelfReference) {
-                addConditionForSelfReferenceField(condition, alias, ((ReferenceFieldMetadata) fieldMetadata).getReferencedField());
-            } else {
-                condition.criterionFieldNames.add(getFieldName(fieldMetadata, true));
-            }
-        } else if (isReferenceField && !isContainedInMain && isSelfReference) {
+        } else if (isReferenceField && isSelfReference) {
             addConditionForSelfReferenceField(condition, alias, ((ReferenceFieldMetadata) fieldMetadata).getReferencedField());
+        } else if (isReferenceField && isContainedInMain) {
+            condition.criterionFieldNames.add(getFieldName(fieldMetadata, true));
         } else {
             String language = OrderBy.SortLanguage.get();
             if (StringUtils.isNotBlank(language) && Types.MULTI_LINGUAL.equals(fieldMetadata.getType().getName())) {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -151,11 +151,17 @@ public class StorageQueryTest extends StorageTestCase {
     private final String TT_Record2 = " <TT><Id>T2</Id><MUl><E1>2</E1><E2>2</E2><E3>[R2]</E3></MUl></TT>";
 
     private final String TT_Record3 = " <TT><Id>T3</Id><MUl><E1>3</E1><E2>3</E2><E3>[R3]</E3></MUl></TT>";
-    
-    private final String COMPTE_Record1 = "<Compte><Level>Compte SF</Level><Code>1</Code><Label>1</Label></Compte>";
 
-    private final String COMPTE_Record2 = "<Compte><Level>Nature Comptable SF</Level><Code>11</Code><Label>11</Label><childOf>[Compte SF][1]</childOf></Compte>";
-    
+    private final String COMPTE_Record1 = "<Compte><Level>1</Level><Code>1</Code><Label>1</Label></Compte>";
+
+    private final String COMPTE_Record5 = "<Compte><Level>5</Level><Code>5</Code><Label>5</Label></Compte>";
+
+    private final String COMPTE_Record2 = "<Compte><Level>2</Level><Code>2</Code><Label>2</Label><childOf>[5][5]</childOf></Compte>";
+
+    private final String COMPTE_Record3 = "<Compte><Level>3</Level><Code>3</Code><Label>2</Label><childOf>[2][2]</childOf></Compte>";
+
+    private final String COMPTE_Record4 = "<Compte><Level>4</Level><Code>4</Code><Label>2</Label><childOf>[1][1]</childOf></Compte>";
+
     private static boolean beanDelegatorContainerFlag = false;
 
     private static void createBeanDelegatorContainer() {
@@ -344,7 +350,10 @@ public class StorageQueryTest extends StorageTestCase {
         allRecords.add(factory.read(repository, tt, TT_Record2));
         allRecords.add(factory.read(repository, tt, TT_Record3));
         allRecords.add(factory.read(repository, compte, COMPTE_Record1));
+        allRecords.add(factory.read(repository, compte, COMPTE_Record5));
         allRecords.add(factory.read(repository, compte, COMPTE_Record2));
+        allRecords.add(factory.read(repository, compte, COMPTE_Record3));
+        allRecords.add(factory.read(repository, compte, COMPTE_Record4));
 
         allRecords.add(factory.read(repository, contexte, "<Contexte><IdContexte>111</IdContexte><name>aaa</name><name>bbb</name></Contexte>"));
         allRecords.add(factory.read(repository, contexte, "<Contexte><IdContexte>222</IdContexte><name>ccc</name></Contexte>"));
@@ -385,6 +394,22 @@ public class StorageQueryTest extends StorageTestCase {
                 .read(repository,
                         type,
                         "<TypeA><Id>4</Id><string>4</string><float>4.0</float><double>4.0</double><decimal>4.00</decimal><dateTime>2017-09-18T12:00:00</dateTime><time>16:00:00</time><date>2017-09-18</date><integer>4</integer><long>4</long><int>4</int><short>4</short><byte>4</byte></TypeA>"));
+
+        allRecords.add(factory.read(repository, orgActivity, "<OrgActivity><idOrgActivity>2</idOrgActivity><libelleFR>2</libelleFR><libelleEN>2</libelleEN><libelleES>2</libelleES><codeOrgActivityMaestro>2</codeOrgActivityMaestro><niveauActivity>2</niveauActivity></OrgActivity>"));
+        allRecords.add(factory.read(repository, orgActivity, "<OrgActivity><idOrgActivity>3</idOrgActivity><libelleFR>3</libelleFR><libelleEN>3</libelleEN><libelleES>3</libelleES><codeOrgActivityMaestro>3</codeOrgActivityMaestro><niveauActivity>3</niveauActivity></OrgActivity>"));
+        allRecords.add(factory.read(repository, orgActivity, "<OrgActivity><idOrgActivity>1</idOrgActivity><libelleFR>1</libelleFR><libelleEN>1</libelleEN><libelleES>1</libelleES><codeOrgActivityMaestro>1</codeOrgActivityMaestro><idOrgActivityMere>[3]</idOrgActivityMere><niveauActivity>1</niveauActivity></OrgActivity>"));
+        allRecords.add(factory.read(repository, orgActivity, "<OrgActivity><idOrgActivity>4</idOrgActivity><libelleFR>4</libelleFR><libelleEN>4</libelleEN><libelleES>4</libelleES><codeOrgActivityMaestro>4</codeOrgActivityMaestro><idOrgActivityMere>[4]</idOrgActivityMere><niveauActivity>4</niveauActivity></OrgActivity>"));
+        allRecords.add(factory.read(repository, orgActivity, "<OrgActivity><idOrgActivity>5</idOrgActivity><libelleFR>5</libelleFR><libelleEN>5</libelleEN><libelleES>5</libelleES><codeOrgActivityMaestro>5</codeOrgActivityMaestro><idOrgActivityMere>[2]</idOrgActivityMere><niveauActivity>5</niveauActivity></OrgActivity>"));
+        allRecords.add(factory.read(repository, orgPerson, "<OrgPerson><PersonId>1</PersonId><Name>1</Name><Address><zip>1</zip><Code>1</Code></Address></OrgPerson>"));
+        allRecords.add(factory.read(repository, orgPerson, "<OrgPerson><PersonId>2</PersonId><Name>2</Name><Address><zip>2</zip><Code>2</Code></Address></OrgPerson>"));
+        allRecords.add(factory.read(repository, orgPerson, "<OrgPerson><PersonId>3</PersonId><Name>3</Name><Address><zip>3</zip><FKPerson>[2]</FKPerson><Code>3</Code></Address></OrgPerson>"));
+        allRecords.add(factory.read(repository, orgPerson, "<OrgPerson><PersonId>4</PersonId><Name>4</Name><Address><zip>4</zip><FKPerson>[1]</FKPerson><Code>4</Code></Address></OrgPerson>"));
+        allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>1</ID_0><ID_1>1</ID_1><FieldX>1</FieldX><FieldA><Name>1</Name></FieldA></OrgEntity>"));
+        allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>5</ID_0><ID_1>5</ID_1><FieldX>5</FieldX><FieldA><Name>5</Name></FieldA></OrgEntity>"));
+        allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>2</ID_0><ID_1>2</ID_1><FieldX>2</FieldX><FieldA><Name>2</Name><FKEntity>[5][5]</FKEntity></FieldA></OrgEntity>"));
+        allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>3</ID_0><ID_1>3</ID_1><FieldX>3</FieldX><FieldA><Name>3</Name><FKEntity>[2][2]</FKEntity></FieldA></OrgEntity>"));
+        allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>4</ID_0><ID_1>4</ID_1><FieldX>4</FieldX><FieldA><Name>4</Name><FKEntity>[1][1]</FKEntity></FieldA></OrgEntity>"));
+
         try {
             storage.begin();
             storage.update(allRecords);
@@ -935,32 +960,37 @@ public class StorageQueryTest extends StorageTestCase {
     }
     
     public void testOrderByCompoundField() throws Exception {
-        FieldMetadata code = compte.getField("Code");
-        String[] ascExpectedValues = { "1", "11" };
-        UserQueryBuilder qb = from(compte).select(compte.getField("Code")).select(compte.getField("Label"))
-                .select(compte.getField("childOf")).orderBy(compte.getField("childOf"), OrderBy.Direction.ASC);
+        FieldMetadata codeField = compte.getField("Code");
+        FieldMetadata childOfField = compte.getField("childOf");
+        /**
+         * |   Data     |    ASC     |    DESC    |
+         * | 1,1        | 1,1        | 2,2 [5][5] |
+         * | 5,5        | 5,5        | 3,3 [2][2] |
+         * | 2,2 [5][5] | 4,4 [1][1] | 4,4 [1][1] |
+         * | 3,3 [2][2] | 3,3 [2][2] | 1,1        |
+         * | 4,4 [1][1] | 2,2 [5][5] | 5,5        |
+         */
+        String[] ascExpectedValues = { "1", "5", "4" , "3", "2" };
+        UserQueryBuilder qb = from(compte).select(codeField).select(childOfField).orderBy(childOfField, OrderBy.Direction.ASC);
         StorageResults results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getSize());
-            assertEquals(2, results.getCount());
+            assertEquals(5, results.getCount());
             int i = 0;
             for (DataRecord result : results) {
-                assertEquals(ascExpectedValues[i++], result.get(code));
+                assertEquals(ascExpectedValues[i++], result.get(codeField));
             }
         } finally {
             results.close();
         }
 
-        String[] descExpectedValues = { "11", "1" };
-        qb = from(compte).select(compte.getField("Code")).select(compte.getField("Label")).select(compte.getField("childOf"))
-                .orderBy(compte.getField("childOf"), OrderBy.Direction.DESC);
+        String[] descExpectedValues = { "2", "3", "4"};
+        qb = from(compte).select(codeField).select(childOfField).where(not(isNull(childOfField))).orderBy(childOfField, OrderBy.Direction.DESC);
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(2, results.getSize());
-            assertEquals(2, results.getCount());
+            assertEquals(3, results.getSize());
             int i = 0;
             for (DataRecord result : results) {
-                assertEquals(descExpectedValues[i++], result.get(code));
+                assertEquals(descExpectedValues[i++], result.get(codeField));
             }
         } finally {
             results.close();
@@ -1857,6 +1887,89 @@ public class StorageQueryTest extends StorageTestCase {
         StorageResults results = storage.fetch(qb.getSelect());
         try {
             assertEquals(3, results.getCount());
+        } finally {
+            results.close();
+        }
+    }
+
+    // TMDM-14546
+    public void testFKOrderBySelfReference() throws Exception {
+        /**
+         * Non-Inherit scenario
+         * |  Data | ASC   |
+         * | 1 [3] | 5 [2] |
+         * | 2     | 1 [3] |
+         * | 3     | 4 [4] |
+         * | 4 [4] |
+         * | 5 [2] |
+         */
+
+        FieldMetadata idOrgActivityField = orgActivity.getField("idOrgActivity");
+        FieldMetadata idOrgActivityMereField = orgActivity.getField("idOrgActivityMere");
+
+        UserQueryBuilder qb = from(orgActivity).selectId(orgActivity).select(idOrgActivityMereField)
+                .where(not(isNull(idOrgActivityMereField))).orderBy(idOrgActivityMereField, OrderBy.Direction.ASC);
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(3, results.getCount());
+            String[] expected = { "5", "1", "4" };
+            int i = 0;
+            for (DataRecord result : results) {
+                assertEquals(expected[i++], result.get(idOrgActivityField));
+            }
+        } finally {
+            results.close();
+        }
+
+        /**
+         * Inherit + Complex scenario
+         * |  Data | DESC  |
+         * | 1     | 3 [2] |
+         * | 2     | 4 [1] |
+         * | 3 [2] |
+         * | 4 [1] |
+         */
+
+        FieldMetadata personIdField = orgPerson.getField("PersonId");
+        FieldMetadata fkPersonField = orgPerson.getField("Address/FKPerson");
+
+        qb = from(orgPerson).selectId(orgPerson).select(fkPersonField).where(not(isNull(fkPersonField)))
+                .orderBy(fkPersonField, OrderBy.Direction.DESC);
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(2, results.getCount());
+            String[] expected = {"3", "4" };
+            int i = 0;
+            for (DataRecord result : results) {
+                assertEquals(expected[i++], result.get(personIdField));
+            }
+        } finally {
+            results.close();
+        }
+
+        /**
+         * Complex + Compound scenario
+         * |  Data      |    ASC     |
+         * | 1,1        | 4,4 [1][1] |
+         * | 2,2 [5][5] | 3,3 [2][2] |
+         * | 3,3 [2][2] | 2,2 [5][5] |
+         * | 4,4 [1][1] |
+         * | 5,5        |
+         */
+
+        FieldMetadata id0Field = orgEntity.getField("ID_0");
+        FieldMetadata fkEntityField = orgEntity.getField("FieldA/FKEntity");
+
+        qb = from(orgEntity).select(id0Field).select(fkEntityField).where(not(isNull(fkEntityField)))
+                .orderBy(fkEntityField, OrderBy.Direction.ASC);
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(3, results.getCount());
+            String[] expected = { "4", "3", "2"};
+            int i = 0;
+            for (DataRecord result : results) {
+                assertEquals(expected[i++], result.get(id0Field));
+            }
         } finally {
             results.close();
         }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
@@ -170,6 +170,12 @@ public class StorageTestCase extends TestCase {
 
     protected static final ComplexTypeMetadata refRegion;
 
+    protected static final ComplexTypeMetadata orgActivity;
+
+    protected static final ComplexTypeMetadata orgPerson;
+
+    protected static final ComplexTypeMetadata orgEntity;
+
     public static final String DATABASE = "H2";
 
     public static final String DATASOURCE_DEFAULT = DATABASE + "-Default";
@@ -249,6 +255,10 @@ public class StorageTestCase extends TestCase {
 
         refPays = repository.getComplexType("RefPays");
         refRegion = repository.getComplexType("RefRegion");
+
+        orgActivity = repository.getComplexType("OrgActivity");
+        orgPerson = repository.getComplexType("OrgPerson");
+        orgEntity = repository.getComplexType("OrgEntity");
 
         systemStorage = new SecuredStorage(new HibernateStorage("MDM", StorageType.SYSTEM), userSecurity);
         systemRepository = buildSystemRepository();

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -3049,4 +3049,160 @@
             <xsd:field xpath="RefSourceSystemId" />
         </xsd:unique>
     </xsd:element>
+    <xsd:element name="OrgActivity">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="idOrgActivity" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="libelleFR" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="libelleEN" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="libelleES" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="codeOrgActivityMaestro" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="idOrgActivityMere" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_ForeignKey">OrgActivity/idOrgActivity</xsd:appinfo>
+                        <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>
+                        <xsd:appinfo source="X_FKIntegrity">false</xsd:appinfo>
+                        <xsd:appinfo source="X_FKIntegrity_Override">false</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="niveauActivity" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="OrgActivity">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="idOrgActivity" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="OrgPerson">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element name="PersonId" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="OrgEUAddress">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="OrgPerson">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="PersonId" />
+        </xsd:unique>
+    </xsd:element>
+	<xsd:complexType name="OrgAddress">
+		<xsd:sequence>
+			<xsd:element maxOccurs="1" minOccurs="1" name="zip" type="xsd:string">
+				<xsd:annotation>
+					<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+				</xsd:annotation>
+			</xsd:element>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:complexType name="OrgEUAddress">
+		<xsd:complexContent>
+			<xsd:extension base="OrgAddress">
+				<xsd:sequence>
+					<xsd:element maxOccurs="1" minOccurs="0" name="FKPerson" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo source="X_ForeignKey">OrgPerson/PersonId</xsd:appinfo>
+							<xsd:appinfo source="X_ForeignKey_NotSep">false</xsd:appinfo>
+							<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:element>
+					<xsd:element maxOccurs="1" minOccurs="0" name="Code" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+						</xsd:annotation>
+					</xsd:element>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="OrgEntity">
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="ID_0" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="ID_1" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="FieldX" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="FieldA">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="Name" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="FKEntity" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_ForeignKey">OrgEntity</xsd:appinfo>
+                                    <xsd:appinfo source="X_ForeignKey_NotSep">false</xsd:appinfo>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="OrgEntity">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="ID_0" />
+            <xsd:field xpath="ID_1" />
+        </xsd:unique>
+    </xsd:element>
 </xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -1945,44 +1945,29 @@
 	</xsd:element>
 	<xsd:element name="Compte">
 		<xsd:annotation>
-
 			<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:all>
-				<xsd:element maxOccurs="1" minOccurs="1" name="Level">
-					<xsd:annotation>
-						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
-					</xsd:annotation>
-					<xsd:simpleType>
-						<xsd:restriction base="xsd:string">
-							<xsd:enumeration value="Compte SF" />
-							<xsd:enumeration value="Nature Comptable SF" />
-							<xsd:enumeration value="Compte Procofiev" />
-							<xsd:enumeration value="Nature Comptable SIUS" />
-							<xsd:enumeration value="Nature Comptable SIUSMCA" />
-						</xsd:restriction>
-					</xsd:simpleType>
-				</xsd:element>
-				<xsd:element maxOccurs="1" minOccurs="1" name="Code"
-					type="xsd:string">
+				<xsd:element maxOccurs="1" minOccurs="1" name="Level" type="xsd:string">
 					<xsd:annotation>
 						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
 					</xsd:annotation>
 				</xsd:element>
-				<xsd:element maxOccurs="1" minOccurs="0" name="Label"
-					type="xsd:string">
+				<xsd:element maxOccurs="1" minOccurs="1" name="Code" type="xsd:string">
 					<xsd:annotation>
-
 						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
 					</xsd:annotation>
 				</xsd:element>
-				<xsd:element maxOccurs="1" minOccurs="0" name="childOf"
-					type="xsd:string">
+				<xsd:element maxOccurs="1" minOccurs="0" name="Label" type="xsd:string">
+					<xsd:annotation>
+						<xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+					</xsd:annotation>
+				</xsd:element>
+				<xsd:element maxOccurs="1" minOccurs="0" name="childOf" type="xsd:string">
 					<xsd:annotation>
 						<xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>
 						<xsd:appinfo source="X_ForeignKey">Compte</xsd:appinfo>
-
 						<xsd:appinfo source="X_ForeignKeyInfo">Compte/Code</xsd:appinfo>
 						<xsd:appinfo source="X_ForeignKeyInfo">Compte/Label</xsd:appinfo>
 						<xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14546
**What is the current behavior?** (You should also link to an open issue here)
- Order by FK which reference to the Entity itself not working


**What is the new behavior?**
- Order by FK which reference to the Entity itself works normally
Following data models are covered so far:
```
EntityA
--ID
--FieldX
--FKEntityA -->EntityA.ID

EntityA
--ID_0
--ID_1
--FieldX
--FKEntityA -->EntityA.ID_0,ID_1

EntityA
--ID
--FieldX
--FieldA(ComplexType)
   --FKEntityA -->EntityA.ID

EntityA
--ID_0
--ID_1
--FieldX
--FieldA(ComplexType)
   --FKEntityA -->EntityA.ID_0,ID_1
```


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
