### PR TITLE
TMDM-14709 Deploy Data Model fails after Element removed : ORA-00904:"X_VERSION" : invalid identifier (7.1)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -18,8 +18,10 @@ import java.io.Writer;
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
@@ -223,7 +225,7 @@ public class LiquibaseSchemaAdapter  {
         Map<String, List<String>> dropColumnMap = new HashMap<>();
         Map<String, List<String>> dropFKMap = new HashMap<>();
         Map<String, List<String[]>> dropIndexMap = new HashMap<>();
-        List<String> dropTableList = new ArrayList<String>();
+        Set<String> dropTableSet = new HashSet<String>();
 
         for (RemoveChange removeAction : diffResults.getRemoveChanges()) {
 
@@ -258,7 +260,7 @@ public class LiquibaseSchemaAdapter  {
                 }
                 // Remove the table for 0-many simple field.
                 if (field.isMany()) {
-                    dropTableList.add(tableName + "_" + columnName);
+                    dropTableSet.add(tableResolver.getCollectionTableToDrop(field));
                 } else {
                     List<String> columnList = dropColumnMap.get(tableName);
                     if (columnList == null) {
@@ -296,7 +298,7 @@ public class LiquibaseSchemaAdapter  {
             }
         }
         
-        for (String tableName : dropTableList) {
+        for (String tableName : dropTableSet) {
             DropTableChange dropTableChange = new DropTableChange();
             dropTableChange.setTableName(tableName);
             changeActionList.add(dropTableChange);

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
@@ -132,6 +132,15 @@ class StorageTableResolver implements TableResolver {
         }
         return formatSQLName(get(field.getContainingType()) + '_' + field.getName());
     }
+    
+    @Override
+    public String getCollectionTableToDrop(FieldMetadata field) {
+        ComplexTypeMetadata typeMetadata = field.getContainingType();
+        if (field.getDeclaringType() instanceof ComplexTypeMetadata) {
+            typeMetadata = (ComplexTypeMetadata) field.getDeclaringType();
+        }
+        return formatSQLName(get(typeMetadata) + '_' + get(field));
+    }
 
     @Override
     public String getFkConstraintName(ReferenceFieldMetadata referenceField) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TableResolver.java
@@ -70,6 +70,14 @@ interface TableResolver {
      * @return A string that can be used as table name on the database.
      */
     String getCollectionTable(FieldMetadata field);
+    
+    /**
+     * Returns name for a table that can store a collection of values for drop.
+     * 
+     * @param field A many valued field.
+     * @return A string that can be used as table name on the database.
+     */
+    String getCollectionTableToDrop(FieldMetadata field);
 
     /**
      * @param referenceField A foreign key to generate in the database

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/ManyFieldCriterionTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/ManyFieldCriterionTest.java
@@ -137,6 +137,11 @@ public class ManyFieldCriterionTest extends TestCase {
             // TODO Auto-generated method stub
             return null;
         }
+
+		@Override
+		public String getCollectionTableToDrop(FieldMetadata field) {
+			return "product_collection";
+		}
     }
 
     private class CriteriaQueryForTest implements CriteriaQuery {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14709
What is the current behavior? (You should also link to an open issue here)

'View or Table doesn't exitst' when dropping table for 0-many simple field

What is the new behavior?

Table name is generated incorrectly before. use tableResolver#formatSQLName to generate correct table name to drop.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
