### PR TITLE
TMDM-14699 Remove useless code change which should only exist in test case

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/objects/ObjectPOJOPK.java
+++ b/org.talend.mdm.core/src/com/amalto/core/objects/ObjectPOJOPK.java
@@ -11,26 +11,14 @@ package com.amalto.core.objects;
 
 import java.io.Serializable;
 
-import org.apache.log4j.Logger;
-import org.talend.mdm.commmon.util.core.MDMConfiguration;
-
 import com.amalto.core.util.Util;
 
 public class ObjectPOJOPK implements Serializable {
 
     private static final long serialVersionUID = 8946570431961920706L;
 
-    private static final Logger LOGGER = Logger.getLogger(ObjectPOJOPK.class);
-
     String[] ids = null;
 
-    static {
-        try {
-            MDMConfiguration.createConfiguration("", true);
-        } catch (IllegalStateException e) {
-            LOGGER.warn("MDMConfiguration had been initialized");
-        }
-    }
 
     public ObjectPOJOPK(String[] itemIds) {
         this.ids = itemIds;


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14699

**What is the current behavior?** (You should also link to an open issue here)
The code change to fix `Exception in thread "main" java.lang.ExceptionInInitializerError` is not correct.
``` 
static {
    try {
        MDMConfiguration.createConfiguration("", true);
    } catch (IllegalStateException e) {
        LOGGER.warn("MDMConfiguration had been initialized");
    }
}
```


**What is the new behavior?**
- Remove the useless code change, the right way should be in DBMigrationTool to init MDMConfiguration earlier with code bellow:
`MDMConfiguration.createConfiguration(config.getToHome() + "/conf/mdm.conf", true);`
See: https://github.com/Talend/tmdm-server-ee/pull/697/files


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
