### PR TITLE
TMDM-14802 Control the schema validation by JVM parameter

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
@@ -25,24 +25,15 @@ import org.springframework.web.context.support.XmlWebApplicationContext;
  * Application Context could disable/enable spring schema validation by JVM Parameter "com.talend.mdm.springSchemaValidation"
  * <ul>
  * <li>Not set -- ENABLED (be default)</li>
- * <li>-Dcom.talend.mdm.springSchemaValidation=true   --ENABLED</li>
- * <li>-Dcom.talend.mdm.springSchemaValidation=false  --DISABLED</li>
+ * <li>-Dcom.talend.mdm.disableSpringSchemaValidation=false  --ENABLED</li>
+ * <li>-Dcom.talend.mdm.disableSpringSchemaValidation=true   --DISABLED</li>
  * </ul>
  * created by pwlin on Nov 25, 2020
  * 
  */
 public class MDMXmlWebApplicationContext extends XmlWebApplicationContext {
-    
-    private static final String SPRING_SCHEMA_VALIDATION = "com.talend.mdm.springSchemaValidation";
 
-    private static boolean getSpringSchemaValidation() {
-        String validation = System.getProperty(SPRING_SCHEMA_VALIDATION);
-        // only set "-Dcom.talend.mdm.springSchemaValidation=false" will disable it
-        if (validation != null && validation.equalsIgnoreCase("false")) {
-            return false;
-        }
-        return true;
-    }
+    private static final String DISABLE_SPRING_SCHEMA_VALIDATION = "com.talend.mdm.disableSpringSchemaValidation";
 
     @Override
     protected void loadBeanDefinitions(DefaultListableBeanFactory beanFactory) throws BeansException, IOException {
@@ -51,7 +42,7 @@ public class MDMXmlWebApplicationContext extends XmlWebApplicationContext {
 
         // Configure the bean definition reader with this context's
         // resource loading environment.
-        beanDefinitionReader.setValidating(getSpringSchemaValidation());
+        beanDefinitionReader.setValidating(!Boolean.getBoolean(DISABLE_SPRING_SCHEMA_VALIDATION));
         beanDefinitionReader.setEnvironment(getEnvironment());
         beanDefinitionReader.setResourceLoader(this);
         beanDefinitionReader.setEntityResolver(new ResourceEntityResolver(this));

--- a/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
@@ -36,13 +36,12 @@ public class MDMXmlWebApplicationContext extends XmlWebApplicationContext {
     private static final String SPRING_SCHEMA_VALIDATION = "com.talend.mdm.springSchemaValidation";
 
     private static boolean getSpringSchemaValidation() {
-        boolean validating = true; // validate by default
         String validation = System.getProperty(SPRING_SCHEMA_VALIDATION);
         // only set "-Dcom.talend.mdm.springSchemaValidation=false" will disable it
         if (validation != null && validation.equalsIgnoreCase("false")) {
-            validating = false;
+            return false;
         }
-        return validating;
+        return true;
     }
 
     @Override

--- a/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
@@ -22,13 +22,29 @@ import org.springframework.web.context.support.XmlWebApplicationContext;
 
 
 /**
- * Application Context which disable schema validation, it can speed up server start up, can make start up normally when no network
- * 
+ * Application Context could disable/enable spring schema validation by JVM Parameter "com.talend.mdm.springSchemaValidation"
+ * <ul>
+ * <li>Not set -- ENABLED (be default)</li>
+ * <li>-Dcom.talend.mdm.springSchemaValidation=true   --ENABLED</li>
+ * <li>-Dcom.talend.mdm.springSchemaValidation=false  --DISABLED</li>
+ * </ul>
  * created by pwlin on Nov 25, 2020
  * 
  */
 public class MDMXmlWebApplicationContext extends XmlWebApplicationContext {
     
+    private static final String SPRING_SCHEMA_VALIDATION = "com.talend.mdm.springSchemaValidation";
+
+    private static boolean getSpringSchemaValidation() {
+        boolean validating = true; // validate by default
+        String validation = System.getProperty(SPRING_SCHEMA_VALIDATION);
+        // only set "-Dcom.talend.mdm.springSchemaValidation=false" will disable it
+        if (validation != null && validation.equalsIgnoreCase("false")) {
+            validating = false;
+        }
+        return validating;
+    }
+
     @Override
     protected void loadBeanDefinitions(DefaultListableBeanFactory beanFactory) throws BeansException, IOException {
         // Create a new XmlBeanDefinitionReader for the given BeanFactory.
@@ -36,7 +52,7 @@ public class MDMXmlWebApplicationContext extends XmlWebApplicationContext {
 
         // Configure the bean definition reader with this context's
         // resource loading environment.
-        beanDefinitionReader.setValidating(false);
+        beanDefinitionReader.setValidating(getSpringSchemaValidation());
         beanDefinitionReader.setEnvironment(getEnvironment());
         beanDefinitionReader.setResourceLoader(this);
         beanDefinitionReader.setEntityResolver(new ResourceEntityResolver(this));

--- a/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/MDMXmlWebApplicationContext.java
@@ -22,7 +22,7 @@ import org.springframework.web.context.support.XmlWebApplicationContext;
 
 
 /**
- * Application Context could disable/enable spring schema validation by JVM Parameter "com.talend.mdm.springSchemaValidation"
+ * Application Context could disable/enable spring schema validation by JVM Parameter
  * <ul>
  * <li>Not set -- ENABLED (be default)</li>
  * <li>-Dcom.talend.mdm.disableSpringSchemaValidation=false  --ENABLED</li>


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)
MDM start up will be slow and get warning like `Ignored XML validation warning` when the network is slow or disconnected.


**What is the new behavior?**
Provide a JVM parameter `com.talend.mdm.disableSpringSchemaValidation` to control XML validation.
- no JVM set or set to `-Dcom.talend.mdm.disableSpringSchemaValidation=false`, will do XML validation
- set `-Dcom.talend.mdm.disableSpringSchemaValidation=true` will ignore XML validation
It will speed up and avoid the warning message during MDM starting up.


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
