### PR TITLE
TMDM-14742 Throw error in server log when tMDMConnection  checked with parameter  'Use client side transaction id'

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/storage/task/staging/SerializableListWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/task/staging/SerializableListWriter.java
@@ -72,6 +72,13 @@ public class SerializableListWriter implements MessageBodyWriter<SerializableLis
             }
             bw.write("]}");
             bw.flush();
+        } else if (mediaType.equals(MediaType.APPLICATION_OCTET_STREAM_TYPE)) {
+            BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(outputStream));
+            for (Object string : strings) {
+                bw.write(String.valueOf(string));
+                bw.write(' ');
+            }
+            bw.flush();
         } else {
             throw new IllegalArgumentException("Media type: '" + mediaType.getType() + "' is not supported.");
         }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14742

**What is the current behavior?** (You should also link to an open issue here)

Throw error in server log when tMDMConnection  checked with parameter  'Use client side transaction id' :
`REST service exception java.lang.IllegalArgumentException: Media type: 'application' is not supported.`

**What is the new behavior?**

No need to throw this error for default media type.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
