### PR TITLE
TMDM-11857 Can't display Match Lineage after switch data container

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
@@ -202,11 +202,7 @@ public class LineageListPanel extends ContentPanel {
     }
 
     private LineageListPanel() {
-        this.cluster = BrowseRecords.getSession().getAppHeader().getDatacluster();
-        this.cluster = this.cluster.endsWith(StorageAdmin.STAGING_SUFFIX) ? this.cluster : this.cluster
-                + StorageAdmin.STAGING_SUFFIX;
-        this.viewBean = BrowseRecords.getSession().getCurrentView();
-        this.entityModel = BrowseRecords.getSession().getCurrentEntityModel();
+    	updateDataModel();
 
         setLayout(new FitLayout());
         setHeaderVisible(false);
@@ -280,7 +276,34 @@ public class LineageListPanel extends ContentPanel {
         refresh();
     }
 
+    private void updateDataModel() {
+        this.cluster = BrowseRecords.getSession().getAppHeader().getDatacluster();
+        this.cluster = this.cluster.endsWith(StorageAdmin.STAGING_SUFFIX) ? this.cluster : this.cluster
+                + StorageAdmin.STAGING_SUFFIX;
+        this.viewBean = BrowseRecords.getSession().getCurrentView();
+        this.entityModel = BrowseRecords.getSession().getCurrentEntityModel();
+    }
+
+    private boolean isDataModelChanged() {
+        String sessionCluster = BrowseRecords.getSession().getAppHeader().getDatacluster();
+        sessionCluster = sessionCluster.endsWith(StorageAdmin.STAGING_SUFFIX) ? sessionCluster : sessionCluster
+                + StorageAdmin.STAGING_SUFFIX;
+
+        String sessionConceptName = BrowseRecords.getSession().getCurrentEntityModel().getConceptName();
+        List<String> sessionViewableXpaths = BrowseRecords.getSession().getCurrentView().getViewableXpaths();
+        List<String> cloneList = new ArrayList<String>(sessionViewableXpaths);
+        cloneList.removeAll(this.viewBean.getViewableXpaths());
+
+        return ((cloneList.size() > 0) ||
+        		!this.entityModel.getConceptName().equals(sessionConceptName) ||
+                !this.cluster.equals(sessionCluster));
+    }
+
     public void refresh() {
+    	final boolean isDataModelChanged = isDataModelChanged();
+    	if (isDataModelChanged) {
+    		updateDataModel();
+    	}
         selectStagingGridPanel();
         browseStagingRecordService.checkTask(cluster, entityModel.getConceptName(), taskId,
                 new SessionAwareAsyncCallback<Map<String, Integer>>() {
@@ -298,6 +321,12 @@ public class LineageListPanel extends ContentPanel {
                         config.setOffset(0);
                         int pageSize = pagingBar.getPageSize();
                         config.setLimit(pageSize);
+
+                        if (isDataModelChanged) {
+	                        ColumnModel columnModel = new ColumnModel(generateColumnList());
+	                        grid.reconfigure(store, columnModel);
+                        }
+
                         loader.load(config);
                         pagingBar.setVisible(true);
                         gridContainer.setHeight(gridContainerHeight);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/LineageListPanel.java
@@ -202,7 +202,7 @@ public class LineageListPanel extends ContentPanel {
     }
 
     private LineageListPanel() {
-    	updateDataModel();
+        updateDataModel();
 
         setLayout(new FitLayout());
         setHeaderVisible(false);
@@ -278,32 +278,31 @@ public class LineageListPanel extends ContentPanel {
 
     private void updateDataModel() {
         this.cluster = BrowseRecords.getSession().getAppHeader().getDatacluster();
-        this.cluster = this.cluster.endsWith(StorageAdmin.STAGING_SUFFIX) ? this.cluster : this.cluster
-                + StorageAdmin.STAGING_SUFFIX;
+        this.cluster = this.cluster.endsWith(StorageAdmin.STAGING_SUFFIX) ? this.cluster
+                : this.cluster + StorageAdmin.STAGING_SUFFIX;
         this.viewBean = BrowseRecords.getSession().getCurrentView();
         this.entityModel = BrowseRecords.getSession().getCurrentEntityModel();
     }
 
     private boolean isDataModelChanged() {
         String sessionCluster = BrowseRecords.getSession().getAppHeader().getDatacluster();
-        sessionCluster = sessionCluster.endsWith(StorageAdmin.STAGING_SUFFIX) ? sessionCluster : sessionCluster
-                + StorageAdmin.STAGING_SUFFIX;
+        sessionCluster = sessionCluster.endsWith(StorageAdmin.STAGING_SUFFIX) ? sessionCluster
+                : sessionCluster + StorageAdmin.STAGING_SUFFIX;
 
         String sessionConceptName = BrowseRecords.getSession().getCurrentEntityModel().getConceptName();
         List<String> sessionViewableXpaths = BrowseRecords.getSession().getCurrentView().getViewableXpaths();
         List<String> cloneList = new ArrayList<String>(sessionViewableXpaths);
         cloneList.removeAll(this.viewBean.getViewableXpaths());
 
-        return ((cloneList.size() > 0) ||
-        		!this.entityModel.getConceptName().equals(sessionConceptName) ||
-                !this.cluster.equals(sessionCluster));
+        return ((cloneList.size() > 0) || !this.entityModel.getConceptName().equals(sessionConceptName)
+                || !this.cluster.equals(sessionCluster));
     }
 
     public void refresh() {
-    	final boolean isDataModelChanged = isDataModelChanged();
-    	if (isDataModelChanged) {
-    		updateDataModel();
-    	}
+        final boolean isDataModelChanged = isDataModelChanged();
+        if (isDataModelChanged) {
+            updateDataModel();
+        }
         selectStagingGridPanel();
         browseStagingRecordService.checkTask(cluster, entityModel.getConceptName(), taskId,
                 new SessionAwareAsyncCallback<Map<String, Integer>>() {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-11857

**What is the current behavior?** (You should also link to an open issue here)

Deployed product demo with match rule, created records in staging and start validation, then the master record can open match lineage detail panel for the record.
Deployed another data model Customer with match rule job ran, when changed data model to Customer in MDM Web UI, the match lineage detail panel didn't display related detail info.


**What is the new behavior?**

When changed cluster and data model, the related match lineage detail panel can be changed and display accordingly.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
