### PR TITLE
TMDM-14795 Deleting a foreign key causes MDM to raise an exception (Oracle DB)(651) 

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/datasource/RDBMSDataSource.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/datasource/RDBMSDataSource.java
@@ -12,6 +12,7 @@ package com.amalto.core.storage.datasource;
 
 import java.net.URI;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
@@ -399,6 +400,16 @@ public class RDBMSDataSource implements DataSource {
 
     public Map<String, String> getAdvancedProperties() {
         return advancedProperties;
+    }
+
+    public Properties getAdvancedPropertiesIncludeUserInfo() {
+        Properties properties = new Properties();
+        for (Map.Entry<String, String> entry : advancedProperties.entrySet()) {
+            properties.setProperty(entry.getKey(), entry.getValue());
+        }
+        properties.setProperty("user", this.getUserName()); // $NON-NLS-1
+        properties.setProperty("password", this.getPassword()); // $NON-NLS-1
+        return properties;
     }
 
     /**

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -329,7 +329,8 @@ public class HibernateStorage implements Storage {
 
                     if ( table == null ) {
                         table = new MDMTable();
-                        table.setAbstract( isAbstract );
+                        ((MDMTable) table).setDataSource(dataSource);
+                        table.setAbstract(isAbstract);
                         table.setName( name );
                         table.setSchema( schema );
                         table.setCatalog( catalog );
@@ -374,6 +375,9 @@ public class HibernateStorage implements Storage {
                             return indexes.iterator();
                         }
                     };
+                    if (table instanceof MDMTable) {
+                        ((MDMTable) table).setDataSource(dataSource);
+                    }
                     table.setAbstract(isAbstract);
                     table.setName(name);
                     table.setSchema(schema);

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapter.java
@@ -160,7 +160,8 @@ public class LiquibaseSchemaAdapter  {
                 FieldMetadata current = (FieldMetadata) modifyAction.getCurrent();
 
                 String defaultValueRule = current.getData(MetadataRepository.DEFAULT_VALUE_RULE);
-                defaultValueRule = HibernateStorageUtils.convertedDefaultValue(dataSource.getDialectName(), defaultValueRule, StringUtils.EMPTY);
+                defaultValueRule = HibernateStorageUtils.convertedDefaultValue(current.getType().getName(),
+                        dataSource.getDialectName(), defaultValueRule, StringUtils.EMPTY);
                 String tableName = getTableName(current);
                 String columnDataType = getColumnTypeName(current);
                 String columnName = upperOrLowerCase(tableResolver.get(current));

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/MappingGenerator.java
@@ -661,9 +661,15 @@ public class MappingGenerator extends DefaultMetadataVisitor<Element> {
         // default value
         String defaultValueRule = field.getData(MetadataRepository.DEFAULT_VALUE_RULE);
         if (StringUtils.isNotBlank(defaultValueRule)) {
+
             Attr defaultValueAttr = document.createAttribute("default"); //$NON-NLS-1$
-            defaultValueAttr.setValue(HibernateStorageUtils.convertedDefaultValue(dataSource.getDialectName(), defaultValueRule, "'"));
-            columnElement.getAttributes().setNamedItem(defaultValueAttr);
+
+            if (!field.getType().getName().equals(TypeMapping.SQL_TYPE_BOOLEAN)
+                    || HibernateStorageUtils.isBooleanDefaultValue(field.getType().getName(), defaultValueRule.trim())) {
+                defaultValueAttr.setValue(HibernateStorageUtils.convertedDefaultValue(field.getType().getName(),
+                        dataSource.getDialectName(), defaultValueRule.trim(), "'"));
+                columnElement.getAttributes().setNamedItem(defaultValueAttr);
+            }
         }
     }
 

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StorageTableResolver.java
@@ -25,8 +25,10 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
+import org.talend.mdm.commmon.metadata.ContainedTypeFieldMetadata;
 import org.talend.mdm.commmon.metadata.FieldMetadata;
 import org.talend.mdm.commmon.metadata.ReferenceFieldMetadata;
+import org.talend.mdm.commmon.metadata.TypeMetadata;
 
 class StorageTableResolver implements TableResolver {
 
@@ -105,12 +107,17 @@ class StorageTableResolver implements TableResolver {
             name = field.getName();
         } else {
             name = prefix + '_' + field.getName();
+        }                
+        name = name.replace('-', '_');
+        if (!StringUtils.startsWithIgnoreCase(name, STANDARD_PREFIX)) {
+        	name = STANDARD_PREFIX + name;
         }
-        String formattedName = formatSQLName(name.replace('-', '_'));
-        if (!formattedName.startsWith(STANDARD_PREFIX) && !formattedName.startsWith(STANDARD_PREFIX.toLowerCase())) {
-            return (STANDARD_PREFIX + formattedName).toLowerCase();
+        if (field instanceof ContainedTypeFieldMetadata) {
+        	name += "_x_talend_id"; //$NON-NLS-1$
+        } else if (field instanceof ReferenceFieldMetadata) {
+        	name += "_" + get(((ReferenceFieldMetadata) field).getReferencedField()); //$NON-NLS-1$
         }
-        return formattedName.toLowerCase();
+        return formatSQLName(name.toLowerCase());
     }
 
     @Override
@@ -132,15 +139,32 @@ class StorageTableResolver implements TableResolver {
         }
         return formatSQLName(get(field.getContainingType()) + '_' + field.getName());
     }
+    
+    @Override
+    public String getCollectionTableToDrop(FieldMetadata field) {
+        ComplexTypeMetadata typeMetadata = field.getContainingType();
+        for (TypeMetadata superType : field.getContainingType().getSuperTypes()) {
+            if (((ComplexTypeMetadata) superType).hasField(field.getName())) {
+                typeMetadata = (ComplexTypeMetadata) superType;
+            }
+        }
+        if (field instanceof ReferenceFieldMetadata) {
+            ReferenceFieldMetadata referenceField = (ReferenceFieldMetadata) field;
+            return formatSQLName(typeMetadata.getName() + "_" + convertFieldName(referenceField.getName()) + '_'
+                    + referenceField.getReferencedType().getName());
+        }
+        return formatSQLName(get(typeMetadata) + '_' + get(field));
+    }
 
     @Override
     public String getFkConstraintName(ReferenceFieldMetadata referenceField) {
+        // TMDM-10993 use the field's XPath to generate fkname
+        String name = getXpath(referenceField, convertFieldName(referenceField.getName()));
         // TMDM-6896 Uses containing type length since FK collision issues happens when same FK is contained in a type
-        // with same
-        // length but different name.
-        if (!referenceFieldNames.add(referenceField.getContainingType().getName().length() + '_' + referenceField.getName())) {
-            // TMDM-10993 use the field's XPath to generate fkname
-            String name = getXpath(referenceField, referenceField.getName());
+        // with same length but different name.
+        if (!referenceFieldNames.add(referenceField.getContainingType().getName().length() + '_' + referenceField.getName())
+                || referenceFieldNames.contains(name)) {
+            referenceFieldNames.add(name);
             return formatSQLName("FK_" + Math.abs(name.hashCode()));
         } else {
             return StringUtils.EMPTY;
@@ -215,5 +239,12 @@ class StorageTableResolver implements TableResolver {
                     + new String(ArrayUtils.subarray(chars, threshold / 2, chars.length)).hashCode();
             return __shortString(s.toCharArray(), threshold);
         }
+    }
+
+    private String convertFieldName(String fieldName) {
+        if (!fieldName.startsWith("x_")) {
+            return "x_" + fieldName.replace('-', '_').toLowerCase();
+        }
+        return fieldName;
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TableResolver.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TableResolver.java
@@ -70,6 +70,14 @@ interface TableResolver {
      * @return A string that can be used as table name on the database.
      */
     String getCollectionTable(FieldMetadata field);
+    
+    /**
+     * Returns name for a table that can store a collection of values for drop.
+     * 
+     * @param field A many valued field.
+     * @return A string that can be used as table name on the database.
+     */
+    String getCollectionTableToDrop(FieldMetadata field);
 
     /**
      * @param referenceField A foreign key to generate in the database

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TypeMapping.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/TypeMapping.java
@@ -50,6 +50,8 @@ public abstract class TypeMapping {
     
     public static final String SQL_TYPE_TEXT = "text"; //$NON-NLS-1$
 
+    public static final String SQL_TYPE_BOOLEAN = "boolean"; //$NON-NLS-1$
+
     /**
      * Used to hold how many times a reusable type is reused within data model (may help to decide whether constrains
      * should be generated).

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/mapping/MDMTable.java
@@ -10,13 +10,21 @@
 
 package com.amalto.core.storage.hibernate.mapping;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Properties;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.hibernate.HibernateException;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.MySQLDialect;
 import org.hibernate.dialect.PostgreSQLDialect;
 import org.hibernate.dialect.SQLServerDialect;
 import org.hibernate.engine.spi.Mapping;
@@ -27,17 +35,113 @@ import org.hibernate.mapping.UniqueKey;
 import org.hibernate.tool.hbm2ddl.ColumnMetadata;
 import org.hibernate.tool.hbm2ddl.TableMetadata;
 
-@SuppressWarnings("nls")
+import com.amalto.core.storage.datasource.RDBMSDataSource;
+import com.amalto.core.storage.hibernate.OracleCustomDialect;
+
+@SuppressWarnings({ "nls", "rawtypes", "deprecation", "serial", "unchecked" })
 public class MDMTable extends Table {
 
+    private static final String LONGTEXT = "longtext";
+
+    protected RDBMSDataSource dataSource;
+
     private static final Logger LOGGER = Logger.getLogger(MDMTable.class);
+
+    @Override
+    public String sqlCreateString(Dialect dialect, Mapping p, String defaultCatalog, String defaultSchema) {
+        StringBuilder buf = new StringBuilder(hasPrimaryKey() ? dialect.getCreateTableString()
+                : dialect.getCreateMultisetTableString()).append(' ')
+                .append(getQualifiedName(dialect, defaultCatalog, defaultSchema)).append(" (");
+
+        boolean identityColumn = getIdentifierValue() != null
+                && getIdentifierValue().isIdentityColumn(p.getIdentifierGeneratorFactory(), dialect);
+
+        // Try to find out the name of the primary key to create it as identity if the IdentityGenerator is used
+        String pkname = null;
+        if (hasPrimaryKey() && identityColumn) {
+            pkname = ((Column) getPrimaryKey().getColumnIterator().next()).getQuotedName(dialect);
+        }
+
+        Iterator iter = getColumnIterator();
+        while (iter.hasNext()) {
+            Column col = (Column) iter.next();
+
+            buf.append(col.getQuotedName(dialect)).append(' ');
+
+            if (identityColumn && col.getQuotedName(dialect).equals(pkname)) {
+                // to support dialects that have their own identity data type
+                if (dialect.hasDataTypeInIdentityColumn()) {
+                    buf.append(col.getSqlType(dialect, p));
+                }
+                buf.append(' ').append(dialect.getIdentityColumnString(col.getSqlTypeCode(p)));
+            } else {
+                String sqlType = col.getSqlType(dialect, p);
+                buf.append(sqlType);
+
+                String defaultValue = col.getDefaultValue();
+                buf.append(convertDefaultValue(dialect, sqlType, defaultValue));
+
+                if (col.isNullable()) {
+                    buf.append(dialect.getNullColumnString());
+                } else {
+                    buf.append(" not null");
+                }
+
+            }
+
+            if (col.isUnique()) {
+                String keyName = Constraint.generateName("UK_", this, col);
+                UniqueKey uk = getOrCreateUniqueKey(keyName);
+                uk.addColumn(col);
+                buf.append(dialect.getUniqueDelegate().getColumnDefinitionUniquenessFragment(col));
+            }
+
+            if (col.hasCheckConstraint() && dialect.supportsColumnCheck()) {
+                buf.append(" check (").append(col.getCheckConstraint()).append(')');
+            }
+
+            String columnComment = col.getComment();
+            if (columnComment != null) {
+                buf.append(dialect.getColumnComment(columnComment));
+            }
+
+            if (iter.hasNext()) {
+                buf.append(", ");
+            }
+
+        }
+        if (hasPrimaryKey()) {
+            buf.append(", ").append(getPrimaryKey().sqlConstraintString(dialect));
+        }
+
+        buf.append(dialect.getUniqueDelegate().getTableCreationUniqueConstraintsFragment(this));
+
+        if (dialect.supportsTableCheck()) {
+            Iterator chiter = getCheckConstraintsIterator();
+            while (chiter.hasNext()) {
+                buf.append(", check (").append(chiter.next()).append(')');
+            }
+        }
+
+        buf.append(')');
+
+        if (getComment() != null) {
+            buf.append(dialect.getTableComment(getComment()));
+        }
+
+        String createSQL = buf.append(dialect.getTableTypeString()).toString();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(createSQL);
+        }
+        return createSQL;
+    }
 
     @Override
     public Iterator sqlAlterStrings(Dialect dialect, Mapping p, TableMetadata tableInfo, String defaultCatalog,
             String defaultSchema) throws HibernateException {
 
-        StringBuilder root = new StringBuilder("alter table ").append(getQualifiedName(dialect, defaultCatalog, defaultSchema))
-                .append(' ');
+        String tableName = getQualifiedName(dialect, defaultCatalog, defaultSchema);
+        StringBuilder root = new StringBuilder("alter table ").append(tableName).append(' ');
 
         Iterator iter = getColumnIterator();
         List results = new ArrayList();
@@ -47,15 +151,15 @@ public class MDMTable extends Table {
 
             ColumnMetadata columnInfo = tableInfo.getColumnMetadata(column.getName());
 
+            String sqlType = column.getSqlType(dialect, p);
+            String defaultValue = column.getDefaultValue();
+            String columnName = column.getQuotedName(dialect);
             if (columnInfo == null) {
                 // the column doesnt exist at all.
                 StringBuilder alter = new StringBuilder(root.toString()).append(dialect.getAddColumnString()).append(' ')
-                        .append(column.getQuotedName(dialect)).append(' ').append(column.getSqlType(dialect, p));
+                        .append(columnName).append(' ').append(sqlType);
 
-                String defaultValue = column.getDefaultValue();
-                if (defaultValue != null) {
-                    alter.append(" default ").append(defaultValue);
-                }
+                alter.append(convertDefaultValue(dialect, sqlType, defaultValue));
 
                 if (column.isNullable()) {
                     alter.append(dialect.getNullColumnString());
@@ -71,7 +175,7 @@ public class MDMTable extends Table {
                 }
 
                 if (column.hasCheckConstraint() && dialect.supportsColumnCheck()) {
-                    alter.append(" check(").append(column.getCheckConstraint()).append(")");
+                    alter.append(" check(").append(column.getCheckConstraint()).append(')');
                 }
 
                 String columnComment = column.getComment();
@@ -81,32 +185,32 @@ public class MDMTable extends Table {
 
                 alter.append(dialect.getAddColumnSuffixString());
 
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(alter.toString());
+                }
                 results.add(alter.toString());
             } else if (MDMTableUtils.isAlterColumnField(column, columnInfo, dialect)) {
                 StringBuilder alter = new StringBuilder(root.toString());
 
                 if (dialect instanceof SQLServerDialect || dialect instanceof PostgreSQLDialect) {
-                    alter.append(" ").append("alter COLUMN").append(" ");
+                    alter.append(" ALTER COLUMN ");
                 } else {
-                    alter.append(" ").append("modify").append(" ");
+                    alter.append(" MODIFY ");
                 }
-                alter.append(" ").append(column.getQuotedName(dialect)).append(" ");
+                alter.append(' ').append(columnName).append(' ');
 
                 if (dialect instanceof PostgreSQLDialect) {
-                    alter.append("TYPE").append(" ");
+                    alter.append("TYPE ");
                 }
 
-                alter.append(column.getSqlType(dialect, p));
+                alter.append(sqlType);
 
-                String defaultValue = column.getDefaultValue();
-                if (defaultValue != null) {
-                    alter.append(" default ").append(defaultValue);
-                }
+                alter.append(convertDefaultValue(dialect, sqlType, defaultValue));
 
                 if (column.isNullable()) {
                     alter.append(dialect.getNullColumnString());
                 } else {
-                    alter.append(" not null");
+                    alter.append(" not null ");
                 }
 
                 if (column.isUnique()) {
@@ -117,7 +221,7 @@ public class MDMTable extends Table {
                 }
 
                 if (column.hasCheckConstraint() && dialect.supportsColumnCheck()) {
-                    alter.append(" check(").append(column.getCheckConstraint()).append(")");
+                    alter.append(" check(").append(column.getCheckConstraint()).append(')');
                 }
 
                 String columnComment = column.getComment();
@@ -127,11 +231,82 @@ public class MDMTable extends Table {
 
                 alter.append(dialect.getAddColumnSuffixString());
 
-                LOGGER.debug(alter.toString());
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(alter.toString());
+                }
+                results.add(alter.toString());
+            } else if (StringUtils.isNotBlank(defaultValue)) {
+                StringBuilder alter = new StringBuilder(root.toString());
+                if (dialect instanceof OracleCustomDialect) {
+                    alter.append(" MODIFY ").append(columnName).append(" DEFAULT ").append(defaultValue);
+                } else if (dialect instanceof SQLServerDialect) {
+                    String alterDropConstraintSQL = generateAlterDefaultValueConstraintSQL(tableName, columnName);
+                    results.add(alterDropConstraintSQL);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug(alterDropConstraintSQL);
+                    }
+                    alter.append("  ADD DEFAULT ").append(defaultValue).append(" FOR ").append(columnName);
+                } else {
+                    if (isDefaultValueNeeded(sqlType, dialect)) {
+                        alter.append(" ALTER COLUMN ").append(columnName).append(" SET DEFAULT ").append(defaultValue);
+                    }
+                }
+                alter.append(dialect.getAddColumnSuffixString());
+
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug(alter.toString());
+                }
                 results.add(alter.toString());
             }
-
         }
         return results.iterator();
+    }
+
+    private String generateAlterDefaultValueConstraintSQL(String tableName, String columnName) {
+        Connection connection = null;
+        PreparedStatement statement = null;
+        String alterDropConstraintSQL = StringUtils.EMPTY;
+        try {
+            Properties properties = dataSource.getAdvancedPropertiesIncludeUserInfo();
+            connection = DriverManager.getConnection(dataSource.getConnectionURL(), properties);
+            String sql = "select c.name from sysconstraints a inner join syscolumns b on a.colid=b.colid inner join sysobjects c on a.constid=c.id "
+                    + "where a.id=object_id(?) and b.name=?";
+            statement = connection.prepareStatement(sql);
+            statement.setString(1, tableName);
+            statement.setString(2, columnName);
+            ResultSet rs = statement.executeQuery();
+            while (rs.next()) {
+                alterDropConstraintSQL = "alter table " + tableName + " drop constraint " + rs.getString(1);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Fetching SQLServer default value constraint failed.", e);
+        } finally {
+            try {
+                statement.close();
+                connection.close();
+            } catch (SQLException e) {
+                LOGGER.error("Unexpected error when closing connection.", e);
+            }
+        }
+        return alterDropConstraintSQL;
+    }
+
+    private String convertDefaultValue(Dialect dialect, String sqlType, String defaultValue) {
+        String defaultSQL = StringUtils.EMPTY;
+        if (StringUtils.isNotBlank(defaultValue) && isDefaultValueNeeded(sqlType, dialect)) {
+            defaultSQL = " DEFAULT " + defaultValue;
+        }
+        return defaultSQL;
+    }
+
+    public static boolean isDefaultValueNeeded(String sqlType, Dialect dialect) {
+        if (LONGTEXT.equals(sqlType) && dialect instanceof MySQLDialect) {
+            return false;
+        }
+        return true;
+    }
+
+    public void setDataSource(RDBMSDataSource dataSource) {
+        this.dataSource = dataSource;
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/HibernateStorageUtilsTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/HibernateStorageUtilsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+ *
+ * This source code is available under agreement available at
+ * %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+ *
+ * You should have received a copy of the agreement along with this program; if not, write to Talend SA 9 rue Pages
+ * 92150 Suresnes, France
+ */
+package com.amalto.core.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.amalto.core.storage.datasource.RDBMSDataSource.DataSourceDialect;
+
+
+public class HibernateStorageUtilsTest {
+
+    @Test
+    public void testConvertedDefaultValue() {
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "\"true\"", "'"));
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "\"true\"", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "\"true\"", "'"));
+
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "fn:true()", "'"));
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "fn:true()", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "fn:true()", "'"));
+
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "'true'", "'"));
+        assertEquals("true", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "'true'", "'"));
+        assertEquals("1", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "'true'", "'"));
+
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "\"false\"", "'"));
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "\"false\"", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "\"false\"", "'"));
+
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "'false'", "'"));
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "'false'", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "'false'", "'"));
+
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.H2, "fn:false()", "'"));
+        assertEquals("false", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.POSTGRES, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.SQL_SERVER, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.MYSQL, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.ORACLE_10G, "fn:false()", "'"));
+        assertEquals("0", HibernateStorageUtils.convertedDefaultValue("boolean", DataSourceDialect.DB2, "fn:false()", "'"));
+
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.H2, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.POSTGRES, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.SQL_SERVER, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.MYSQL, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.ORACLE_10G, "\"[En:*]\"", "'"));
+        assertEquals("'[En:*]'", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.DB2, "\"[En:*]\"", "'"));
+
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.H2, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.POSTGRES, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.SQL_SERVER, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.MYSQL, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.ORACLE_10G, "100", "'"));
+        assertEquals("100", HibernateStorageUtils.convertedDefaultValue("string", DataSourceDialect.DB2, "100", "'"));
+    }
+
+    @Test
+    public void testIsBooleanDefaultValue() throws Exception {
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "fn:false()"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "fn:true()"));
+        assertFalse(HibernateStorageUtils.isBooleanDefaultValue("boolean", "1"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "'true'"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("boolean", "'false'"));
+
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"true\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("\"false\""));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("fn:false()"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("fn:true()"));
+        assertFalse(HibernateStorageUtils.isBooleanDefaultValue("1"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("'true'"));
+        assertTrue(HibernateStorageUtils.isBooleanDefaultValue("'false'"));
+    }
+}

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/adapt/StorageAdaptTest.java
@@ -27,8 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import junit.framework.TestCase;
-
 import org.apache.log4j.Logger;
 import org.h2.jdbc.JdbcSQLException;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
@@ -51,6 +49,8 @@ import com.amalto.core.storage.hibernate.LiquibaseSchemaAdapter;
 import com.amalto.core.storage.record.DataRecord;
 import com.amalto.core.storage.record.DataRecordReader;
 import com.amalto.core.storage.record.XmlStringDataRecordReader;
+
+import junit.framework.TestCase;
 
 @SuppressWarnings("nls")
 public class StorageAdaptTest extends TestCase {
@@ -1919,9 +1919,10 @@ public class StorageAdaptTest extends TestCase {
         storage.init(dataSource);
         String[] typeNames = { "Person" };
         String[] tables = { "Person" };
-        String[] columns = { "", "X_ID", "X_BB_X_TALEND_ID", "X_EE", "X_UU_X_TALEND_ID", "X_TALEND_TIMESTAMP", "X_TALEND_TASK_ID" };
+        String[] columns = { "", "X_ID", "X_BB_X_TALEND_ID", "X_EE", "X_UU_X_TALEND_ID", "X_ADDRESS_X_ADDRESSID",
+                "X_TALEND_TIMESTAMP", "X_TALEND_TASK_ID" };
 
-        int[] isNullable = { 0, 0, 0, 0, 0, 0, 1 };
+        int[] isNullable = { 0, 0, 0, 0, 0, 1, 0, 1 };
         DataRecordReader<String> factory = new XmlStringDataRecordReader();
         MetadataRepository repository1 = new MetadataRepository();
         repository1.load(StorageAdaptTest.class.getResourceAsStream("../hibernate/schema2_1.xsd"));
@@ -1941,9 +1942,11 @@ public class StorageAdaptTest extends TestCase {
             assertNull(e2);
         }
 
+        String[] columnsUpdated = { "", "X_ID", "X_BB_X_TALEND_ID", "X_EE", "X_UU_X_TALEND_ID", "X_TALEND_TIMESTAMP",
+                "X_TALEND_TASK_ID" };
         int[] isNullableUpdated = { 0, 0, 1, 1, 1, 0, 1 };
         try {
-            assertColumnNullAble(dataSource, tables, columns, isNullableUpdated);
+            assertColumnNullAble(dataSource, tables, columnsUpdated, isNullableUpdated);
         } catch (SQLException e) {
             assertNull(e);
         }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
@@ -164,9 +164,8 @@ public class LiquibaseSchemaAdapterTest {
         updated2.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_2.xsd")); //$NON-NLS-1$
         Compare.DiffResults diffResults = Compare.compare(original, updated2);
 
-        assertEquals(7, diffResults.getActions().size());
+        assertEquals(8, diffResults.getActions().size());
         assertEquals(7, diffResults.getModifyChanges().size());
-        assertEquals(0, diffResults.getRemoveChanges().size());
         assertEquals(0, diffResults.getAddChanges().size());
 
         List<AbstractChange> changeList = adapter.analyzeModifyChange(diffResults);
@@ -179,6 +178,23 @@ public class LiquibaseSchemaAdapterTest {
         assertEquals("x_bb_x_talend_id", ((DropNotNullConstraintChange) changeList.get(0)).getColumnName());
         assertEquals("x_ee", ((DropNotNullConstraintChange) changeList.get(1)).getColumnName());
         assertEquals("x_uu_x_talend_id", ((DropNotNullConstraintChange) changeList.get(2)).getColumnName());
+    }
+
+    @Test
+    public void testAnalyzeRemoveChange_FK() throws Exception {
+        MetadataRepository original = new MetadataRepository();
+        original.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_1.xsd")); //$NON-NLS-1$
+        original = original.copy();
+        MetadataRepository updated2 = new MetadataRepository();
+        updated2.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_2.xsd")); //$NON-NLS-1$
+
+        Compare.DiffResults diffResults = Compare.compare(original, updated2);
+        assertEquals(1, diffResults.getRemoveChanges().size());
+
+        List<AbstractChange> removeChangeList = adapter.analyzeRemoveChange(diffResults);
+        assertEquals(2, removeChangeList.size());
+        assertEquals("liquibase.change.core.DropForeignKeyConstraintChange", removeChangeList.get(0).getClass().getName());
+        assertEquals("liquibase.change.core.DropColumnChange", removeChangeList.get(1).getClass().getName());
     }
 
     @Test

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/LiquibaseSchemaAdapterTest.java
@@ -165,7 +165,7 @@ public class LiquibaseSchemaAdapterTest {
         Compare.DiffResults diffResults = Compare.compare(original, updated2);
 
         assertEquals(8, diffResults.getActions().size());
-        assertEquals(7, diffResults.getModifyChanges().size());
+        assertEquals(6, diffResults.getModifyChanges().size());
         assertEquals(0, diffResults.getAddChanges().size());
 
         List<AbstractChange> changeList = adapter.analyzeModifyChange(diffResults);
@@ -189,12 +189,13 @@ public class LiquibaseSchemaAdapterTest {
         updated2.load(LiquibaseSchemaAdapterTest.class.getResourceAsStream("schema2_2.xsd")); //$NON-NLS-1$
 
         Compare.DiffResults diffResults = Compare.compare(original, updated2);
-        assertEquals(1, diffResults.getRemoveChanges().size());
+        assertEquals(2, diffResults.getRemoveChanges().size());
 
         List<AbstractChange> removeChangeList = adapter.analyzeRemoveChange(diffResults);
-        assertEquals(2, removeChangeList.size());
+        assertEquals(3, removeChangeList.size());
         assertEquals("liquibase.change.core.DropForeignKeyConstraintChange", removeChangeList.get(0).getClass().getName());
-        assertEquals("liquibase.change.core.DropColumnChange", removeChangeList.get(1).getClass().getName());
+        assertEquals("liquibase.change.core.DropTableChange", removeChangeList.get(1).getClass().getName());
+        assertEquals("liquibase.change.core.DropColumnChange", removeChangeList.get(2).getClass().getName());
     }
 
     @Test

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/ManyFieldCriterionTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/hibernate/ManyFieldCriterionTest.java
@@ -108,6 +108,11 @@ public class ManyFieldCriterionTest extends TestCase {
             // TODO Auto-generated method stub
             return null;
         }
+
+		@Override
+		public String getCollectionTableToDrop(FieldMetadata field) {
+			return "product_collection";
+		}
     }
 
     private class CriteriaQueryForTest implements CriteriaQuery {

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/BooleanType.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/BooleanType.xsd
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:element name="BooleanType">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a1" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">fn:true()</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a2" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">"false"</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a3" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Default_Value_Rule">'false'</xsd:appinfo>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a4" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Default_Value_Rule">"true"</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a5" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Default_Value_Rule">1</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="a6" type="xsd:boolean">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                        <xsd:appinfo source="X_Default_Value_Rule">'true'</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="BooleanType">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="Id" />
+        </xsd:unique>
+    </xsd:element>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_1.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_1.xsd
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
     <xsd:element name="Person">
         <xsd:annotation>
             <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo>
@@ -52,11 +51,18 @@
 		            </xsd:all> 
 		          </xsd:complexType> 
 		        </xsd:element> 
+		        <xsd:element maxOccurs="1" minOccurs="0" name="address" type="xsd:string">
+		          <xsd:annotation>
+		            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+		            <xsd:appinfo source="X_ForeignKey">Address/AddressId</xsd:appinfo>
+		            <xsd:appinfo source="X_ForeignKey_NotSep">false</xsd:appinfo>
+		          </xsd:annotation>
+		        </xsd:element>
             </xsd:sequence>
         </xsd:complexType>
         <xsd:unique name="Person">
-            <xsd:selector xpath="." />
-            <xsd:field xpath="Id" />
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
         </xsd:unique>
     </xsd:element>
     <xsd:complexType name="Boy"> 
@@ -73,4 +79,16 @@
       </xsd:element> 
     </xsd:all> 
   </xsd:complexType>  
+  <xsd:element name="Address">
+	<xsd:complexType>
+		<xsd:all>
+			<xsd:element name="AddressId" type="xsd:string"/>
+			<xsd:element maxOccurs="1" minOccurs="0" name="name" type="xsd:string"/>
+		</xsd:all>
+	</xsd:complexType>
+	<xsd:unique name="Address">
+		<xsd:selector xpath="."/>
+		<xsd:field xpath="AddressId"/>
+	</xsd:unique>
+  </xsd:element>
 </xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <xsd:import namespace="http://www.w3.org/2001/XMLSchema" />
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
     <xsd:element name="Person">
         <xsd:annotation>
             <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo>
@@ -55,8 +54,8 @@
             </xsd:sequence>
         </xsd:complexType>
         <xsd:unique name="Person">
-            <xsd:selector xpath="." />
-            <xsd:field xpath="Id" />
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
         </xsd:unique>
     </xsd:element>
     <xsd:complexType name="Boy"> 
@@ -73,4 +72,16 @@
       </xsd:element> 
     </xsd:all> 
   </xsd:complexType>  
+    <xsd:element name="Address">
+      <xsd:complexType>
+      <xsd:all>
+          <xsd:element name="AddressId" type="xsd:string"/>
+          <xsd:element maxOccurs="1" minOccurs="0" name="name" type="xsd:string"/>
+      </xsd:all>
+      </xsd:complexType>
+      <xsd:unique name="Address">
+          <xsd:selector xpath="."/>
+          <xsd:field xpath="AddressId"/>
+      </xsd:unique>
+    </xsd:element>
 </xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/storage/hibernate/schema2_2.xsd
@@ -36,11 +36,6 @@
                         <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo>
                     </xsd:annotation>
                 </xsd:element>
-                <xsd:element maxOccurs="unbounded" minOccurs="0" name="gg" type="xsd:string">
-                    <xsd:annotation>
-                        <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo>
-                    </xsd:annotation>
-                </xsd:element>
                 <xsd:element maxOccurs="1" minOccurs="0" name="uu"> 
 		          <xsd:annotation> 
 		            <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo> 


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14795
What is the current behavior? (You should also link to an open issue here)
Remove a field for the cases below for medium change, redeploy failed.

0-many fk field
Entityname + fieldname is longer than 30 on oracle
Field on inheritance type
We got incorrect table name or fk name to drop.
What is the new behavior?
Process fk field name by "x"+ referenceField.getName().replace('-', '_').toLowerCase()
Then we can got correct table for 0-many fk fields to drop.
For 0-many field in inheritance type, if the field is from super type need generate table name according to super type.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
