### PR TITLE
(7.3)TMDM-14458 [6.4.1] Values displayed in Journal (Before / After) are not correct

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
@@ -320,15 +320,19 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
         Accessor newAccessor = newDocument.createAccessor(path);
         if (!originalAccessor.exist()) {
             if (newAccessor.exist()) { // new accessor exist
-                if (newAccessor.get() != null && !newAccessor.get().isEmpty()) { // Empty accessor means no op to ensure legacy behavior
+                String newValue = newAccessor.get();
+                if (StringUtils.isNotEmpty(newValue)) { // Empty accessor means no op to ensure legacy behavior
                     generateNoOp(lastMatchPath);
+                    if (comparedField instanceof ReferenceFieldMetadata && !newValue.startsWith("[")) {
+                		newValue = "[" + newValue + "]";
+                    }
                     if (comparedField.isMany() && preserveCollectionOldValues) {
                         int newItemIndex = Integer.parseInt(StringUtils.substringBetween(path, "[", "]"));//$NON-NLS-1$ //$NON-NLS-2$
                         int oldItemIndex = originalDocument.createAccessor(StringUtils.substringBeforeLast(path, "[")).size();//$NON-NLS-1$
                         int insertIndex = newItemIndex + oldItemIndex;
                         path = path.replaceAll("\\[\\d+\\]", "[" + insertIndex + "]");//$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                     }
-                    actions.add(new FieldUpdateAction(date, source, userName, path, StringUtils.EMPTY, newAccessor.get(), comparedField, userAction));
+                    actions.add(new FieldUpdateAction(date, source, userName, path, StringUtils.EMPTY, newValue, comparedField, userAction));
                     generateNoOp(path);
                 } else if (EUUIDCustomType.AUTO_INCREMENT.getName().equalsIgnoreCase(comparedField.getType().getName())
                         && isCreateAction == false) {
@@ -382,6 +386,9 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
             } else { // new accessor exist
                 String newValue = newAccessor.get();
                 if (newValue != null && !(comparedField instanceof ContainedTypeFieldMetadata)) {
+                	if (comparedField instanceof ReferenceFieldMetadata && !newValue.isEmpty() && !newValue.startsWith("[")) {
+                		newValue = "[" + newValue + "]";
+                	}
                     if (comparedField.isMany() && preserveCollectionOldValues) {
                         // Inverted order the index
                         if (!invertedIndex.containsKey(comparedField)) {

--- a/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/server/ForeignKeyInfoTransformer.java
+++ b/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/server/ForeignKeyInfoTransformer.java
@@ -226,7 +226,7 @@ public class ForeignKeyInfoTransformer implements DocumentTransformer {
             String[] key = new String[allKeys.length];
             int i = 0;
             for (String currentKey : allKeys) {
-                key[i++] = currentKey.substring(1);
+                key[i++] = currentKey.startsWith("[") ? currentKey.substring(1) : currentKey;
             }
             pk.setIds(key);
 

--- a/org.talend.mdm.webapp.journal/src/test/java/org/talend/mdm/webapp/journal/server/ForeignKeyInfoTransformerTest.java
+++ b/org.talend.mdm.webapp.journal/src/test/java/org/talend/mdm/webapp/journal/server/ForeignKeyInfoTransformerTest.java
@@ -127,7 +127,7 @@ public class ForeignKeyInfoTransformerTest extends TestCase {
     }
 
     public void testCase0_FK_defined_in_anonymoustype_and_fKInfo_directly_under_root() {
-        String recordId = "d1";
+        String recordId = "d1-x";
         String conceptName = "D";
         executeTestFor(recordId, conceptName);
     }
@@ -416,6 +416,7 @@ public class ForeignKeyInfoTransformerTest extends TestCase {
 
         // case 0:
         xmlDomRecordInputs.put("d1", "<D><D_Id>d1</D_Id><D_Name>dName1</D_Name><FK_to_E>[e1]</FK_to_E></D>");
+        xmlDomRecordInputs.put("d1-x", "<D><D_Id>d1</D_Id><D_Name>dName1</D_Name><FK_to_E>e1</FK_to_E></D>");
         // case 1:
         xmlDomRecordInputs.put("a1", "<A><A_Id>a1</A_Id><A_Name>aName1</A_Name><FK_to_B>[b1]</FK_to_B></A>");
         xmlDomRecordInputs.put("a11", "<A><A_Id>a11</A_Id><A_Name>aName11</A_Name><FK_to_B>[b11]</FK_to_B></A>");


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14458
What is the current behavior? (You should also link to an open issue here)
Journal record is generated incorrectly when updating fk value without brackets by Rest API

What is the new behavior?

Journal record is generated correctly when updating fk value without brackets by Rest API
Resolve FK info correctly when FK item in journal records has no brackets

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
