### PR TITLE
TMDM-11410 Operator 'contains the sentence' and 'whole content contains' not work for foreign key conditions filtering

### DIFF
--- a/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
+++ b/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
@@ -298,6 +298,10 @@ public abstract class Util {
             WSWhereOperator operator = null;
             if (values[1].equals("Contains")) {
                 operator = WSWhereOperator.CONTAINS;
+            } else if (values[1].equals("contains the sentence")) {
+                operator = WSWhereOperator.CONTAINS_SENTENCE;
+            } else if (values[1].equals("whole content contains")) {
+                operator = WSWhereOperator.FULLTEXTSEARCH;
             } else if (values[1].equals("Contains Text Of")) {
                 operator = WSWhereOperator.JOIN;
             } else if (values[1].equals("=")) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-11410
**What is the current behavior?** (You should also link to an open issue here)
don't support operator 'contains the sentence ' and 'whole content contains' for foreign key conditions filtering

**What is the new behavior?**
Add support for above two operator.
```
if (values[1].equals("contains the sentence")) {
     operator = WSWhereOperator.CONTAINS_SENTENCE;
 } else if (values[1].equals("whole content contains")) {
     operator = WSWhereOperator.FULLTEXTSEARCH;
 }
```

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
