### PR TITLE
TMDM-14696 [REST] PUT query : sort on FK : empty value wrongly sorted(7.2)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -1960,12 +1960,12 @@ public class StorageQueryTest extends StorageTestCase {
         FieldMetadata id0Field = orgEntity.getField("ID_0");
         FieldMetadata fkEntityField = orgEntity.getField("FieldA/FKEntity");
 
-        qb = from(orgEntity).select(id0Field).select(fkEntityField).where(not(isNull(fkEntityField)))
+        qb = from(orgEntity).select(id0Field).select(fkEntityField)
                 .orderBy(fkEntityField, OrderBy.Direction.ASC);
         results = storage.fetch(qb.getSelect());
         try {
-            assertEquals(3, results.getCount());
-            String[] expected = { "4", "3", "2"};
+            assertEquals(5, results.getCount());
+            String[] expected = { "1","5","4", "3", "2"};
             int i = 0;
             for (DataRecord result : results) {
                 assertEquals(expected[i++], result.get(id0Field));


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14696
What is the current behavior? (You should also link to an open issue here)

Null values display last when orderby asc on oracle/postgres db.

What is the new behavior?
Set nulls first for asc order
Set nulls last for desc order
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
