### PR TITLE
TMDM-14795 Deleting a foreign key causes MDM to raise an exception (Oracle DB) (701)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -222,19 +222,22 @@ public class LiquibaseSchemaAdapter  {
                 	// FK constraint only exists in master DB.
                 	if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {                
 	                    ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
-	                    String fkName = tableResolver.getFkConstraintName(referenceField);
-	                    if (fkName.isEmpty()) {
-	                        List<Column> columns = new ArrayList<>();
-	                        columns.add(new Column(columnName));
-	                        fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
-	                                new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
-	                    }
-	                    List<String> fkList = dropFKMap.get(tableName);
-	                    if (fkList == null) {
-	                        fkList = new ArrayList<String>();
-	                    }
-	                    fkList.add(upperOrLowerCase(fkName));
-	                    dropFKMap.put(tableName, fkList);
+                        if (!(referenceField.getContainingType().equals(referenceField.getReferencedType())
+                                && HibernateStorageUtils.isOracle(dataSource.getDialectName()))) {
+                            String fkName = tableResolver.getFkConstraintName(referenceField);
+                            if (fkName.isEmpty()) {
+                                List<Column> columns = new ArrayList<>();
+                                columns.add(new Column(columnName));
+                                fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
+                                        new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
+                            }
+                            List<String> fkList = dropFKMap.get(tableName);
+                            if (fkList == null) {
+                                fkList = new ArrayList<String>();
+                            }
+                            fkList.add(upperOrLowerCase(fkName));
+                            dropFKMap.put(tableName, fkList);
+                        }
 	                } 
                     List<String> columnList = dropColumnMap.get(tableName);
                     if (columnList == null) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14795
What is the current behavior? (You should also link to an open issue here)

Delete 0-many fk field, redeploy failed.
We got incorrect table name by StorageTableResolver#getCollectionTableToDrop()
Deploy failed when deleting a fk field refer to itself on oracle

What is the new behavior?
Process fk field name by "_x_"+ referenceField.getName().replace('-', '_').toLowerCase()
Then we can got correct table for 0-many fk fields to drop.
For 0-many field in inheritance type, if the field is from super type need generate table name according to super type.
No fk constraint for fk field refer to itself on oracle.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
