### PR TITLE
TMDM-14579 Provide in 7.x a method to update Read-only fields in Before-Saving process as it was possible in 6.5

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/BulkImportRecordSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/BulkImportRecordSaveTest.java
@@ -345,7 +345,7 @@ public class BulkImportRecordSaveTest extends TestCase {
         @Override
         public OutputReport invokeBeforeSaving(DocumentSaverContext context, MutableDocument updateReportDocument) {
             String message = "<report><message type=\"info\">change the value successfully!</message></report>";
-            return new OutputReport(message, null);
+            return new OutputReport(message, null, false);
         }
 
         @Override

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/save/DocumentSaveTest.java
@@ -5014,7 +5014,7 @@ public class DocumentSaveTest extends TestCase {
         @Override
         public OutputReport invokeBeforeSaving(DocumentSaverContext context, MutableDocument updateReportDocument) {
             String message = "<report><message type=\"info\">change the value successfully!</message></report>";
-            return new OutputReport(message, null);
+            return new OutputReport(message, null, false);
         }
 
         @Override
@@ -5126,7 +5126,7 @@ public class DocumentSaveTest extends TestCase {
                 message = "<report><message type=\"error\">change the value failed!</message></report>";
             }
             String item = null;
-            OutputReport report = new OutputReport(message, item);
+            OutputReport report = new OutputReport(message, item, false);
 
             if (newOutput) {
                 item = "<exchange><item>"
@@ -5160,7 +5160,7 @@ public class DocumentSaveTest extends TestCase {
                 message = "<report><message type=\"error\">Save the value failed!</message></report>";
             }
             String item = null;
-            OutputReport report = new OutputReport(message, item);
+            OutputReport report = new OutputReport(message, item, false);
 
             if (newOutput) {
                 item = "<exchange><item>"
@@ -5191,7 +5191,7 @@ public class DocumentSaveTest extends TestCase {
                 message = "<report><message type=\"error\">Save the value failed!</message></report>";
             }
             String item = null;
-            OutputReport report = new OutputReport(message, item);
+            OutputReport report = new OutputReport(message, item, false);
 
             if (newOutput) {
                 item = "<exchange><item>"
@@ -5300,7 +5300,7 @@ public class DocumentSaveTest extends TestCase {
                 message = "<report><message type=\"error\">no change update failed!</message></report>";
             }
             String item = null;
-            OutputReport report = new OutputReport(message, item);
+            OutputReport report = new OutputReport(message, item, false);
 
             if (newOutput) {
                 item = "<exchange><item>" + "<Agency>" + "<Id>5258f292-5670-473b-bc01-8b63434682f3</Id>"

--- a/org.talend.mdm.core/src/com/amalto/core/objects/transformers/TransformerV2POJO.java
+++ b/org.talend.mdm.core/src/com/amalto/core/objects/transformers/TransformerV2POJO.java
@@ -86,7 +86,7 @@ public class TransformerV2POJO extends ObjectPOJO{
 		this.processSteps = processSteps;
 	}
 
-    public boolean withAdminPermissions() {
+    public boolean isWithAdminPermissions() {
         return withAdminPermissions;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/objects/transformers/TransformerV2POJO.java
+++ b/org.talend.mdm.core/src/com/amalto/core/objects/transformers/TransformerV2POJO.java
@@ -15,19 +15,16 @@ import com.amalto.core.objects.ObjectPOJO;
 import com.amalto.core.objects.ObjectPOJOPK;
 import com.amalto.core.objects.transformers.util.TransformerProcessStep;
 
-
-
 /**
  * @author bgrieder
  *
  */
 public class TransformerV2POJO extends ObjectPOJO{
 
-
     private String name;
     private String description;
+    private boolean withAdminPermissions;
     private ArrayList<TransformerProcessStep> processSteps;
-
 
     /**
      *
@@ -36,9 +33,6 @@ public class TransformerV2POJO extends ObjectPOJO{
         super();
     }
 
-
-
-
 	public TransformerV2POJO(
 			String name,
 			ArrayList<TransformerProcessStep> processSteps
@@ -48,36 +42,27 @@ public class TransformerV2POJO extends ObjectPOJO{
 		this.processSteps = processSteps;
 	}
 
-
-	public TransformerV2POJO(
-			String name,
-			String description,
-			ArrayList<TransformerProcessStep> processSteps
-	) {
-		super();
-		this.name = name;
-		this.description = description;
-		this.processSteps = processSteps;
-	}
-
+    public TransformerV2POJO(String name, String description, boolean withAdminPermissions,
+            ArrayList<TransformerProcessStep> processSteps) {
+        super();
+        this.name = name;
+        this.description = description;
+        this.withAdminPermissions = withAdminPermissions;
+        this.processSteps = processSteps;
+    }
 
 	@Override
 	public ObjectPOJOPK getPK() {
 		return new ObjectPOJOPK(new String[] {name});
 	}
 
-
-
 	public String getName() {
 		return name;
 	}
 
-
-
 	public void setName(String name) {
 		this.name = name;
 	}
-
 
 	/**
 	 * @return Returns the Description.
@@ -93,21 +78,20 @@ public class TransformerV2POJO extends ObjectPOJO{
 		this.description = description;
 	}
 
-
 	public ArrayList<TransformerProcessStep> getProcessSteps() {
 		return processSteps;
 	}
-
-
 
 	public void setProcessSteps(ArrayList<TransformerProcessStep> processSteps) {
 		this.processSteps = processSteps;
 	}
 
+    public boolean withAdminPermissions() {
+        return withAdminPermissions;
+    }
 
-
-
-
-
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+        this.withAdminPermissions = withAdminPermissions;
+    }
 
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/AutoCommitSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/AutoCommitSaverContext.java
@@ -152,8 +152,8 @@ public class AutoCommitSaverContext implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
-        return delegate.withAdminPermissions();
+    public boolean isWithAdminPermissions() {
+        return delegate.isWithAdminPermissions();
     }
 
     @Override

--- a/org.talend.mdm.core/src/com/amalto/core/save/AutoCommitSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/AutoCommitSaverContext.java
@@ -150,4 +150,14 @@ public class AutoCommitSaverContext implements DocumentSaverContext {
     public void setId(String[] id) {
         delegate.setId(id);
     }
+
+    @Override
+    public boolean withAdminPermissions() {
+        return delegate.withAdminPermissions();
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+        delegate.setWithAdminPermissions(withAdminPermissions);
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/DocumentSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/DocumentSaverContext.java
@@ -118,4 +118,8 @@ public interface DocumentSaverContext {
     boolean generateTouchActions();
 
     boolean isInvokeBeforeSaving();
+
+    boolean withAdminPermissions();
+
+    void setWithAdminPermissions(boolean withAdminPermissions);
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/DocumentSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/DocumentSaverContext.java
@@ -119,7 +119,7 @@ public interface DocumentSaverContext {
 
     boolean isInvokeBeforeSaving();
 
-    boolean withAdminPermissions();
+    boolean isWithAdminPermissions();
 
     void setWithAdminPermissions(boolean withAdminPermissions);
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/PartialUpdateSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/PartialUpdateSaverContext.java
@@ -187,4 +187,13 @@ public class PartialUpdateSaverContext implements DocumentSaverContext {
         return delegate;
     }
 
+    @Override
+    public boolean withAdminPermissions() {
+        return delegate.withAdminPermissions();
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+        delegate.setWithAdminPermissions(withAdminPermissions);
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/PartialUpdateSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/PartialUpdateSaverContext.java
@@ -188,8 +188,8 @@ public class PartialUpdateSaverContext implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
-        return delegate.withAdminPermissions();
+    public boolean isWithAdminPermissions() {
+        return delegate.isWithAdminPermissions();
     }
 
     @Override

--- a/org.talend.mdm.core/src/com/amalto/core/save/ReportDocumentSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/ReportDocumentSaverContext.java
@@ -160,8 +160,8 @@ public class ReportDocumentSaverContext implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
-        return delegate.withAdminPermissions();
+    public boolean isWithAdminPermissions() {
+        return delegate.isWithAdminPermissions();
     }
 
     @Override

--- a/org.talend.mdm.core/src/com/amalto/core/save/ReportDocumentSaverContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/ReportDocumentSaverContext.java
@@ -158,4 +158,14 @@ public class ReportDocumentSaverContext implements DocumentSaverContext {
     public DocumentSaverContext getDelegate() {
         return this.delegate;
     }
+
+    @Override
+    public boolean withAdminPermissions() {
+        return delegate.withAdminPermissions();
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+        delegate.setWithAdminPermissions(withAdminPermissions);
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/BeforeSaving.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/BeforeSaving.java
@@ -108,7 +108,7 @@ public class BeforeSaving implements DocumentSaver {
                 } else if (TYPE_ERROR.equals(errorCode)) {
                     throw new BeforeSavingErrorException(message);
                 }
-                context.setWithAdminPermissions(outputreport.withAdminPermissions());
+                context.setWithAdminPermissions(outputreport.isWithAdminPermissions());
                 // handle output_item
                 if (outputreport.getItem() != null) {
                     xpath = "//exchange/item"; //$NON-NLS-1$

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/BeforeSaving.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/BeforeSaving.java
@@ -108,7 +108,7 @@ public class BeforeSaving implements DocumentSaver {
                 } else if (TYPE_ERROR.equals(errorCode)) {
                     throw new BeforeSavingErrorException(message);
                 }
-
+                context.setWithAdminPermissions(outputreport.withAdminPermissions());
                 // handle output_item
                 if (outputreport.getItem() != null) {
                     xpath = "//exchange/item"; //$NON-NLS-1$

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadContext.java
@@ -138,4 +138,14 @@ class BulkLoadContext implements DocumentSaverContext {
     public boolean isInvokeBeforeSaving() {
         return false; // No support in bulk load
     }
+
+    @Override
+    public boolean withAdminPermissions() {
+        return false;
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/BulkLoadContext.java
@@ -140,7 +140,7 @@ class BulkLoadContext implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
+    public boolean isWithAdminPermissions() {
         return false;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/DirectWriteContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/DirectWriteContext.java
@@ -190,4 +190,14 @@ class DirectWriteContext implements DocumentSaverContext {
 
     }
 
+    @Override
+    public boolean withAdminPermissions() {
+        return false;
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+
+    }
+
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/DirectWriteContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/DirectWriteContext.java
@@ -191,7 +191,7 @@ class DirectWriteContext implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
+    public boolean isWithAdminPermissions() {
         return false;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/RecordValidationContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/RecordValidationContext.java
@@ -200,4 +200,14 @@ public class RecordValidationContext implements DocumentSaverContext {
         // TODO Auto-generated method stub
         return true;
     }
+
+    @Override
+    public boolean withAdminPermissions() {
+        return false;
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/RecordValidationContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/RecordValidationContext.java
@@ -202,7 +202,7 @@ public class RecordValidationContext implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
+    public boolean isWithAdminPermissions() {
         return false;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/StorageSaver.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/StorageSaver.java
@@ -223,7 +223,7 @@ public class StorageSaver implements DocumentSaverContext {
 
     @Override
     public boolean isWithAdminPermissions() {
-        return isWithAdminPermissions;
+        return withAdminPermissions;
     }
 
     @Override

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/StorageSaver.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/StorageSaver.java
@@ -222,8 +222,8 @@ public class StorageSaver implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
-        return withAdminPermissions;
+    public boolean isWithAdminPermissions() {
+        return isWithAdminPermissions;
     }
 
     @Override

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/StorageSaver.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/StorageSaver.java
@@ -53,6 +53,8 @@ public class StorageSaver implements DocumentSaverContext {
 
     private final boolean preserveOldCollectionValues;
 
+    private boolean withAdminPermissions;
+
     public StorageSaver(Storage storage,
                         String dataModelName,
                         MutableDocument userDocument,
@@ -217,5 +219,15 @@ public class StorageSaver implements DocumentSaverContext {
     @Override
     public boolean isInvokeBeforeSaving() {
         return this.invokeBeforeSaving;
+    }
+
+    @Override
+    public boolean withAdminPermissions() {
+        return withAdminPermissions;
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+        this.withAdminPermissions = withAdminPermissions;
     }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UserContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UserContext.java
@@ -189,4 +189,14 @@ class UserContext implements DocumentSaverContext {
     public boolean isInvokeBeforeSaving() {
         return this.invokeBeforeSaving;
     }
+
+    @Override
+    public boolean withAdminPermissions() {
+        return false;
+    }
+
+    @Override
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UserContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UserContext.java
@@ -191,7 +191,7 @@ class UserContext implements DocumentSaverContext {
     }
 
     @Override
-    public boolean withAdminPermissions() {
+    public boolean isWithAdminPermissions() {
         return false;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/server/DefaultTransformer.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/DefaultTransformer.java
@@ -344,7 +344,7 @@ public class DefaultTransformer implements TransformerPluginCallBack, com.amalto
             if ((transformerPOJO.getProcessSteps() != null) && (transformerPOJO.getProcessSteps().size() > 0)) {
                 executePlugin(globalContext, 0);
             }
-            boolean withAdminPermissions = transformerPOJO.withAdminPermissions();
+            boolean withAdminPermissions = transformerPOJO.isWithAdminPermissions();
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Run the process '" + transformerPOJO.getName() + "' with admin permissions -----> " //$NON-NLS-1$
                         + withAdminPermissions);

--- a/org.talend.mdm.core/src/com/amalto/core/server/DefaultTransformer.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/DefaultTransformer.java
@@ -344,6 +344,7 @@ public class DefaultTransformer implements TransformerPluginCallBack, com.amalto
             if ((transformerPOJO.getProcessSteps() != null) && (transformerPOJO.getProcessSteps().size() > 0)) {
                 executePlugin(globalContext, 0);
             }
+            globalContext.put("withAdmin", Boolean.valueOf(transformerPOJO.withAdminPermissions()));
             // signal done to the call back
             callBack.done(globalContext);
         } catch (Exception e) {

--- a/org.talend.mdm.core/src/com/amalto/core/server/DefaultTransformer.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/DefaultTransformer.java
@@ -344,7 +344,12 @@ public class DefaultTransformer implements TransformerPluginCallBack, com.amalto
             if ((transformerPOJO.getProcessSteps() != null) && (transformerPOJO.getProcessSteps().size() > 0)) {
                 executePlugin(globalContext, 0);
             }
-            globalContext.put("withAdmin", Boolean.valueOf(transformerPOJO.withAdminPermissions()));
+            boolean withAdminPermissions = transformerPOJO.withAdminPermissions();
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Run the process '" + transformerPOJO.getName() + "' with admin permissions -----> " //$NON-NLS-1$
+                        + withAdminPermissions);
+            }
+            globalContext.put("withAdmin", Boolean.valueOf(withAdminPermissions));
             // signal done to the call back
             callBack.done(globalContext);
         } catch (Exception e) {

--- a/org.talend.mdm.core/src/com/amalto/core/util/OutputReport.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/OutputReport.java
@@ -24,9 +24,12 @@ public class OutputReport {
      */
     private String item;
 
-    public OutputReport(String message, String item) {
+    private boolean withAdminPermissions;
+
+    public OutputReport(String message, String item, boolean withAdminPermissions) {
         this.message = message;
         this.item = item;
+        this.withAdminPermissions = withAdminPermissions;
     }
 
     public String getMessage() {
@@ -43,6 +46,14 @@ public class OutputReport {
 
     public void setItem(String item) {
         this.item = item;
+    }
+
+    public boolean withAdminPermissions() {
+        return withAdminPermissions;
+    }
+
+    public void setWithAdminPermissions(boolean withAdminPermissions) {
+        this.withAdminPermissions = withAdminPermissions;
     }
 
 }

--- a/org.talend.mdm.core/src/com/amalto/core/util/OutputReport.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/OutputReport.java
@@ -48,7 +48,7 @@ public class OutputReport {
         this.item = item;
     }
 
-    public boolean withAdminPermissions() {
+    public boolean isWithAdminPermissions() {
         return withAdminPermissions;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/util/Util.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/Util.java
@@ -600,7 +600,8 @@ public class Util extends XmlUtil {
                 if (!hasOutputReport) {
                     throw new OutputReportMissingException("Output variable 'output_report' is missing");
                 }
-                return new OutputReport(message, item);
+                boolean withAdmin = ((Boolean) context.get("withAdmin")).booleanValue();
+                return new OutputReport(message, item, withAdmin);
             } catch (Exception e) {
                 LOGGER.error(e);
                 throw e;

--- a/org.talend.mdm.core/src/com/amalto/core/util/XConverter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/util/XConverter.java
@@ -682,6 +682,7 @@ public class XConverter {
         WSTransformerV2 ws = new WSTransformerV2();
         ws.setName(transformerPOJO.getName());
         ws.setDescription(transformerPOJO.getDescription());
+        ws.setWithAdminPermissions(transformerPOJO.isWithAdminPermissions());
         ArrayList<WSTransformerProcessStep> wsSteps = new ArrayList<WSTransformerProcessStep>();
         ArrayList<TransformerProcessStep> processSteps = transformerPOJO.getProcessSteps();
         if (processSteps != null) {
@@ -697,6 +698,7 @@ public class XConverter {
         TransformerV2POJO pojo = new TransformerV2POJO();
         pojo.setName(wsTransformerV2.getName());
         pojo.setDescription(wsTransformerV2.getDescription());
+        pojo.setWithAdminPermissions(wsTransformerV2.isWithAdminPermissions());
         ArrayList<TransformerProcessStep> steps = new ArrayList<TransformerProcessStep>();
         WSTransformerProcessStep[] wsSteps = wsTransformerV2.getProcessSteps();
         if (wsSteps != null) {

--- a/org.talend.mdm.core/src/com/amalto/core/webservice/WSTransformerV2.java
+++ b/org.talend.mdm.core/src/com/amalto/core/webservice/WSTransformerV2.java
@@ -54,7 +54,7 @@ public class WSTransformerV2 {
         this.processSteps = processSteps;
     }
 
-    public java.lang.Boolean withAdminPermissions() {
+    public java.lang.Boolean isWithAdminPermissions() {
         return withAdminPermissions;
     }
 

--- a/org.talend.mdm.core/src/com/amalto/core/webservice/WSTransformerV2.java
+++ b/org.talend.mdm.core/src/com/amalto/core/webservice/WSTransformerV2.java
@@ -15,14 +15,18 @@ import javax.xml.bind.annotation.XmlType;
 public class WSTransformerV2 {
     protected java.lang.String name;
     protected java.lang.String description;
+
+    protected java.lang.Boolean withAdminPermissions;
     protected com.amalto.core.webservice.WSTransformerProcessStep[] processSteps;
 
     public WSTransformerV2() {
     }
 
-    public WSTransformerV2(java.lang.String name, java.lang.String description, com.amalto.core.webservice.WSTransformerProcessStep[] processSteps) {
+    public WSTransformerV2(java.lang.String name, java.lang.String description, java.lang.Boolean withAdminPermissions,
+            com.amalto.core.webservice.WSTransformerProcessStep[] processSteps) {
         this.name = name;
         this.description = description;
+        this.withAdminPermissions = withAdminPermissions;
         this.processSteps = processSteps;
     }
 
@@ -48,5 +52,13 @@ public class WSTransformerV2 {
 
     public void setProcessSteps(com.amalto.core.webservice.WSTransformerProcessStep[] processSteps) {
         this.processSteps = processSteps;
+    }
+
+    public java.lang.Boolean withAdminPermissions() {
+        return withAdminPermissions;
+    }
+
+    public void setWithAdminPermissions(java.lang.Boolean withAdminPermissions) {
+        this.withAdminPermissions = withAdminPermissions;
     }
 }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14579
**What is the current behavior?** (You should also link to an open issue here)

User can't update read only field by beforeSaving process.

**What is the new behavior?**
When withAdminPermission checked in studio, user can update read-only field successfully by beforeSaving process.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
