### PR TITLE
TMDM-14851 Leading spaces "lost" when using the MDM Webui export

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/DownloadWriter.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/DownloadWriter.java
@@ -181,7 +181,6 @@ public abstract class DownloadWriter {
             }
 
             if (cellValue != null) {
-                cellValue = cellValue.trim();
                 cellValue = cellValue.replaceAll("__h", "");
                 cellValue = cellValue.replaceAll("h__", "");
             } else {

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/DownloadWriterTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/DownloadWriterTest.java
@@ -106,7 +106,7 @@ public class DownloadWriterTest extends TestCase {
         DownloadUtil.assembleFkMap(colFkMap, fkMap, "<fkColXPath><item>Product/Family,ProductFamily/Id</item></fkColXPath>",
                 "<fkInfo><item>ProductFamily/Name</item></fkInfo>");
         String[] stringArray = { "<totalCount>1</totalCount>",
-                "<result xmlns:metadata=\"http://www.talend.com/mdm/metadata\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><Id>1</Id><Name>2,2\"</Name><Family>[7]</Family><Price>1.00</Price><Availability>true</Availability><Description>1</Description><Features></Features><Sizes></Sizes><Colors></Colors><Size>Small,Medium,Large</Size><Color>White,Light Blue,Light Pink</Color><taskId/></result>" };
+                "<result xmlns:metadata=\"http://www.talend.com/mdm/metadata\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><Id>1</Id><Name>  2,2\"  </Name><Family>[7]</Family><Price>1.00</Price><Availability>true</Availability><Description>1</Description><Features></Features><Sizes></Sizes><Colors></Colors><Size>Small,Medium,Large</Size><Color>White,Light Blue,Light Pink</Color><taskId/></result>" };
         WSStringArray wsStringArray = new WSStringArray(stringArray);
 
         XtentisPort port = PowerMockito.mock(XtentisPort.class);
@@ -124,7 +124,7 @@ public class DownloadWriterTest extends TestCase {
 
         String expectedResult = "Id,Name,Family,Price,Availability,Description,Features,Features/Sizes,Features/Colors,Features/Sizes/Size,Features/Colors/Color"
                 + System.getProperty("line.separator")
-                + "1,2&#44;2&#34;,[7]|F33,1.00,true,1,,,,Small|Medium|Large,White|Light Blue|Light Pink";
+                + "1,  2&#44;2&#34;  ,[7]|F33,1.00,true,1,,,,Small|Medium|Large,White|Light Blue|Light Pink";
         DownloadWriter writer = new CSVWriter(concept, viewPk, idsList, headerArray, xpathArray, criteria, multipleValueSeparator,
                 fkDisplay, fkResovled, colFkMap, fkMap, false, language);
         writer.writeFile();
@@ -156,7 +156,7 @@ public class DownloadWriterTest extends TestCase {
                 continue;
             } else if (rowNumber == 2) {
                 assertEquals("1", row.getCell(0).getRichStringCellValue().getString());
-                assertEquals("2,2\"", row.getCell(1).getRichStringCellValue().getString());
+                assertEquals("  2,2\"  ", row.getCell(1).getRichStringCellValue().getString());
                 assertEquals("[7]|F33", row.getCell(2).getRichStringCellValue().getString());
                 assertEquals("1.00", row.getCell(3).getRichStringCellValue().getString());
                 assertEquals("true", row.getCell(4).getRichStringCellValue().getString());


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14851
**What is the current behavior?** (You should also link to an open issue here)
When you export records using the "Import And Export" MDM WebUi, the leading spaces are lost in the xls and csv files.


**What is the new behavior?**
When you export records using the "Import And Export" MDM WebUi, the leading spaces won't lost in the xls and csv files.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
