### PR TITLE
TMDM-14743 Only 2 search operators : Is equal to / Is empty or null available when the Foreign Key has a "Custom Simple Type" 

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/creator/SearchFieldCreator.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/inputfield/creator/SearchFieldCreator.java
@@ -51,10 +51,10 @@ public class SearchFieldCreator {
             } else {
                 String keyPath = entityModel.getKeys()[0];
                 TypeModel keyTypeModel = entityModel.getTypeModel(keyPath);
-                boolean isString = DataTypeConstants.STRING.getTypeName().equals(keyTypeModel.getType().getTypeName());
-                boolean isAutoIncrement = DataTypeConstants.AUTO_INCREMENT.getTypeName()
-                        .equals(keyTypeModel.getType().getTypeName());
-                boolean isUUID = DataTypeConstants.UUID.getTypeName().equals(keyTypeModel.getType().getTypeName());
+                String baseTypeName = keyTypeModel.getType().getBaseTypeName();
+                boolean isString = DataTypeConstants.STRING.getTypeName().equals(baseTypeName);
+                boolean isAutoIncrement = DataTypeConstants.AUTO_INCREMENT.getTypeName().equals(baseTypeName);
+                boolean isUUID = DataTypeConstants.UUID.getTypeName().equals(baseTypeName);
                 if (isString || isAutoIncrement || isUUID) {
                     cons = OperatorConstants.stringOperators;
                     field = createForeignKeyField(typeModel, true);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14743

What is the current behavior? (You should also link to an open issue here)

Only 2 search operators : Is equal to / Is empty or null available when the Foreign Key has a "Custom Simple Type"

What is the new behavior?
For custom simple type , use its base type to add operators.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
