### PR TITLE
TPS-3260 [7.2.1] MDM war file deployed on Tomcat 8.5 : Error java.lang.NoSuchMethodError: javax.servlet.ServletContext.getSessionTimeout() (TMDM-13686)

### DIFF
--- a/org.talend.mdm.webapp.general/pom.xml
+++ b/org.talend.mdm.webapp.general/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TPS-3260
**What is the current behavior?** (You should also link to an open issue here)

Tomcat 8.5 doesn't support method javax.servlet.ServletContext.getSessionTimeout()


**What is the new behavior?**

Manually get timeout from web.xml

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
