### PR TITLE
TMDM-14772 Replace toLowerCase().equals() with equalsIgnoreCase

### DIFF
--- a/org.talend.mdm.core.plugin.base/src/com/amalto/core/plugin/base/codec/CodecPluginBean.java
+++ b/org.talend.mdm.core.plugin.base/src/com/amalto/core/plugin/base/codec/CodecPluginBean.java
@@ -85,7 +85,7 @@ public class CodecPluginBean extends Plugin {
      */
     public String getDescription(String twoLettersLanguageCode) throws XtentisException {
         String description = "";
-        if (twoLettersLanguageCode.toLowerCase().equals("en")) {
+        if (twoLettersLanguageCode.equalsIgnoreCase("en")) {
             description = "This is a plugin used for encode or decode text";
         } else {
             description = "Unsupported language! ";

--- a/org.talend.mdm.core.plugin.base/src/com/amalto/core/plugin/base/dumpandgo/DumpAndGoPluginBean.java
+++ b/org.talend.mdm.core.plugin.base/src/com/amalto/core/plugin/base/dumpandgo/DumpAndGoPluginBean.java
@@ -84,7 +84,7 @@ public class DumpAndGoPluginBean extends Plugin {
     public String getDescription(String twoLettersLanguageCode)
 			throws XtentisException {
 		String description="";
-		if(twoLettersLanguageCode.toLowerCase().equals("en")){
+		if(twoLettersLanguageCode.equalsIgnoreCase("en")){
 			description="This is a plugin used for dump text and pass it. ";
 		}else{
 			description="Unsupported language! ";

--- a/org.talend.mdm.core.plugin.base/src/com/amalto/core/plugin/base/groovy/GroovyPluginBean.java
+++ b/org.talend.mdm.core.plugin.base/src/com/amalto/core/plugin/base/groovy/GroovyPluginBean.java
@@ -89,7 +89,7 @@ public class GroovyPluginBean extends Plugin {
 	public String getDescription(String twoLettersLanguageCode)
 			throws XtentisException {
 		String description="";
-		if(twoLettersLanguageCode.toLowerCase().equals("en")){
+		if(twoLettersLanguageCode.equalsIgnoreCase("en")){
 			description="This is a plugin which you can call the groovy script. ";
 		}else{
 			description="Unsupported language! ";

--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/util/XmlUtil.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/server/util/XmlUtil.java
@@ -271,10 +271,10 @@ public final class XmlUtil {
 
     public static void write(Document document, String filePath, String printMode, String encoding) throws IOException {
         OutputFormat format;
-        if (printMode.toLowerCase().equals("pretty")) { //$NON-NLS-1$
+        if (printMode.equalsIgnoreCase("pretty")) { //$NON-NLS-1$
             // Pretty print the document
             format = OutputFormat.createPrettyPrint();
-        } else if (printMode.toLowerCase().equals("compact")) { //$NON-NLS-1$
+        } else if (printMode.equalsIgnoreCase("compact")) { //$NON-NLS-1$
             // Compact format
             format = OutputFormat.createCompactFormat();
         } else {


### PR DESCRIPTION
There are a some instances in the code where toLowerCase().equals() is used, when equalsIgnoreCase() would suffice. The latter is more concise + also doesn't involve the default Locale that's used with toLowerCase(), which might be problematic depending on the String being compared.