### PR TITLE
TMDM-14932 Display FK Id instead of FK info when set FK  as dynamic label

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/DynamicLabelUtil.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/DynamicLabelUtil.java
@@ -142,7 +142,14 @@ public class DynamicLabelUtil {
 
         XSType xsct = null;
         org.dom4j.Element el = pathNodes.get(pos);
-        Attribute attr = el.attribute("xsi:type"); //$NON-NLS-1$
+        Attribute attr = null;
+        List<Attribute> elAttrs = el.attributes();
+        for (Attribute elAttr : elAttrs) {
+            if (elAttr.getQualifiedName().equals("xsi:type")) {
+                attr = elAttr;
+                break;
+            }
+        }
         String xsiType = attr == null ? null : attr.getStringValue();
         if (xsiType != null && !xsiType.equals("")) { //$NON-NLS-1$
             xsct = typeMap.get(xsiType);
@@ -155,7 +162,7 @@ public class DynamicLabelUtil {
             for (XSParticle xs : xsp) {
                 List<XSElementDecl> dels = getElementDecls(xs);
                 for (XSElementDecl del : dels) {
-                    if (del.getName().equals(pathNodes.get(pos + 1).getName())) {
+                    if (del.getName().equals(pathNodes.get(pos + 1).getQualifiedName())) {
                         Object[] fkObj = getForeign(del, pathNodes, pos + 1, typeMap);
                         if (fkObj != null) {
                             return fkObj;


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14932

**What is the current behavior?** (You should also link to an open issue here)

After dom4j upgrade from 1.6 to 2.1, dynamic label can't be displayed well in MDM web UI as before.

**What is the new behavior?**

Changed code to use right xml node name.

For more details, please refer to:
https://jira.talendforge.org/browse/TMDM-14932?focusedCommentId=856557&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-856557

**Please check if the PR fulfills these requirements**

- [X] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
