### PR TITLE
TMDM-14393 The order in which the tabs are displayed in the "Item Details" in the MDM Web UI changes sometimes

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsDetailPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsDetailPanel.java
@@ -489,18 +489,23 @@ public class ItemsDetailPanel extends ContentPanel {
                     // Select the tab
                     this.tabBar.selectTab(0);
                 } else {
-                    // Create the tab
-                    Label tabLabel = this.createTabLabel(title);
-                    this.tabBar.addTab(tabLabel);
+                	int itemIndex = this.tabTitles.indexOf(title);
+                    if (itemIndex == -1) {
+                        // Create the tab
+                        Label tabLabel = this.createTabLabel(title);
+                        this.tabBar.addTab(tabLabel);
 
-                    // Save the ID
-                    this.tabIds.add(id);
+                        // Save the ID
+                        this.tabIds.add(id);
 
-                    // Save the ID
-                    this.tabTitles.add(title);
+                        // Save the ID
+                        this.tabTitles.add(title);
 
-                    // Save the panel
-                    this.tabPanels.add(panel);
+                        // Save the panel
+                        this.tabPanels.add(panel);
+                    } else {
+                        this.tabPanels.set(itemIndex, panel);
+                    }
                 }
 
             } else {

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsDetailPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsDetailPanel.java
@@ -484,7 +484,7 @@ public class ItemsDetailPanel extends ContentPanel {
                     // Select the tab
                     this.tabBar.selectTab(0);
                 } else {
-                	int itemIndex = this.tabTitles.indexOf(title);
+                    int itemIndex = this.tabTitles.indexOf(title);
                     if (itemIndex == -1) {
                         // Create the tab
                         Label tabLabel = this.createTabLabel(title);

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsDetailPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemsDetailPanel.java
@@ -233,9 +233,6 @@ public class ItemsDetailPanel extends ContentPanel {
     }
 
     public ItemDetailTabPanelContentHandle addTabItem(String title, ContentPanel panel, String pattern, String id) {
-        if (itemsDetailTabPanel.getTabTitles().contains(title)) {
-            itemsDetailTabPanel.closeTabPanelWithTitle(title);
-        }
         return itemsDetailTabPanel.addTabItem(title, panel, pattern, id);
     }
 
@@ -463,9 +460,7 @@ public class ItemsDetailPanel extends ContentPanel {
          * @param id
          */
         public ItemDetailTabPanelContentHandle addTabItem(String title, ContentPanel panel, String pattern, String id) {
-            if (pattern.equalsIgnoreCase(ItemsDetailPanel.MULTIPLE)) {
-                this.closeTabPanelWithId(id);
-
+            if (pattern.equalsIgnoreCase(ItemsDetailPanel.MULTIPLE)) {               
                 if (this.getTabCount() == 0) {
                     // Adding a first tab
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14393
**What is the current behavior?** (You should also link to an open issue here)
Tab order changed during executing visable rule


**What is the new behavior?**

Tab order not changed during executing visable rule.
Add itemIndex to check if tab already exist. If yes, won't create new tab 

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...



**Other information**:
http://192.168.31.210:8080/view/Master/job/Master_03_TMDMEE_FOR-JIRA/439/
http://192.168.31.210:8080/view/Master/job/MDM-REST-EE-MySQL8-CentOS-DEBUG2/666/
http://192.168.31.210:8080/view/Master/job/MDM-SOAP-EE-CentOS-MySQL8-DEBUG1/564/
