### PR TITLE
TMDM-14903 Add profile "dev-build" to pom.xml of org.talend.mdm.query

### DIFF
--- a/org.talend.mdm.query/pom.xml
+++ b/org.talend.mdm.query/pom.xml
@@ -54,4 +54,27 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>dev-build</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deploy-tomcat</id>
+                                <configuration>
+                                    <target>
+                                        <copy tofile="${lib.dest}" file="${jar.lib.src}" />
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14903
**What is the current behavior?** (You should also link to an open issue here)
During development, when build `org.talend.mdm.query`, the jar need to move to `WEB-INF/lib` manually


**What is the new behavior?**
The jar could be moved to `WEB-INF/lib` automatically.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
