### PR TITLE
TMDM-14613 Failed to run hierarchy to view records using customer's datamodel

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -1833,7 +1833,7 @@ class StandardQueryHandler extends AbstractQueryHandler {
             addConditionForCompoundField(condition, alias, fieldMetadata);
         } else if (isReferenceField && isSelfReference && !isMany) {
             addConditionForSelfReferenceField(condition, alias, ((ReferenceFieldMetadata) fieldMetadata).getReferencedField());
-        } else if (isReferenceField && isContainedInMain && !isMany) {
+        } else if (isReferenceField && isContainedInMain) {
             condition.criterionFieldNames.add(getFieldName(fieldMetadata, true));
         } else {
             String language = OrderBy.SortLanguage.get();

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -1828,10 +1828,9 @@ class StandardQueryHandler extends AbstractQueryHandler {
         boolean isReferenceField = fieldMetadata instanceof ReferenceFieldMetadata;
         boolean isContainedInMain = mainType.equals(fieldMetadata.getContainingType());
         boolean isSelfReference = isSelfReference(fieldMetadata);
-        boolean isMany = fieldMetadata.isMany();
         if (isCompoundField) {
             addConditionForCompoundField(condition, alias, fieldMetadata);
-        } else if (isReferenceField && isSelfReference && !isMany) {
+        } else if (isReferenceField && isSelfReference && !fieldMetadata.isMany()) {
             addConditionForSelfReferenceField(condition, alias, ((ReferenceFieldMetadata) fieldMetadata).getReferencedField());
         } else if (isReferenceField && isContainedInMain) {
             condition.criterionFieldNames.add(getFieldName(fieldMetadata, true));

--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/StandardQueryHandler.java
@@ -1828,11 +1828,12 @@ class StandardQueryHandler extends AbstractQueryHandler {
         boolean isReferenceField = fieldMetadata instanceof ReferenceFieldMetadata;
         boolean isContainedInMain = mainType.equals(fieldMetadata.getContainingType());
         boolean isSelfReference = isSelfReference(fieldMetadata);
+        boolean isMany = fieldMetadata.isMany();
         if (isCompoundField) {
             addConditionForCompoundField(condition, alias, fieldMetadata);
-        } else if (isReferenceField && isSelfReference) {
+        } else if (isReferenceField && isSelfReference && !isMany) {
             addConditionForSelfReferenceField(condition, alias, ((ReferenceFieldMetadata) fieldMetadata).getReferencedField());
-        } else if (isReferenceField && isContainedInMain) {
+        } else if (isReferenceField && isContainedInMain && !isMany) {
             condition.criterionFieldNames.add(getFieldName(fieldMetadata, true));
         } else {
             String language = OrderBy.SortLanguage.get();


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14613
**What is the current behavior?** (You should also link to an open issue here)
When search condition field is 0-many fk fields, handle it as normal fk field, get the id field of referenced type and add it into the condition.
Use referencedType.id in addCondition();


**What is the new behavior?**
When the fk field is many, add ` alias + '.' + fieldMetadata.getName()` into `conditions.criterionFieldNames`

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
