### PR TITLE
TMDM-14583 SOAP API updating records work unexpected when not provide value for non-PK autoincrement fields

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583-update.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583-update.xml
@@ -1,0 +1,6 @@
+<testAutoIncrement>
+  <Id>1</Id>
+  <complex>
+    <test2>test1</test2>
+  </complex>
+</testAutoIncrement>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583.xml
@@ -1,0 +1,6 @@
+<testAutoIncrement>
+  <Id>1</Id>
+  <complex>
+    <test2>test</test2>
+  </complex>
+</testAutoIncrement>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583.xsd
@@ -1,0 +1,53 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <xsd:import namespace="http://www.w3.org/2001/XMLSchema"/>
+    <xsd:element name="testAutoIncrement">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:all>
+                <xsd:element maxOccurs="1" minOccurs="1" name="Id" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="autoIncrement" type="AUTO_INCREMENT">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="complex">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:all>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="autoIncrement2" type="AUTO_INCREMENT">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <xsd:element maxOccurs="1" minOccurs="0" name="test2" type="xsd:string">
+                                <xsd:annotation>
+                                    <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:all>
+                    </xsd:complexType>
+                </xsd:element>
+                <xsd:element maxOccurs="1" minOccurs="0" name="test1" type="xsd:string">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:all>
+        </xsd:complexType>
+        <xsd:unique name="testAutoIncrement">
+            <xsd:selector xpath="."/>
+            <xsd:field xpath="Id"/>
+        </xsd:unique>
+    </xsd:element>
+    <xsd:simpleType name="AUTO_INCREMENT">
+        <xsd:restriction base="xsd:string"/>
+    </xsd:simpleType>
+</xsd:schema>

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583_original.xml
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/save/TMDM14583_original.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+<ii>
+    <c>testAutoIncrement</c>
+    <n>testAutoIncrement</n>
+    <dmn>testAutoIncrement</dmn>
+    <i>1</i>
+    <t>1</t>
+    <p>
+        <testAutoIncrement xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <Id>1</Id>
+            <test1>test1</test1>
+        </testAutoIncrement>
+    </p>
+</ii>

--- a/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
+++ b/org.talend.mdm.core/src/com/amalto/core/save/context/UpdateActionCreator.java
@@ -374,11 +374,19 @@ public class UpdateActionCreator extends DefaultMetadataVisitor<List<Action>> {
                         actions.add(new FieldUpdateAction(date, source, userName, path, oldValue == null ? StringUtils.EMPTY
                                 : oldValue, null, comparedField, userAction));
                     }
-                }
-                else if(!comparedField.isMany() && this.newDocument.considerMissingElementsAsEmpty()){
+                } else if(!comparedField.isMany() && this.newDocument.considerMissingElementsAsEmpty()){
                     actions.add(new FieldUpdateAction(date, source, userName, path, oldValue == null ? StringUtils.EMPTY : oldValue, StringUtils.EMPTY, comparedField, userAction));
+                } else if (EUUIDCustomType.AUTO_INCREMENT.getName().equalsIgnoreCase(comparedField.getType().getName())
+                        && isCreateAction == false) {
+                    String conceptName = rootTypeName + "." + comparedField.getPath().replaceAll("/", "."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+                    String autoIncrementValue = saverSource.nextAutoIncrementId(dataCluster, dataModel, conceptName);
+                    actions.add(new FieldUpdateAction(date, source, userName, path, oldValue == null ? StringUtils.EMPTY : oldValue, autoIncrementValue, comparedField, userAction));
+                } else if (EUUIDCustomType.UUID.getName().equalsIgnoreCase(comparedField.getType().getName())
+                        && isCreateAction == false) {
+                    String uuidValue = UUID.randomUUID().toString();
+                    actions.add(new FieldUpdateAction(date, source, userName, path, oldValue == null ? StringUtils.EMPTY : oldValue, uuidValue, comparedField, userAction));
                 }
-                
+
                 if (isDeletingContainedElement) {
                     // Null values may happen if accessor is targeting an element that contains other elements
                     actions.add(new FieldUpdateAction(date, source, userName, path, oldValue == null ? StringUtils.EMPTY


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14583

**What is the current behavior?** (You should also link to an open issue here)

To update a record from tMDMBulkLoad with same payload, if checked or not checked update report option, the result for auto increment field isn't same.

**What is the new behavior?**

From same payload, it has same result if checked or not checked update report option from tMDMBulkLoad job.

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
