### PR TITLE
TMDM-14659 [REST API] Throw UnsupportedOperationException when the foreign key points to an entity with composite key

### DIFF
--- a/org.talend.mdm.query/src/com/amalto/core/query/user/UserQueryBuilder.java
+++ b/org.talend.mdm.query/src/com/amalto/core/query/user/UserQueryBuilder.java
@@ -1014,11 +1014,19 @@ public class UserQueryBuilder {
                     rightField instanceof CompoundFieldMetadata) {
                 FieldMetadata[] leftFields = ((CompoundFieldMetadata) leftReferencedField).getFields();
                 FieldMetadata[] rightFields = ((CompoundFieldMetadata) rightField).getFields();
-                if (!isEqualForCompoundField(leftFields, rightFields)) {
+                if (!isEqualForBothCompoundField(leftFields, rightFields)) {
                     throw new IllegalArgumentException("Left field '" + leftReferencedField + "' is a FK, but right field isn't the one left is referring to.");
                 }
+            } else if (leftReferencedField instanceof CompoundFieldMetadata
+                    && rightField instanceof SimpleTypeFieldMetadata) {
+                FieldMetadata[] leftFields = ((CompoundFieldMetadata) leftReferencedField).getFields();
+                if (!isEqualForLeftCompoundField(leftFields, rightField)) {
+                    throw new IllegalArgumentException("Left field '" + leftReferencedField
+                            + "' is a FK, but right field isn't the one left is referring to.");
+                }
             } else if (!leftReferencedField.equals(rightField)) {
-                throw new IllegalArgumentException("Left field '" + leftReferencedField.getName() + "' is a FK, but right field isn't the one left is referring to.");
+                throw new IllegalArgumentException("Left field '" + leftReferencedField.getName()
+                        + "' is a FK, but right field isn't the one left is referring to.");
             }
         }
         Field leftUserField = new Field(leftField);
@@ -1032,25 +1040,36 @@ public class UserQueryBuilder {
         return this;
     }
 
-    private boolean isEqualForCompoundField(FieldMetadata[] leftFields, FieldMetadata[] rightFields) {
+    private boolean isEqualForBothCompoundField(FieldMetadata[] leftFields, FieldMetadata[] rightFields) {
         if (null == leftFields && null == rightFields) {
             return true;
         }
-        if (leftFields.length != rightFields.length) {
-            return false;
-        }
-        int len = leftFields.length;
-        for (int i = 0; i < len; i++) {
-            if (!leftFields[i].equals(rightFields[i])) {
+        for (int i = 0; i < leftFields.length; i++) {
+            if (!((SimpleTypeFieldMetadata)leftFields[i]).getContainingType().equals(
+                    ((SimpleTypeFieldMetadata)rightFields[i]).getContainingType())) {
                 return false;
             }
         }
         return true;
     }
 
+    private boolean isEqualForLeftCompoundField(FieldMetadata[] leftFields, FieldMetadata rightField) {
+        if (null == leftFields && null == rightField) {
+            return true;
+        }
+        for (int i = 0; i < leftFields.length; i++) {
+            if (((SimpleTypeFieldMetadata) leftFields[i]).getContainingType().equals(
+                    ((SimpleTypeFieldMetadata) rightField).getContainingType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * <p>
-     * Join a type's field with another. This method expects field to be a {@link ReferenceFieldMetadata} and automatically
+     * Join a type's field with another. This method expects field to be a {@link ReferenceFieldMetadata} and
+     * automatically
      * creates a Join between <code>field</code> parameter and the field(s) it targets.
      * </p>
      *


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14659

**What is the current behavior?** (You should also link to an open issue here)

Previous version didn't support composite key in Join of MDM query, details can be found from Dev Design in Jira:
https://jira.talendforge.org/browse/TMDM-14659?focusedCommentId=805994&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-805994

**What is the new behavior?**

Added support for composite key in Join of MDM query.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
