### PR TITLE
TMDM-14793 During Migration leading spaces are removed (trim FK value)

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageRecordCreationTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageRecordCreationTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static com.amalto.core.query.user.UserQueryBuilder.eq;
 import static com.amalto.core.query.user.UserQueryBuilder.from;
+import static com.amalto.core.query.user.UserQueryBuilder.lt;
 
 @SuppressWarnings("nls")
 public class StorageRecordCreationTest extends StorageTestCase {
@@ -559,6 +560,47 @@ public class StorageRecordCreationTest extends StorageTestCase {
         } finally {
             results.close();
             storage.commit();
+        }
+    }
+
+    // TMDM-14793
+    public void testPKWithLeadingAndEndingSpace() {
+        DataRecordReader<String> factory = new XmlStringDataRecordReader();
+        // Create
+        String RR_Record4 = "<RR><Id> R4 </Id><Name>R4 Name</Name></RR>";
+        try {
+            storage.begin();
+            storage.update(factory.read(repository, rr, RR_Record4));
+            storage.commit();
+        } finally {
+            storage.end();
+        }
+        UserQueryBuilder qb = from(rr).where(eq(rr.getField("Name"), "R4 Name"));
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(results.getSize(), 1);
+            DataRecord record = results.iterator().next();
+            assertEquals(record.get("Id"), "R4");
+        } finally {
+            results.close();
+        }
+        // Update
+        String RR_Record4_2 = "<RR><Id> R4 </Id><Name> R4 Change </Name></RR>";
+        try {
+            storage.begin();
+            storage.update(factory.read(repository, rr, RR_Record4_2));
+            storage.commit();
+        } finally {
+            storage.end();
+        }
+        qb = from(rr).where(eq(rr.getField("Id"), "R4"));
+        results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(results.getSize(), 1);
+            DataRecord record = results.iterator().next();
+            assertEquals(record.get("Name"), " R4 Change ");
+        } finally {
+            results.close();
         }
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageRecordCreationTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageRecordCreationTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import static com.amalto.core.query.user.UserQueryBuilder.eq;
 import static com.amalto.core.query.user.UserQueryBuilder.from;
-import static com.amalto.core.query.user.UserQueryBuilder.lt;
 
 @SuppressWarnings("nls")
 public class StorageRecordCreationTest extends StorageTestCase {

--- a/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/DefaultCommitter.java
@@ -77,7 +77,7 @@ public class DefaultCommitter implements SaverSession.Committer {
                 if (!keyAccessor.exist()) {
                     throw new RuntimeException("Unexpected state: '"+ type +"' does not have value for key '" + keyFieldName + "'.");  //$NON-NLS-1$ //$NON-NLS-2$//$NON-NLS-3$
                 }
-                ids.add(keyAccessor.get());
+                ids.add(keyAccessor.get().trim());
             }
             ItemPOJO item = new ItemPOJO(new DataClusterPOJOPK(document.getDataCluster()),
                     type.getName(),

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/GenerateActions.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/GenerateActions.java
@@ -116,7 +116,7 @@ class GenerateActions implements DocumentSaver {
                             }
                         }
                     } else {
-                        idValues.add(context.getUserDocument().createAccessor(key.getPath()).get());
+                        idValues.add(context.getUserDocument().createAccessor(key.getPath()).get().trim());
                     }
                 }
                 // Join ids read from XML document and generated ID values.

--- a/org.talend.mdm.query/pom.xml
+++ b/org.talend.mdm.query/pom.xml
@@ -54,43 +54,4 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>tem-build</id>
-            <properties>
-                <jar.include>${project.build.finalName}.jar</jar.include>
-            </properties>
-        </profile>
-        <profile>
-            <id>tom-build</id>
-            <properties>
-                <jar.include>${project.build.finalName}*.jar</jar.include>
-            </properties>
-        </profile>
-        <profile>
-            <id>dev-build</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>deploy-tomcat</id>
-                                <configuration>
-                                    <target>
-                                        <copy todir="${mdm.lib.dir}" overwrite="true">
-                                            <fileset dir="${project.build.directory}">
-                                                <include name="${jar.include}" />
-                                            </fileset>
-                                        </copy>
-                                    </target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                     </plugin>
-                 </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/org.talend.mdm.query/pom.xml
+++ b/org.talend.mdm.query/pom.xml
@@ -54,4 +54,43 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>tem-build</id>
+            <properties>
+                <jar.include>${project.build.finalName}.jar</jar.include>
+            </properties>
+        </profile>
+        <profile>
+            <id>tom-build</id>
+            <properties>
+                <jar.include>${project.build.finalName}*.jar</jar.include>
+            </properties>
+        </profile>
+        <profile>
+            <id>dev-build</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy-tomcat</id>
+                                <configuration>
+                                    <target>
+                                        <copy todir="${mdm.lib.dir}" overwrite="true">
+                                            <fileset dir="${project.build.directory}">
+                                                <include name="${jar.include}" />
+                                            </fileset>
+                                        </copy>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                     </plugin>
+                 </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/org.talend.mdm.query/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.query/src/com/amalto/core/storage/record/DataRecord.java
@@ -299,7 +299,11 @@ public class DataRecord {
             throw new IllegalArgumentException("Field can not be null.");
         }
         if (!field.isMany()) {
-            fieldToValue.put(field, o);
+            if (field.isKey() && o instanceof String) {
+                fieldToValue.put(field, ((String) o).trim());
+            } else {
+                fieldToValue.put(field, o);
+            }
         } else {
             List list = (List) fieldToValue.get(field);
             // fields that may contain data records.


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14793
**What is the current behavior?** (You should also link to an open issue here)
FK starts with empty space will be kept, and open record from WebUI will fail

**What is the new behavior?**
FK value will always be trimed as before


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
