### PR TITLE
TMDM-14709 Deploy Data Model fails after Element removed : ORA-00904:"X_VERSION" : invalid identifier (7.1)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -61,6 +61,7 @@ import liquibase.change.core.DropColumnChange;
 import liquibase.change.core.DropForeignKeyConstraintChange;
 import liquibase.change.core.DropIndexChange;
 import liquibase.change.core.DropNotNullConstraintChange;
+import liquibase.change.core.DropTableChange;
 import liquibase.database.DatabaseConnection;
 import liquibase.precondition.core.IndexExistsPrecondition;
 import liquibase.precondition.core.PreconditionContainer;
@@ -222,6 +223,7 @@ public class LiquibaseSchemaAdapter  {
         Map<String, List<String>> dropColumnMap = new HashMap<>();
         Map<String, List<String>> dropFKMap = new HashMap<>();
         Map<String, List<String[]>> dropIndexMap = new HashMap<>();
+        List<String> dropTableList = new ArrayList<String>();
 
         for (RemoveChange removeAction : diffResults.getRemoveChanges()) {
 
@@ -254,12 +256,17 @@ public class LiquibaseSchemaAdapter  {
                     fkList.add(fkName);
                     dropFKMap.put(tableName, fkList);
                 }
-                List<String> columnList = dropColumnMap.get(tableName);
-                if (columnList == null) {
-                    columnList = new ArrayList<String>();
-                }
-                columnList.add(columnName);
-                dropColumnMap.put(tableName, columnList);
+                // Remove the table for 0-many simple field.
+                if (field.isMany()) {
+                    dropTableList.add(tableName + "_" + columnName);
+                } else {
+                    List<String> columnList = dropColumnMap.get(tableName);
+                    if (columnList == null) {
+                        columnList = new ArrayList<String>();
+                    }
+                    columnList.add(columnName);
+                    dropColumnMap.put(tableName, columnList);
+                }                               
 
                 List<String[]> indexList = dropIndexMap.get(tableName);
                 if (indexList == null) {
@@ -287,6 +294,12 @@ public class LiquibaseSchemaAdapter  {
                 dropFKChange.setConstraintName(fk);
                 changeActionList.add(dropFKChange);
             }
+        }
+        
+        for (String tableName : dropTableList) {
+            DropTableChange dropTableChange = new DropTableChange();
+            dropTableChange.setTableName(tableName);
+            changeActionList.add(dropTableChange);
         }
 
         for (Map.Entry<String, List<String>> entry : dropColumnMap.entrySet()) {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
@@ -165,7 +165,7 @@ public class LiquibaseSchemaAdapterTest {
         Compare.DiffResults diffResults = Compare.compare(original, updated2);
 
         assertEquals(8, diffResults.getActions().size());
-        assertEquals(7, diffResults.getModifyChanges().size());
+        assertEquals(6, diffResults.getModifyChanges().size());
         assertEquals(0, diffResults.getAddChanges().size());
 
         List<AbstractChange> changeList = adapter.analyzeModifyChange(diffResults);
@@ -184,12 +184,13 @@ public class LiquibaseSchemaAdapterTest {
         updated2.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_2.xsd")); //$NON-NLS-1$
 
         Compare.DiffResults diffResults = Compare.compare(original, updated2);
-        assertEquals(1, diffResults.getRemoveChanges().size());
+        assertEquals(2, diffResults.getRemoveChanges().size());
 
         List<AbstractChange> removeChangeList = adapter.analyzeRemoveChange(diffResults);
-        assertEquals(2, removeChangeList.size());
+        assertEquals(3, removeChangeList.size());
         assertEquals("liquibase.change.core.DropForeignKeyConstraintChange", removeChangeList.get(0).getClass().getName());
-        assertEquals("liquibase.change.core.DropColumnChange", removeChangeList.get(1).getClass().getName());
+        assertEquals("liquibase.change.core.DropTableChange", removeChangeList.get(1).getClass().getName());
+        assertEquals("liquibase.change.core.DropColumnChange", removeChangeList.get(2).getClass().getName());
     }
 
     @Test

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
@@ -36,11 +36,6 @@
                         <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
                     </xsd:annotation>
                 </xsd:element>
-                <xsd:element maxOccurs="unbounded" minOccurs="0" name="gg" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
-                    </xsd:annotation>
-                </xsd:element>
                 <xsd:element maxOccurs="1" minOccurs="0" name="uu"> 
 		          <xsd:annotation> 
 		            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14709
What is the current behavior? (You should also link to an open issue here)

Deploy failed after removing a 0-many simple field.

What is the new behavior?
Deploy successfully after removing a 0-many simple field.
Modify the changeAction to drop table for removing 0-many field.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
