### PR TITLE
TMDM-14661 - Update liquibase to 3.8.8

### DIFF
--- a/org.talend.mdm.core.storage.sql/pom.xml
+++ b/org.talend.mdm.core.storage.sql/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.5.3</version>
+            <version>3.8.8</version>
         </dependency>
 
         <!-- jdbc drivers -->


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14661

Veracode is reporting a high level CVE in liquibase 3.5.3. The fixed version is 3.8.8.