### PR TITLE
TMDM-14650 [CVE] - Update Jackson to 2.10.1 (refactor)

### DIFF
--- a/org.talend.mdm.core/pom.xml
+++ b/org.talend.mdm.core/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <jackson.version>2.10.1</jackson.version>
         <activemq.version>5.15.9</activemq.version>
-        <woodstox.core.version>5.3.0</woodstox.core.version>
+        <woodstox.core.version>6.0.2</woodstox.core.version>
         <joda.time.version>2.10</joda.time.version>
         <hazelcast.version>3.10.7</hazelcast.version>
     </properties>
@@ -242,6 +242,12 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>${jackson.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>

--- a/org.talend.mdm.core/pom.xml
+++ b/org.talend.mdm.core/pom.xml
@@ -14,7 +14,6 @@
 
     <properties>
         <jackson.version>2.10.1</jackson.version>
-        <jackson.provider.version>2.10.1</jackson.provider.version>
         <activemq.version>5.15.9</activemq.version>
         <woodstox.core.version>5.3.0</woodstox.core.version>
         <joda.time.version>2.10</joda.time.version>
@@ -232,22 +231,37 @@
 	                <artifactId>snakeyaml</artifactId>
 	            </exclusion>
             </exclusions>
-            <version>${jackson.provider.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-xml</artifactId>
-            <version>${jackson.provider.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
-            <version>${jackson.provider.version}</version>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-base</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jaxrs</groupId>
+            <artifactId>jackson-jaxrs-json-provider</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.provider.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -257,32 +271,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.provider.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
-		<dependency>
-		    <groupId>com.fasterxml.jackson.module</groupId>
-		    <artifactId>jackson-module-jaxb-annotations</artifactId>
-		    <version>${jackson.provider.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>com.fasterxml.woodstox</groupId>
-		    <artifactId>woodstox-core</artifactId>
-		    <version>${woodstox.core.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>joda-time</groupId>
-		    <artifactId>joda-time</artifactId>
-		    <version>${joda.time.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>com.fasterxml.jackson.jaxrs</groupId>
-		    <artifactId>jackson-jaxrs-base</artifactId>
-		    <version>${jackson.provider.version}</version>
-		</dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>${jackson.provider.version}</version>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda.time.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/org.talend.mdm.core/pom.xml
+++ b/org.talend.mdm.core/pom.xml
@@ -242,12 +242,6 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-joda</artifactId>
             <version>${jackson.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>joda-time</groupId>
-                    <artifactId>joda-time</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14650
All artificates with groupId start with `com.fasterxml.jackson` have same parent pom as bellow, so define one parameter `jackson.version` would be enough.
```
<parent>
    <groupId>com.fasterxml.jackson</groupId>
    <artifactId>jackson-base</artifactId>
    <version>2.10.1</version>
  </parent>
```