### PR TITLE
TMDM-15023 Search Filter with Where Condition / Operator=Join With fails with : Field 'xxx' isn't reachable from type 'yyy'

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/LuceneQueryGenerator.java
@@ -465,7 +465,11 @@ class LuceneQueryGenerator extends VisitorAdapter<Query> {
                 throw new FullTextQueryCompositeKeyException(referenceFieldMetadata.getReferencedType().getName());
             } else if (((ReferenceFieldMetadata) field).getReferencedType().equals(fieldMetadata.getContainingType())) {
                 sb.append(getFullPathName(field));
-                sb.append(fieldMetadata.getName());
+                if (fieldMetadata instanceof ReferenceFieldMetadata) {
+                    sb.append(getFieldNameForFKField((ReferenceFieldMetadata) fieldMetadata));
+                } else {
+                    sb.append(fieldMetadata.getName());
+                }               
             } else {
                 ComplexTypeMetadata subComplexTypeMetadata = ((ReferenceFieldMetadata) field).getReferencedType();
                 if (subComplexTypeMetadata.getFields().stream()
@@ -478,43 +482,49 @@ class LuceneQueryGenerator extends VisitorAdapter<Query> {
 
     private String getFieldName(FieldMetadata fieldMetadata) {
         String fieldName = fieldMetadata.getName();
-        if (fieldMetadata instanceof ReferenceFieldMetadata) {
-            ReferenceFieldMetadata referenceFieldMetadata = ((ReferenceFieldMetadata) fieldMetadata);
-            if (referenceFieldMetadata.getReferencedType().getKeyFields().size() > 1) {
-                throw new FullTextQueryCompositeKeyException(referenceFieldMetadata.getReferencedType().getName());
-            } else {
-                fieldName = getFullPathName(fieldMetadata) + referenceFieldMetadata.getReferencedField().getName(); //$NON-NLS-1$
-            }
-        }
-        else {
-            ComplexTypeMetadata containingType = fieldMetadata.getContainingType();
-            // TMDM-13918 Query by field of joining type, field name in lucene index should be fkIdField.fieldName
-            if (fieldMetadata instanceof SimpleTypeFieldMetadata && !types.contains(containingType) && !selectedTypes
-                    .contains(containingType)) {
-                FieldMetadata keyField = containingType.getKeyFields().iterator().next();
-                fieldName = keyField.getName() + "." + fieldName; //$NON-NLS-1$
-            } else if ((!selectedTypes.contains(containingType) && types.contains(containingType)) || (
-                    selectedTypes.contains(containingType) && !types.contains(containingType))) {
-                if (containingType.getContainer() != null) {
+        ComplexTypeMetadata containingType = fieldMetadata.getContainingType();
+        // TMDM-13918 Query by field of joining type, field name in lucene index should be fkIdField.fieldName
+        if (fieldMetadata instanceof SimpleTypeFieldMetadata && !types.contains(containingType) && !selectedTypes
+                .contains(containingType)) {
+            FieldMetadata keyField = containingType.getKeyFields().iterator().next();
+            fieldName = keyField.getName() + "." + fieldName; //$NON-NLS-1$
+        } else if ((!selectedTypes.contains(containingType) && types.contains(containingType)) || (
+                selectedTypes.contains(containingType) && !types.contains(containingType))) {
+            if (containingType.getContainer() != null) {
+                if (fieldMetadata instanceof ReferenceFieldMetadata) {
+                    fieldName = getFieldNameForFKField((ReferenceFieldMetadata) fieldMetadata);
+                } else {
                     FieldMetadata field = containingType.getContainer();
                     StringBuilder sb = getFullPathName(field);
-                    sb.append(fieldMetadata.getName());
+                    sb.append(fieldName);
                     fieldName = sb.toString();
-                } else {
-                    StringBuilder sb = new StringBuilder();
-                    for (ComplexTypeMetadata complexTypeMetadata : selectedTypes) {
-                        getFullPathName(complexTypeMetadata, fieldMetadata, sb);
-                        if (!sb.toString().equals(StringUtils.EMPTY)) {
-                            break;
-                        }
+                }                               
+            } else {
+                StringBuilder sb = new StringBuilder();
+                for (ComplexTypeMetadata complexTypeMetadata : selectedTypes) {
+                    getFullPathName(complexTypeMetadata, fieldMetadata, sb);
+                    if (!sb.toString().equals(StringUtils.EMPTY)) {
+                        break;
                     }
-                    fieldName = sb.toString();
                 }
+                fieldName = sb.toString();
             }
+        } else if(fieldMetadata instanceof ReferenceFieldMetadata) {
+            fieldName = getFieldNameForFKField((ReferenceFieldMetadata) fieldMetadata);
         }
         return fieldName;
     }
 
+    private String getFieldNameForFKField(ReferenceFieldMetadata referenceFieldMetadata) {
+        String fieldName;
+        if (referenceFieldMetadata.getReferencedType().getKeyFields().size() > 1) {
+            throw new FullTextQueryCompositeKeyException(referenceFieldMetadata.getReferencedType().getName());
+        } else {
+            fieldName = getFullPathName(referenceFieldMetadata) + referenceFieldMetadata.getReferencedField().getName(); //$NON-NLS-1$
+        }
+        return fieldName;
+    }
+    
     @Override
     public Query visit(FieldFullText fieldFullText) {
         FieldMetadata fieldMetadata = fieldFullText.getField().getFieldMetadata();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
@@ -175,6 +175,12 @@ public class StorageTestCase extends TestCase {
     protected static final ComplexTypeMetadata orgPerson;
 
     protected static final ComplexTypeMetadata orgEntity;
+    
+    protected static final ComplexTypeMetadata cmd_xref_party;
+    
+    protected static final ComplexTypeMetadata cmd_party;
+    
+    protected static final ComplexTypeMetadata cmd_member;
 
     public static final String DATABASE = "H2";
 
@@ -259,6 +265,10 @@ public class StorageTestCase extends TestCase {
         orgActivity = repository.getComplexType("OrgActivity");
         orgPerson = repository.getComplexType("OrgPerson");
         orgEntity = repository.getComplexType("OrgEntity");
+        
+        cmd_xref_party = repository.getComplexType("xRef_Party");
+        cmd_party = repository.getComplexType("Party");
+        cmd_member = repository.getComplexType("Member");
 
         systemStorage = new SecuredStorage(new HibernateStorage("MDM", StorageType.SYSTEM), userSecurity);
         systemRepository = buildSystemRepository();

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -3190,4 +3190,84 @@
             <xsd:field xpath="ID_1" />
         </xsd:unique>
     </xsd:element>
+    
+    <!-- CMD DATA MODEL -->
+    
+    <xsd:simpleType name="AUTO_INCREMENT"> 
+	    <xsd:restriction base="xsd:string"/> 
+    </xsd:simpleType>  
+    <xsd:element name="Party"> 
+	    <xsd:annotation> 
+	      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	    </xsd:annotation>  
+	    <xsd:complexType> 
+	      <xsd:all> 
+	        <xsd:element maxOccurs="1" minOccurs="1" name="Party_ID" type="AUTO_INCREMENT"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element>  
+	        <xsd:element maxOccurs="1" minOccurs="0" name="Participant_ID" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_ForeignKey">Member/Participant_ID</xsd:appinfo>  
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>  
+	            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>  
+	            <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element> 
+	      </xsd:all> 
+	    </xsd:complexType>  
+	    <xsd:unique name="Party"> 
+	      <xsd:selector xpath="."/>  
+	      <xsd:field xpath="Party_ID"/> 
+	    </xsd:unique> 
+    </xsd:element>  
+    <xsd:element name="Member"> 
+	    <xsd:annotation> 
+	      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	    </xsd:annotation>  
+	    <xsd:complexType> 
+	      <xsd:all> 
+	        <xsd:element maxOccurs="1" minOccurs="1" name="Participant_ID" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element>  
+	        <xsd:element maxOccurs="1" minOccurs="0" name="Master_Tier" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element> 
+	      </xsd:all> 
+	    </xsd:complexType>  
+	    <xsd:unique name="Member"> 
+	      <xsd:selector xpath="."/>  
+	      <xsd:field xpath="Participant_ID"/> 
+	    </xsd:unique> 
+    </xsd:element>  
+    <xsd:element name="xRef_Party"> 
+	    <xsd:annotation> 
+	      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	    </xsd:annotation>  
+	    <xsd:complexType> 
+	      <xsd:all> 
+	        <xsd:element maxOccurs="1" minOccurs="1" name="ID" type="AUTO_INCREMENT"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element>  
+	        <xsd:element maxOccurs="1" minOccurs="1" name="Party_ID" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_ForeignKey">Party/Party_ID</xsd:appinfo>  
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>  
+	            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element> 
+	      </xsd:all> 
+	    </xsd:complexType>  
+	    <xsd:unique name="xRef_Party"> 
+	      <xsd:selector xpath="."/>  
+	      <xsd:field xpath="ID"/> 
+	    </xsd:unique> 
+    </xsd:element> 
 </xsd:schema>

--- a/org.talend.mdm.query/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.query/src/com/amalto/core/storage/record/DataRecord.java
@@ -157,8 +157,11 @@ public class DataRecord {
                 if (value != null) { // Support explicit projection type fields
                     return value;
                 }
-                throw new IllegalArgumentException("Field '" + field.getName() + "' isn't reachable from type '" + type.getName()
-                        + "'");
+                path = MetaDataUtils.path(type, field, true).iterator();
+                if (!path.hasNext()) {
+                    throw new IllegalArgumentException("Field '" + field.getName() + "' isn't reachable from type '" + type.getName()
+                            + "'");
+                }
             }
             DataRecord current = this;
             while (path.hasNext()) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-15023
What is the current behavior? (You should also link to an open issue here)

Ref_address_party referenced to Party and Party referenced to Member.
Throw exception when got the path of field in Member from Ref_address_party.

What is the new behavior?
if got the path failed. try again by set includeReferences true.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
