### PR TITLE
TMDM-14909 Hibernate & Lucene Upgrade - Depracated item management

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/DefaultStorageClassLoader.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/DefaultStorageClassLoader.java
@@ -36,8 +36,8 @@ import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.talend.mdm.commmon.metadata.ComplexTypeMetadata;
 import org.talend.mdm.commmon.util.core.MDMXMLUtils;
 import org.w3c.dom.Attr;
@@ -52,7 +52,6 @@ import com.amalto.core.storage.StorageType;
 import com.amalto.core.storage.datasource.RDBMSDataSource;
 import com.amalto.core.storage.datasource.RDBMSDataSourceBuilder;
 
-@SuppressWarnings("UnusedDeclaration")
 // Dynamically called! Do not remove!
 public class DefaultStorageClassLoader extends StorageClassLoader {
 
@@ -248,11 +247,6 @@ public class DefaultStorageClassLoader extends StorageClassLoader {
         mapping.getAttributes().setNamedItem(resource);
         sessionFactoryElement.appendChild(mapping);
 
-        if (rdbmsDataSource.supportFullText()) {
-        } else if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Hibernate configuration does not define full text extensions due to datasource configuration."); //$NON-NLS-1$
-        }
-
         return document;
     }
 
@@ -266,21 +260,6 @@ public class DefaultStorageClassLoader extends StorageClassLoader {
             default:
                 throw new IllegalArgumentException("Not supported database type '" + dialectType + "'");
         }
-    }
-
-    private static void addEvent(Document document, Node sessionFactoryElement, String eventType, String listenerClass) {
-        Element event = document.createElement("event"); //$NON-NLS-1$
-        Attr type = document.createAttribute("type"); //$NON-NLS-1$
-        type.setValue(eventType);
-        event.getAttributes().setNamedItem(type);
-        {
-            Element listener = document.createElement("listener"); //$NON-NLS-1$
-            Attr clazz = document.createAttribute("class"); //$NON-NLS-1$
-            clazz.setValue(listenerClass);
-            listener.getAttributes().setNamedItem(clazz);
-            event.appendChild(listener);
-        }
-        sessionFactoryElement.appendChild(event);
     }
 
     private static void addProperty(Document document, Node sessionFactoryElement, String propertyName, String propertyValue) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14909
**What is the current behavior?** (You should also link to an open issue here)
If you change the entity mapping to the index, chances are that the whole index needs to be updated; some new API be provided in hibernate 5, so need to upgrade them.

**What is the new behavior?**
Add cacheMode to `CacheMode.IGNORE`, as in most reindexing situations the cache will be a useless additional overhead; 
Add a MassIndexerProgressMonitor implementation to track the status during indexing the whole entities.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
