### PR TITLE
TMDM-14671 Error while query composite key and multi-occurence field

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ManyFieldProjection.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ManyFieldProjection.java
@@ -153,6 +153,10 @@ class ManyFieldProjection extends SimpleProjection {
             this.dataSourceDialect = dataSourceDialect;
         }
 
+        /**
+         * Due to different DB to use separate aggregation function, The special enum instance will overwrite the
+         * <b>toFunctionNames</b> method.
+         */
         public abstract void toFunctionNames(StringBuilder sqlFragment, String containerTable, String collectionTable);
 
         public void toJoinEnd(StringBuilder sqlFragment) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ManyFieldProjection.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ManyFieldProjection.java
@@ -154,8 +154,10 @@ class ManyFieldProjection extends SimpleProjection {
         }
 
         /**
-         * Due to different DB to use separate aggregation function, The special enum instance will overwrite the
-         * <b>toFunctionNames</b> method.
+         * The special functions, like (<b>group_concat</b> in Mysql) are identical in SQL due to different DB to use
+         * separate one, The special enum instance will overwrite the <b>toFunctionNames</b> method. And the we retrieve
+         * the data one-to-many association from the database store it in that Query object and iterate this object with
+         * the help of Iterator and finally displays the requested data on the front-end.
          */
         public abstract void toFunctionNames(StringBuilder sqlFragment, String containerTable, String collectionTable);
 
@@ -173,7 +175,7 @@ class ManyFieldProjection extends SimpleProjection {
          *  WHERE CompositeKeyTable.x_id2 = this_.x_id2 AND CompositeKeyTable.x_id1 = this_.x_id1)
          * </pre>
          */
-        public void toSqlString(StringBuilder sqlFragment, CriteriaQuery criteriaQuery, Criteria subCriteria,
+        private void toSqlString(StringBuilder sqlFragment, CriteriaQuery criteriaQuery, Criteria subCriteria,
                 String containerTable, String collectionTable, Set<String> keyNameSet) {
             toFunctionNames(sqlFragment, containerTable, collectionTable);
             treatedManyFieldJoin(sqlFragment, criteriaQuery, subCriteria, containerTable, collectionTable, keyNameSet);
@@ -209,7 +211,7 @@ class ManyFieldProjection extends SimpleProjection {
             toJoinEnd(sqlFragment);
         }
 
-        public static SpecialDBSQLProvider selectDataSource(DataSourceDialect dataSourceDialect) {
+        private static SpecialDBSQLProvider selectDataSource(DataSourceDialect dataSourceDialect) {
             for (SpecialDBSQLProvider item : SpecialDBSQLProvider.values()) {
                 if (item.dataSourceDialect.equals(dataSourceDialect)) {
                     return item;

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ManyFieldProjection.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/ManyFieldProjection.java
@@ -76,11 +76,11 @@ class ManyFieldProjection extends SimpleProjection {
             sqlFragment.append("distinct "); //$NON-NLS-1$
         }
         Set<String> keyNameSet = containingType.getKeyFields().stream().map((item) -> resolver.get(item)).collect(Collectors.toSet());
-        SQLGenerator currentSQLGenerator = SQLGenerator.selectDataSource(dataSource.getDialectName());
-        sqlFragment.append(currentSQLGenerator.getSelectFragment(containerTable, collectionTable))
-                   .append(currentSQLGenerator.getJoinFragment(criteriaQuery, subCriteria, containerTable, collectionTable, keyNameSet))
-                   .append(currentSQLGenerator.getWhereFragment(criteriaQuery, subCriteria, containerTable, collectionTable, keyNameSet))
-                   .append(currentSQLGenerator.getEndFragment());
+        SQLGenerator sqlGenerator = SQLGenerator.selectDataSource(dataSource.getDialectName());
+        sqlFragment.append(sqlGenerator.getSelectFragment(containerTable, collectionTable))
+                   .append(sqlGenerator.getJoinFragment(criteriaQuery, subCriteria, containerTable, collectionTable, keyNameSet))
+                   .append(sqlGenerator.getWhereFragment(criteriaQuery, subCriteria, containerTable, collectionTable, keyNameSet))
+                   .append(sqlGenerator.getEndFragment());
 
         if (count && !isMSSQLDataDource()) {
             sqlFragment.append(")"); //$NON-NLS-1$
@@ -97,11 +97,9 @@ class ManyFieldProjection extends SimpleProjection {
 
               @Override
               protected String getSelectFragment(String containerTable, String collectionTable) {
-                  StringBuilder selectFragment = new StringBuilder();
-                  selectFragment.append("(SELECT string_agg(") //$NON-NLS-1$
-                      .append(collectionTable)
-                      .append(".value, ',') FROM ").append(containerTable);
-                  return selectFragment.toString();
+                  return new StringBuilder().append("(SELECT string_agg(") //$NON-NLS-1$
+                          .append(collectionTable).append(".value, ',') FROM ").append(containerTable)
+                          .toString();
               }
           },
 
@@ -117,11 +115,9 @@ class ManyFieldProjection extends SimpleProjection {
 
               @Override
               protected String getSelectFragment(String containerTable, String collectionTable) {
-                  StringBuilder selectFragment = new StringBuilder();
-                  selectFragment.append("(SELECT group_concat(") //$NON-NLS-1$
+                  return new StringBuilder().append("(SELECT group_concat(") //$NON-NLS-1$
                       .append(collectionTable)
-                      .append(".value separator ',') FROM ").append(containerTable); //$NON-NLS-1$
-                  return selectFragment.toString();
+                      .append(".value separator ',') FROM ").append(containerTable).toString(); //$NON-NLS-1$
               }
           },
 
@@ -129,11 +125,9 @@ class ManyFieldProjection extends SimpleProjection {
 
               @Override
               protected String getSelectFragment(String containerTable, String collectionTable) {
-                  StringBuilder selectFragment = new StringBuilder();
-                  selectFragment.append("(SELECT listagg(") //$NON-NLS-1$
+                  return new StringBuilder().append("(SELECT listagg(") //$NON-NLS-1$
                       .append(collectionTable)
-                      .append(".value, ',') WITHIN GROUP (ORDER BY pos) FROM ").append(containerTable); //$NON-NLS-1$
-                  return selectFragment.toString();
+                      .append(".value, ',') WITHIN GROUP (ORDER BY pos) FROM ").append(containerTable).toString(); //$NON-NLS-1$
               }
           },
 
@@ -141,11 +135,9 @@ class ManyFieldProjection extends SimpleProjection {
 
               @Override
               protected String getSelectFragment(String containerTable, String collectionTable) {
-                  StringBuilder selectFragment = new StringBuilder();
-                  selectFragment.append("STUFF((select ',' + ") //$NON-NLS-1$
+                  return new StringBuilder().append("STUFF((select ',' + ") //$NON-NLS-1$
                       .append(collectionTable)
-                      .append(".value FROM ").append(containerTable); //$NON-NLS-1$
-                  return selectFragment.toString();
+                      .append(".value FROM ").append(containerTable).toString(); //$NON-NLS-1$
               }
 
               @Override
@@ -158,11 +150,9 @@ class ManyFieldProjection extends SimpleProjection {
 
               @Override
               protected String getSelectFragment(String containerTable, String collectionTable) {
-                  StringBuilder selectFragment = new StringBuilder();
-                  selectFragment.append("(SELECT listagg(") //$NON-NLS-1$
+                  return new StringBuilder().append("(SELECT listagg(") //$NON-NLS-1$
                       .append(collectionTable)
-                      .append(".value, ',') WITHIN GROUP (ORDER BY pos) FROM ").append(containerTable); //$NON-NLS-1$
-                  return selectFragment.toString();
+                      .append(".value, ',') WITHIN GROUP (ORDER BY pos) FROM ").append(containerTable).toString(); //$NON-NLS-1$
               }
           };
 
@@ -227,7 +217,6 @@ class ManyFieldProjection extends SimpleProjection {
                 } else {
                     whereClause.append(" AND "); //$NON-NLS-1$
                 }
-
                 whereClause.append(containerTable).append('.').append(keyName).append(" = ") //$NON-NLS-1$
                     .append(criteriaQuery.getSQLAlias(subCriteria)).append('.').append(keyName);
             }

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/CKTest_1.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/CKTest_1.xsd
@@ -1,0 +1,84 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:element name="CompositeKey">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+            <xsd:appinfo source="X_Description_EN">hello</xsd:appinfo>
+            <xsd:appinfo source="X_Description_FR">Voir</xsd:appinfo>
+            <xsd:appinfo source="X_Description_JA">レコ</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id1" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id2" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id3" type="xsd:date">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" name="name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="Address" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="3" minOccurs="0" name="Name3" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="2" minOccurs="1" name="Name2" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="unbounded" minOccurs="1" name="Name5" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="CompositeKey">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id3" />
+            <xsd:field xpath="Id2" />
+            <xsd:field xpath="Id1" />
+        </xsd:unique>
+    </xsd:element>
+    <xsd:element name="SingleEntity">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="unbounded" minOccurs="0" name="Name" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="SingleEntity">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14671
**What is the current behavior?** (You should also link to an open issue here)
A relational database composite key contains two or more columns which together for the primary key of a given table, To map this structure to generate SQL, we extends Hibernate SimpleProjection class, and overwrite toSqlString method. but now, previous implement logic don't support the composite key that caused a Exception.

**What is the new behavior?**
Add the extra code to support it. We can even map relationships using the information provided within the Composite Key itself. New add logic will be checked in major DB, like oracle, postgrasql, ms sql, mysql and h2.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
