### PR TITLE
TMDM-14795 Deleting a foreign key causes MDM to raise an exception (Oracle DB)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -217,25 +217,25 @@ public class LiquibaseSchemaAdapter  {
                 // Remove the table for 0-many field.
                 if (field.isMany()) {
                     dropTableSet.add(formatSQLName(tableResolver.getCollectionTableToDrop(field)));
-                } 
-                // Need remove the FK constraint first before remove a reference field.
-                // FK constraint only exists in master DB.
-                else if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {
-                    ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
-                    String fkName = tableResolver.getFkConstraintName(referenceField);
-                    if (fkName.isEmpty()) {
-                        List<Column> columns = new ArrayList<>();
-                        columns.add(new Column(columnName));
-                        fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
-                                new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
-                    }
-                    List<String> fkList = dropFKMap.get(tableName);
-                    if (fkList == null) {
-                        fkList = new ArrayList<String>();
-                    }
-                    fkList.add(formatSQLName(fkName));
-                    dropFKMap.put(tableName, fkList);
                 } else {
+                	// Need remove the FK constraint first before remove a reference field.
+                    // FK constraint only exists in master DB.
+                	if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {                
+	                    ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
+	                    String fkName = tableResolver.getFkConstraintName(referenceField);
+	                    if (fkName.isEmpty()) {
+	                        List<Column> columns = new ArrayList<>();
+	                        columns.add(new Column(columnName));
+	                        fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
+	                                new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
+	                    }
+	                    List<String> fkList = dropFKMap.get(tableName);
+	                    if (fkList == null) {
+	                        fkList = new ArrayList<String>();
+	                    }
+	                    fkList.add(formatSQLName(fkName));
+	                    dropFKMap.put(tableName, fkList);
+	                } 
                     List<String> columnList = dropColumnMap.get(tableName);
                     if (columnList == null) {
                         columnList = new ArrayList<String>();

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -217,9 +217,13 @@ public class LiquibaseSchemaAdapter  {
                 String tableName = getTableName(field);
                 String columnName = tableResolver.get(field);
 
+                // Remove the table for 0-many field.
+                if (field.isMany()) {
+                    dropTableSet.add(tableResolver.getCollectionTableToDrop(field));
+                } 
                 // Need remove the FK constraint first before remove a reference field.
                 // FK constraint only exists in master DB.
-                if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {
+                else if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {
                     ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
                     String fkName = tableResolver.getFkConstraintName(referenceField);
                     if (fkName.isEmpty()) {
@@ -237,10 +241,6 @@ public class LiquibaseSchemaAdapter  {
                     }
                     fkList.add(fkName);
                     dropFKMap.put(tableName, fkList);
-                }
-                // Remove the table for 0-many simple field.
-                if (field.isMany()) {
-                    dropTableSet.add(tableResolver.getCollectionTableToDrop(field));
                 } else {
                     List<String> columnList = dropColumnMap.get(tableName);
                     if (columnList == null) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -149,7 +149,7 @@ public class LiquibaseSchemaAdapter  {
 
     protected String getTableName(FieldMetadata field) {
         String tableName = tableResolver.get(field.getContainingType());
-        return formatSQLName(tableName);
+        return upperOrLowerCase(tableName);
     }
 
     protected List<AbstractChange> analyzeModifyChange(DiffResults diffResults) {
@@ -166,7 +166,7 @@ public class LiquibaseSchemaAdapter  {
                         dataSource.getDialectName(), defaultValueRule, StringUtils.EMPTY);
                 String tableName = getTableName(current);
                 String columnDataType = getColumnTypeName(current);
-                String columnName = formatSQLName(tableResolver.get(current));
+                String columnName = upperOrLowerCase(tableResolver.get(current));
 
                 if (current.isMandatory() && !previous.isMandatory() && !isModifyMinOccursForRepeatable(previous, current)) {
                     if (storageType == StorageType.MASTER) {
@@ -216,10 +216,10 @@ public class LiquibaseSchemaAdapter  {
 
                 // Remove the table for 0-many field.
                 if (field.isMany()) {
-                    dropTableSet.add(formatSQLName(tableResolver.getCollectionTableToDrop(field)));
+                    dropTableSet.add(upperOrLowerCase(tableResolver.getCollectionTableToDrop(field)));
                 } else {
                 	// Need remove the FK constraint first before remove a reference field.
-                    // FK constraint only exists in master DB.
+                	// FK constraint only exists in master DB.
                 	if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {                
 	                    ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
 	                    String fkName = tableResolver.getFkConstraintName(referenceField);
@@ -233,7 +233,7 @@ public class LiquibaseSchemaAdapter  {
 	                    if (fkList == null) {
 	                        fkList = new ArrayList<String>();
 	                    }
-	                    fkList.add(formatSQLName(fkName));
+	                    fkList.add(upperOrLowerCase(fkName));
 	                    dropFKMap.put(tableName, fkList);
 	                } 
                     List<String> columnList = dropColumnMap.get(tableName);
@@ -483,7 +483,7 @@ public class LiquibaseSchemaAdapter  {
         return columnDataType.equals("bit") || columnDataType.equals("boolean"); //$NON-NLS-1$ //$NON-NLS-2$
     }
     
-    protected String formatSQLName(String name) {
+    private String upperOrLowerCase(String name) {
     	if (HibernateStorageUtils.isOracle(dataSource.getDialectName())) {
     		return name.toUpperCase();
     	} else if (HibernateStorageUtils.isPostgres(dataSource.getDialectName())) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
 
@@ -105,12 +106,17 @@ class StorageTableResolver implements TableResolver {
             name = field.getName();
         } else {
             name = prefix + '_' + field.getName();
+        }                
+        name = name.replace('-', '_');
+        if (!StringUtils.startsWithIgnoreCase(name, STANDARD_PREFIX)) {
+        	name = STANDARD_PREFIX + name;
         }
-        String formattedName = formatSQLName(name.replace('-', '_'));
-        if (!formattedName.startsWith(STANDARD_PREFIX) && !formattedName.startsWith(STANDARD_PREFIX.toLowerCase())) {
-            return (STANDARD_PREFIX + formattedName).toLowerCase();
+        if (field instanceof ContainedTypeFieldMetadata) {
+        	name += "_x_talend_id"; //$NON-NLS-1$
+        } else if (field instanceof ReferenceFieldMetadata) {
+        	name += "_" + get(((ReferenceFieldMetadata) field).getReferencedField()); //$NON-NLS-1$
         }
-        return formattedName.toLowerCase();
+        return formatSQLName(name.toLowerCase());
     }
 
     @Override

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
@@ -147,7 +147,7 @@ class StorageTableResolver implements TableResolver {
         }
         if (field instanceof ReferenceFieldMetadata) {
             ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) field;
-            return formatSQLName(referenceField.getContainingType().getName() + "_X_" + referenceField.getName() + '_'
+            return formatSQLName(referenceField.getContainingType().getName() + "_x_" + referenceField.getName() + '_'
                     + referenceField.getReferencedType().getName());
         }
         return formatSQLName(get(typeMetadata) + '_' + get(field));

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
@@ -145,6 +145,11 @@ class StorageTableResolver implements TableResolver {
         if (field.getDeclaringType() instanceof ComplexTypeMetadata) {
             typeMetadata = (ComplexTypeMetadata) field.getDeclaringType();
         }
+        if (field instanceof ReferenceFieldMetadata) {
+            ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) field;
+            return formatSQLName(referenceField.getContainingType().getName() + "_X_" + referenceField.getName() + '_'
+                    + referenceField.getReferencedType().getName());
+        }
         return formatSQLName(get(typeMetadata) + '_' + get(field));
     }
 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14795

**What is the current behavior?** (You should also link to an open issue here)

In LiquibaseSchemaAdapter#getColumnName(), we didn't process the column name with formatSQLName().
When column name in getColumnName() for referencedField is longer than maxlength, it is incorrect without processed by formatSQLName().

**What is the new behavior?**
All table/column name using in database need be processed with StorageTableResolver#formatSQLName()


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
http://192.168.31.210:8080/view/7.0/job/7.0_03_TMDMEE_FOR-JIRA/35/
http://192.168.31.210:8080/job/7.0_MDM-REST-EE-MySQL8-CentOS/7/HTML_20Report/
http://192.168.31.210:8080/view/7.0/job/7.0_MDM-SOAP-EE-CentOS-MySQL8/9