### PR TITLE
TMDM-14946 High Memory used by MDM Tomcat JVM when calling REST API PUT with "as of "

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/inmemory/MemoryStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/inmemory/MemoryStorage.java
@@ -57,7 +57,9 @@ public class MemoryStorage extends HibernateStorage {
             Session h2Session = (Session) h2Connection.getSession();
             Database h2Database = h2Session.getDatabase();
             h2Database.shutdownImmediately();
-            LOGGER.info("H2 Database: " + h2Database.getName() + " has been shutted down.");
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("In-memory h2 db '" + h2Database.getName() + "' has been shutted down.");
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -66,7 +68,9 @@ public class MemoryStorage extends HibernateStorage {
     @Override
     public synchronized void prepare(MetadataRepository repository, boolean dropExistingData) {
         if (dropExistingData) {
-            LOGGER.debug("No need to drop existing data for a in-memory storage.");
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("No need to drop existing data for a in-memory storage.");
+            }
         }
         super.prepare(repository, false);
     }
@@ -75,7 +79,9 @@ public class MemoryStorage extends HibernateStorage {
     public synchronized void prepare(MetadataRepository repository, Set<Expression> optimizedExpressions, boolean force,
             boolean dropExistingData) {
         if (dropExistingData) {
-            LOGGER.debug("No need to drop existing data for a in-memory storage.");
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("No need to drop existing data for a in-memory storage.");
+            }
         }
         super.prepare(repository, optimizedExpressions, force, false);
     }


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14946
**What is the current behavior?** (You should also link to an open issue here)
High Memory used by MDM Tomcat JVM when calling REST API PUT with "as of "

Under the hood an H2 in-memory database is used to refine the Rest History query prior to serve  the response. A new db is created at each call but is never closed, leading to memory consumption till overwhelming the JVM.

**What is the new behavior?**
The memory is OK when calling same REST API PUT with "as of"


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
