### PR TITLE
TMDM-14696 [REST] PUT query : sort on FK : empty value wrongly sorted (7.1)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
 import org.hibernate.Hibernate;
+import org.hibernate.NullPrecedence;
 import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.Session;
@@ -860,10 +861,10 @@ class StandardQueryHandler extends AbstractQueryHandler {
             list.add(Projections.count(propertyName).as(alias));
             switch (orderBy.getDirection()) {
             case ASC:
-                criteria.addOrder(Order.asc(alias));
+                criteria.addOrder(Order.asc(alias).nulls(NullPrecedence.FIRST));
                 break;
             case DESC:
-                criteria.addOrder(Order.desc(alias));
+                criteria.addOrder(Order.desc(alias).nulls(NullPrecedence.LAST));
                 break;
             }
         }
@@ -872,10 +873,10 @@ class StandardQueryHandler extends AbstractQueryHandler {
                 OrderBy.Direction direction = orderBy.getDirection();
                 switch (direction) {
                 case ASC:
-                    criteria.addOrder(Order.asc(fieldName));
+                    criteria.addOrder(Order.asc(fieldName).nulls(NullPrecedence.FIRST));
                     break;
                 case DESC:
-                    criteria.addOrder(Order.desc(fieldName));
+                    criteria.addOrder(Order.desc(fieldName).nulls(NullPrecedence.LAST));
                     break;
                 }
             }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -118,6 +118,7 @@ import com.amalto.core.query.user.metadata.StagingStatus;
 import com.amalto.core.query.user.metadata.TaskId;
 import com.amalto.core.query.user.metadata.Timestamp;
 import com.amalto.core.storage.CloseableIterator;
+import com.amalto.core.storage.HibernateStorageUtils;
 import com.amalto.core.storage.Storage;
 import com.amalto.core.storage.StorageMetadataUtils;
 import com.amalto.core.storage.StorageResults;
@@ -859,29 +860,36 @@ class StandardQueryHandler extends AbstractQueryHandler {
             list.add(Projections.groupProperty(propertyName));
             String alias = "x_talend_countField" + countAggregateIndex++; //$NON-NLS-1$
             list.add(Projections.count(propertyName).as(alias));
-            switch (orderBy.getDirection()) {
-            case ASC:
-                criteria.addOrder(Order.asc(alias).nulls(NullPrecedence.FIRST));
-                break;
-            case DESC:
-                criteria.addOrder(Order.desc(alias).nulls(NullPrecedence.LAST));
-                break;
-            }
+            orderByWithNulls(orderBy.getDirection(), alias);
         }
         if (condition != null) {
             for (String fieldName : condition.criterionFieldNames) {
-                OrderBy.Direction direction = orderBy.getDirection();
-                switch (direction) {
-                case ASC:
-                    criteria.addOrder(Order.asc(fieldName).nulls(NullPrecedence.FIRST));
-                    break;
-                case DESC:
-                    criteria.addOrder(Order.desc(fieldName).nulls(NullPrecedence.LAST));
-                    break;
-                }
+            	orderByWithNulls(orderBy.getDirection(), fieldName);                
             }
         }
         return null;
+    }
+    
+    // Nulls first when order by with ASC direction, nulls last when order by DESC direction
+    private void orderByWithNulls(OrderBy.Direction direction, String field) {
+    	RDBMSDataSource dataSource = (RDBMSDataSource) storage.getDataSource();
+        switch (direction) {
+        case ASC:
+        	// Nulls first/last not supported by SQLServer, its default behavior is the same as expected
+        	if (HibernateStorageUtils.isSQLServer(dataSource.getDialectName())) {
+        		criteria.addOrder(Order.asc(field));
+        	} else {
+        		criteria.addOrder(Order.asc(field).nulls(NullPrecedence.FIRST));
+        	}
+            break;
+        case DESC:
+        	if (HibernateStorageUtils.isSQLServer(dataSource.getDialectName())) {
+        		criteria.addOrder(Order.desc(field));
+        	} else {
+        		criteria.addOrder(Order.desc(field).nulls(NullPrecedence.LAST));
+        	}
+        	break;
+        }
     }
 
     @Override

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -1960,12 +1960,12 @@ public class StorageQueryTest extends StorageTestCase {
         FieldMetadata id0Field = orgEntity.getField("ID_0");
         FieldMetadata fkEntityField = orgEntity.getField("FieldA/FKEntity");
 
-        qb = from(orgEntity).select(id0Field).select(fkEntityField).where(not(isNull(fkEntityField)))
+        qb = from(orgEntity).select(id0Field).select(fkEntityField)
                 .orderBy(fkEntityField, OrderBy.Direction.ASC);
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(3, results.getCount());
-            String[] expected = { "4", "3", "2"};
+            assertEquals(5, results.getCount());
+            String[] expected = { "1","5","4", "3", "2"};
             int i = 0;
             for (DataRecord result : results) {
                 assertEquals(expected[i++], result.get(id0Field));


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14696
**What is the current behavior?**  (You should also link to an open issue here)

Null values display last when orderby asc on oracle/postgres db.

**What is the new behavior?**
Set nulls first for asc order
Set null last for desc order


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
