### PR TITLE
TMDM-14795 Deleting a foreign key causes MDM to raise an exception (Oracle DB)(7.1)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -228,19 +228,22 @@ public class LiquibaseSchemaAdapter  {
                 	// FK constraint only exists in master DB.
                 	if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {                
 	                    ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
-	                    String fkName = tableResolver.getFkConstraintName(referenceField);
-	                    if (fkName.isEmpty()) {
-	                        List<Column> columns = new ArrayList<>();
-	                        columns.add(new Column(columnName));
-	                        fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
-	                                new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
-	                    }
-	                    List<String> fkList = dropFKMap.get(tableName);
-	                    if (fkList == null) {
-	                        fkList = new ArrayList<String>();
-	                    }
-	                    fkList.add(upperOrLowerCase(fkName));
-	                    dropFKMap.put(tableName, fkList);
+                        if (!(referenceField.getContainingType().equals(referenceField.getReferencedType())
+                                && HibernateStorageUtils.isOracle(dataSource.getDialectName()))) {
+                            String fkName = tableResolver.getFkConstraintName(referenceField);
+                            if (fkName.isEmpty()) {
+                                List<Column> columns = new ArrayList<>();
+                                columns.add(new Column(columnName));
+                                fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
+                                        new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
+                            }
+                            List<String> fkList = dropFKMap.get(tableName);
+                            if (fkList == null) {
+                                fkList = new ArrayList<String>();
+                            }
+                            fkList.add(upperOrLowerCase(fkName));
+                            dropFKMap.put(tableName, fkList);
+                        }
 	                } 
                     List<String> columnList = dropColumnMap.get(tableName);
                     if (columnList == null) {

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -149,24 +149,7 @@ public class LiquibaseSchemaAdapter  {
 
     protected String getTableName(FieldMetadata field) {
         String tableName = tableResolver.get(field.getContainingType());
-        if (dataSource.getDialectName() == DataSourceDialect.POSTGRES) {
-            tableName = tableName.toLowerCase();
-        }
-        return tableName;
-    }
-
-    private String getColumnName(FieldMetadata field) {
-        String columnName = tableResolver.get(field);
-        if (field instanceof ContainedTypeFieldMetadata) {
-            columnName += "_x_talend_id"; //$NON-NLS-1$
-        }
-        if (field instanceof ReferenceFieldMetadata) {
-            columnName += "_" + tableResolver.get(((ReferenceFieldMetadata) field).getReferencedField()); //$NON-NLS-1$
-        }
-        if (HibernateStorageUtils.isOracle(dataSource.getDialectName())) {
-            columnName = columnName.toUpperCase();
-        }
-        return columnName;
+        return upperOrLowerCase(tableName);
     }
 
     protected List<AbstractChange> analyzeModifyChange(DiffResults diffResults) {
@@ -189,7 +172,7 @@ public class LiquibaseSchemaAdapter  {
                         dataSource.getDialectName(), defaultValueRule, StringUtils.EMPTY);
                 String tableName = getTableName(current);
                 String columnDataType = getColumnTypeName(current);
-                String columnName = getColumnName(current);
+                String columnName = upperOrLowerCase(tableResolver.get(current));
 
                 if (current.isMandatory() && !previous.isMandatory() && !isModifyMinOccursForRepeatable(previous, current)) {
                     if (storageType == StorageType.MASTER) {
@@ -235,33 +218,30 @@ public class LiquibaseSchemaAdapter  {
                 FieldMetadata field = (FieldMetadata) element;
 
                 String tableName = getTableName(field);
-                String columnName = getColumnName(field);
+                String columnName = tableResolver.get(field);
 
-                // Need remove the FK constraint first before remove a reference field.
-                // FK constraint only exists in master DB.
-                if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {
-                    ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
-                    String fkName = tableResolver.getFkConstraintName(referenceField);
-                    if (fkName.isEmpty()) {
-                        List<Column> columns = new ArrayList<>();
-                        columns.add(new Column(columnName.toLowerCase()));
-                        fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
-                                new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
-                        if (HibernateStorageUtils.isPostgres(dataSource.getDialectName())) {
-                            fkName = fkName.toLowerCase();
-                        }
-                    }
-                    List<String> fkList = dropFKMap.get(tableName);
-                    if (fkList == null) {
-                        fkList = new ArrayList<String>();
-                    }
-                    fkList.add(fkName);
-                    dropFKMap.put(tableName, fkList);
-                }
-                // Remove the table for 0-many simple field.
+                // Remove the table for 0-many field.
                 if (field.isMany()) {
-                    dropTableSet.add(tableResolver.getCollectionTableToDrop(field));
+                    dropTableSet.add(upperOrLowerCase(tableResolver.getCollectionTableToDrop(field)));
                 } else {
+                	// Need remove the FK constraint first before remove a reference field.
+                	// FK constraint only exists in master DB.
+                	if (element instanceof ReferenceFieldMetadata && storageType == StorageType.MASTER) {                
+	                    ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) element;
+	                    String fkName = tableResolver.getFkConstraintName(referenceField);
+	                    if (fkName.isEmpty()) {
+	                        List<Column> columns = new ArrayList<>();
+	                        columns.add(new Column(columnName));
+	                        fkName = Constraint.generateName(new ForeignKey().generatedConstraintNamePrefix(),
+	                                new Table(tableResolver.get(field.getContainingType().getEntity())), columns);
+	                    }
+	                    List<String> fkList = dropFKMap.get(tableName);
+	                    if (fkList == null) {
+	                        fkList = new ArrayList<String>();
+	                    }
+	                    fkList.add(upperOrLowerCase(fkName));
+	                    dropFKMap.put(tableName, fkList);
+	                } 
                     List<String> columnList = dropColumnMap.get(tableName);
                     if (columnList == null) {
                         columnList = new ArrayList<String>();
@@ -511,5 +491,14 @@ public class LiquibaseSchemaAdapter  {
 
     protected boolean isBooleanType(String columnDataType) {
         return columnDataType.equals("bit") || columnDataType.equals("boolean"); //$NON-NLS-1$ //$NON-NLS-2$
+    }
+    
+    private String upperOrLowerCase(String name) {
+    	if (HibernateStorageUtils.isOracle(dataSource.getDialectName())) {
+    		return name.toUpperCase();
+    	} else if (HibernateStorageUtils.isPostgres(dataSource.getDialectName())) {
+    		return name.toLowerCase();
+    	}
+    	return name;
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
 
@@ -105,12 +106,17 @@ class StorageTableResolver implements TableResolver {
             name = field.getName();
         } else {
             name = prefix + '_' + field.getName();
+        }                
+        name = name.replace('-', '_');
+        if (!StringUtils.startsWithIgnoreCase(name, STANDARD_PREFIX)) {
+        	name = STANDARD_PREFIX + name;
         }
-        String formattedName = formatSQLName(name.replace('-', '_'));
-        if (!formattedName.startsWith(STANDARD_PREFIX) && !formattedName.startsWith(STANDARD_PREFIX.toLowerCase())) {
-            return (STANDARD_PREFIX + formattedName).toLowerCase();
+        if (field instanceof ContainedTypeFieldMetadata) {
+        	name += "_x_talend_id"; //$NON-NLS-1$
+        } else if (field instanceof ReferenceFieldMetadata) {
+        	name += "_" + get(((ReferenceFieldMetadata) field).getReferencedField()); //$NON-NLS-1$
         }
-        return formattedName.toLowerCase();
+        return formatSQLName(name.toLowerCase());
     }
 
     @Override
@@ -138,6 +144,11 @@ class StorageTableResolver implements TableResolver {
         ComplexTypeMetadata typeMetadata = field.getContainingType();
         if (field.getDeclaringType() instanceof ComplexTypeMetadata) {
             typeMetadata = (ComplexTypeMetadata) field.getDeclaringType();
+        }
+        if (field instanceof ReferenceFieldMetadata) {
+            ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) field;
+            return formatSQLName(referenceField.getContainingType().getName() + "_x_" + referenceField.getName() + '_'
+                    + referenceField.getReferencedType().getName());
         }
         return formatSQLName(get(typeMetadata) + '_' + get(field));
     }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14795
What is the current behavior? (You should also link to an open issue here)
Remove a field for the cases below for medium change, redeploy failed.

1. 0-many fk field
2. Entityname + fieldname is longer than 30 on oracle
3. Field on inheritance type
We got incorrect table name or fk name to drop.

What is the new behavior?
Process fk field name by "x"+ referenceField.getName().replace('-', '_').toLowerCase()
Then we can got correct table for 0-many fk fields to drop.
For 0-many field in inheritance type, if the field is from super type need generate table name according to super type.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
http://192.168.31.210:8080/view/7.1/job/7.1_03_TMDMEE_FOR-JIRA/106/
http://192.168.31.210:8080/view/7.1/job/7.1_MDM-REST-EE-MySQL8-CentOS/12/HTML_20Report/
http://192.168.31.210:8080/view/7.1/job/7.1_MDM-SOAP-EE-CentOS-MySQL8/8/