### PR TITLE
TMDM-14709 Deploy Data Model fails after Element removed : ORA-00904:"X_VERSION" : invalid identifier (7.3)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
@@ -168,7 +168,7 @@ public class LiquibaseSchemaAdapterTest {
         Compare.DiffResults diffResults = Compare.compare(original, updated2);
 
         assertEquals(8, diffResults.getActions().size());
-        assertEquals(7, diffResults.getModifyChanges().size());
+        assertEquals(6, diffResults.getModifyChanges().size());
         assertEquals(0, diffResults.getAddChanges().size());
 
         List<AbstractChange> changeList = adapter.analyzeModifyChange(diffResults);
@@ -187,12 +187,13 @@ public class LiquibaseSchemaAdapterTest {
         updated2.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_2.xsd")); //$NON-NLS-1$
 
         Compare.DiffResults diffResults = Compare.compare(original, updated2);
-        assertEquals(1, diffResults.getRemoveChanges().size());
+        assertEquals(2, diffResults.getRemoveChanges().size());
 
         List<AbstractChange> removeChangeList = adapter.analyzeRemoveChange(diffResults);
-        assertEquals(2, removeChangeList.size());
+        assertEquals(3, removeChangeList.size());
         assertEquals("liquibase.change.core.DropForeignKeyConstraintChange", removeChangeList.get(0).getClass().getName());
-        assertEquals("liquibase.change.core.DropColumnChange", removeChangeList.get(1).getClass().getName());
+        assertEquals("liquibase.change.core.DropTableChange", removeChangeList.get(1).getClass().getName());
+        assertEquals("liquibase.change.core.DropColumnChange", removeChangeList.get(2).getClass().getName());
     }
 
     @Test

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
@@ -36,11 +36,6 @@
                         <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
                     </xsd:annotation>
                 </xsd:element>
-                <xsd:element maxOccurs="unbounded" minOccurs="0" name="gg" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
-                    </xsd:annotation>
-                </xsd:element>
                 <xsd:element maxOccurs="1" minOccurs="0" name="uu"> 
 		          <xsd:annotation> 
 		            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14709
What is the current behavior? (You should also link to an open issue here)

Deploy failed after removing a 0-many simple field.

What is the new behavior?
Deploy successfully after removing a 0-many simple field.
Modify the changeAction to drop table for removing 0-many field.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
http://192.168.31.210/deploy/7.3/20200701/tmdmee/TMDM-14709