### PR TITLE
TMDM-14625 Foreign Key Item not set to value entered in the Web UI (7.3)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -4743,6 +4743,39 @@ public class DocumentSaveTest extends TestCase {
         assertEquals("3", evaluate(committedElement, "/TestC/Id"));
         assertEquals("[11]", evaluate(committedElement, "/TestC/DocterField/BaseField/TestA_FK"));
     }
+    
+    public void test_UpdateSpecialFK() throws Exception {
+    	MetadataRepository repository = new MetadataRepository();
+        repository.load(DocumentSaveTest.class.getResourceAsStream("testSpecialFK.xsd"));
+        MockMetadataRepositoryAdmin.INSTANCE.register("testSpecialFK", repository);
+        SaverSource source = new TestSaverSource(repository, true, "testSpecialFK_original.xml", "testSpecialFK.xsd");
+
+        // Case 1, update foreign key refer to itself
+        SaverSession session = SaverSession.newSession(source);
+        InputStream recordXml = new ByteArrayInputStream(("<OrgActivity><idOrgActivity>id1</idOrgActivity><idOrgActivityMere>[id1]</idOrgActivityMere><FK1>[1]</FK1><FK2>[2]</FK2></OrgActivity>").getBytes("UTF-8"));
+        DocumentSaverContext context = session.getContextFactory().create("testSpecialFK", "testSpecialFK", "Source", recordXml, false, true, true, false, false);
+        DocumentSaver saver = context.createSaver();
+        saver.save(session, context);
+        MockCommitter committer = new MockCommitter();
+        session.end(committer);
+        
+        assertTrue(committer.hasSaved());
+        Element committedElement = committer.getCommittedElement();
+        assertEquals("[id1]", evaluate(committedElement, "/OrgActivity/idOrgActivityMere"));
+        
+        // Case 2, update foreign key FK2 that refer to the same type with FK1.
+        session = SaverSession.newSession(source);
+        recordXml = new ByteArrayInputStream(("<OrgActivity><idOrgActivity>id1</idOrgActivity><idOrgActivityMere>[id1]</idOrgActivityMere><FK1>[1]</FK1><FK2>[1]</FK2></OrgActivity>").getBytes("UTF-8"));
+        context = session.getContextFactory().create("testSpecialFK", "testSpecialFK", "Source", recordXml, false, true, true, false, false);
+        saver = context.createSaver();
+        saver.save(session, context);
+        committer = new MockCommitter();
+        session.end(committer);
+        
+        assertTrue(committer.hasSaved());
+        committedElement = committer.getCommittedElement();
+        assertEquals("[1]", evaluate(committedElement, "/OrgActivity/FK2"));
+    }
 
     private void assertUpdateReportAction(Document doc, int index, String expectedPath, String expectedOldValue,
             String expectedNewValue) throws Exception {

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/testSpecialFK.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/testSpecialFK.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">  
+  <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>  
+  <xsd:element name="OrgActivity"> 
+    <xsd:annotation> 
+      <xsd:appinfo source="X_Label_FR">[Org] Origin Activity</xsd:appinfo>  
+      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+    </xsd:annotation>  
+    <xsd:complexType> 
+      <xsd:all> 
+        <xsd:element maxOccurs="1" minOccurs="1" name="idOrgActivity" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Label_FR">&lt;i&gt;Identifiant activity&lt;/i&gt;</xsd:appinfo>  
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="idOrgActivityMere" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_ForeignKey">OrgActivity/idOrgActivity</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>  
+            <xsd:appinfo source="X_FKIntegrity">false</xsd:appinfo>  
+            <xsd:appinfo source="X_FKIntegrity_Override">false</xsd:appinfo>  
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="FK1" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey">OrgType/idOrgType</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element>  
+        <xsd:element maxOccurs="1" minOccurs="0" name="FK2" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey">OrgType/idOrgType</xsd:appinfo>  
+            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element> 
+      </xsd:all> 
+    </xsd:complexType>  
+    <xsd:unique name="OrgActivity"> 
+      <xsd:selector xpath="."/>  
+      <xsd:field xpath="idOrgActivity"/> 
+    </xsd:unique> 
+  </xsd:element>  
+  <xsd:element name="OrgType"> 
+    <xsd:annotation> 
+      <xsd:appinfo source="X_Label_FR">[Org] TypeOrganisation</xsd:appinfo> 
+    </xsd:annotation>  
+    <xsd:complexType> 
+      <xsd:all> 
+        <xsd:element maxOccurs="1" minOccurs="1" name="idOrgType" type="xsd:string"> 
+          <xsd:annotation> 
+            <xsd:appinfo source="X_Label_FR">&lt;i&gt;Code&lt;/i&gt;</xsd:appinfo> 
+          </xsd:annotation> 
+        </xsd:element> 
+      </xsd:all> 
+    </xsd:complexType>  
+    <xsd:unique name="OrgType"> 
+      <xsd:selector xpath="."/>  
+      <xsd:field xpath="idOrgType"/> 
+    </xsd:unique> 
+  </xsd:element> 
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/testSpecialFK_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/testSpecialFK_original.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<ii>
+    <c>testSpecialFK</c>
+    <n>testSpecialFK</n>
+    <dmn>testSpecialFK</dmn>
+    <i>231035933</i>
+    <t>1327653438644</t>
+    <p>
+        <OrgActivity>
+		  <idOrgActivity>id1</idOrgActivity>
+		  <idOrgActivityMere>[fkA]</idOrgActivityMere>
+		  <FK1>[1]</FK1>
+		  <FK2>[2]</FK2>
+		</OrgActivity>
+    </p>
+</ii>

--- a/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/SimpleValue.java
+++ b/org.talend.mdm.core/src/com/amalto/core/history/accessor/record/SimpleValue.java
@@ -31,7 +31,7 @@ class SimpleValue implements Setter, Getter {
             ReferenceFieldMetadata fieldMetadata = (ReferenceFieldMetadata) element.field;
             boolean needResetValue = true;
             if (record.get(element.field) != null) {
-                String oldValue = String.valueOf(record.get(fieldMetadata.getReferencedField()));
+                String oldValue = String.valueOf(DataRecord.getId((DataRecord) record.get(element.field)));
                 if (!(fieldMetadata.getReferencedField() instanceof CompoundFieldMetadata)) {
                     oldValue = '[' + oldValue + ']';
                 }


### PR DESCRIPTION
What is the current behavior? (You should also link to an open issue here)
FK doesn't update correctly when refer to itself or 2 FK fields refer to the same entity

What is the new behavior?
Getting the correct old value for FK field when the field refer to itself or the same entity with another field.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
