### PR TITLE
TMDM-15023 Search Filter with Where Condition / Operator=Join With fails with : Field 'xxx' isn't reachable from type 'yyy'

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageFullTextTest.java
@@ -182,6 +182,10 @@ public class StorageFullTextTest extends StorageTestCase {
         allRecords.add(factory.read(repository, refRegion, "<RefRegion><codeRegion>BEL_BC</codeRegion><PaysFk>[1]</PaysFk><libelleRegion><codeLangue>fr</codeLangue><libelle>Bruxelles-Capitale</libelle><Con><Add_City>Pairs</Add_City><Add_Country>Franch</Add_Country></Con></libelleRegion><libelleRegion><codeLangue>en</codeLangue><libelle>Bruxees-Capitale</libelle><Con><Add_City>Longdong</Add_City><Add_Country>England</Add_Country></Con></libelleRegion><libelleRegion><codeLangue>es</codeLangue><libelle>Bruxeeserses-Capitale</libelle><Con><Add_City>Longdong</Add_City><Add_Country>England</Add_Country></Con></libelleRegion></RefRegion>"));
         allRecords.add(factory.read(repository, refRegion, "<RefRegion><codeRegion>CAN_NBR</codeRegion><PaysFk>[2]</PaysFk><libelleRegion><codeLangue>fr</codeLangue><libelle>NOUVENAU-BRUNSWICK</libelle><Con><Add_City>PARISE</Add_City><Add_Country>FRANCH</Add_Country></Con></libelleRegion><libelleRegion><codeLangue>en</codeLangue><libelle>NEW-BRUNSWICK</libelle><Con><Add_City>LONGDONG</Add_City><Add_Country>ENGLAND</Add_Country></Con></libelleRegion><libelleRegion><codeLangue>es</codeLangue><libelle>NUEVO BRUNSWICK</libelle><Con><Add_City>ENGLAND</Add_City><Add_Country>ENGLAND</Add_Country></Con></libelleRegion></RefRegion>"));
 
+        allRecords.add(factory.read(repository, cmd_member, "<Member><Participant_ID>m1</Participant_ID><Master_Tier>mt1</Master_Tier></Member>"));
+        allRecords.add(factory.read(repository, cmd_party, "<Party><Party_ID>p1</Party_ID><Participant_ID>[m1]</Participant_ID></Party>"));
+        allRecords.add(factory.read(repository, cmd_xref_party, "<xRef_Party><ID>1</ID><Party_ID>[p1]</Party_ID></xRef_Party>"));
+        
         try {
             storage.begin();
             storage.update(allRecords);
@@ -2027,6 +2031,26 @@ public class StorageFullTextTest extends StorageTestCase {
             assertTrue(results.getSize() == 1);
             for (DataRecord result : results) {
                 assertEquals("4", result.get("Id"));
+            }
+        } finally {
+            results.close();
+        }
+    }
+    
+    //TMDM-15023 Search Filter with Where Condition / Operator=Join With fails with : Field 'xxx' isn't reachable from type 'yyy'
+    public void testFKfieldWithJoinTypeSearch() {
+        UserQueryBuilder qb = from(cmd_xref_party)
+        .selectId(cmd_xref_party).select(cmd_xref_party.getField("Party_ID"))
+        .select(cmd_party.getField("Participant_ID")).select(cmd_member.getField("Participant_ID"))
+        .where(contains(cmd_party.getField("Participant_ID"), "m1"))
+        .join(cmd_xref_party.getField("Party_ID")).join(cmd_party.getField("Participant_ID"));
+        
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertTrue(results.getSize() == 1);
+            for (DataRecord result : results) {
+                assertTrue("p1".equals(((List)result.get("Party/Party_ID")).get(0)));
+                assertTrue("m1".equals(result.get("Member/Participant_ID")));
             }
         } finally {
             results.close();

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
@@ -182,6 +182,12 @@ public class StorageTestCase extends TestCase {
     protected static final ComplexTypeMetadata orgPerson;
 
     protected static final ComplexTypeMetadata orgEntity;
+    
+    protected static final ComplexTypeMetadata cmd_xref_party;
+    
+    protected static final ComplexTypeMetadata cmd_party;
+    
+    protected static final ComplexTypeMetadata cmd_member;
 
     public static final String DATABASE = "H2";
 
@@ -269,6 +275,10 @@ public class StorageTestCase extends TestCase {
         orgActivity = repository.getComplexType("OrgActivity");
         orgPerson = repository.getComplexType("OrgPerson");
         orgEntity = repository.getComplexType("OrgEntity");
+        
+        cmd_xref_party = repository.getComplexType("xRef_Party");
+        cmd_party = repository.getComplexType("Party");
+        cmd_member = repository.getComplexType("Member");
 
         systemStorage = new SecuredStorage(new HibernateStorage("MDM", StorageType.SYSTEM), userSecurity);
         systemRepository = buildSystemRepository();

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -3265,4 +3265,84 @@
             <xsd:field xpath="ID_1" />
         </xsd:unique>
     </xsd:element>
+    
+    <!-- CMD DATA MODEL -->
+    
+    <xsd:simpleType name="AUTO_INCREMENT"> 
+	    <xsd:restriction base="xsd:string"/> 
+    </xsd:simpleType>  
+    <xsd:element name="Party"> 
+	    <xsd:annotation> 
+	      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	    </xsd:annotation>  
+	    <xsd:complexType> 
+	      <xsd:all> 
+	        <xsd:element maxOccurs="1" minOccurs="1" name="Party_ID" type="AUTO_INCREMENT"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element>  
+	        <xsd:element maxOccurs="1" minOccurs="0" name="Participant_ID" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_ForeignKey">Member/Participant_ID</xsd:appinfo>  
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>  
+	            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo>  
+	            <xsd:appinfo source="X_Retrieve_FKinfos">true</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element> 
+	      </xsd:all> 
+	    </xsd:complexType>  
+	    <xsd:unique name="Party"> 
+	      <xsd:selector xpath="."/>  
+	      <xsd:field xpath="Party_ID"/> 
+	    </xsd:unique> 
+    </xsd:element>  
+    <xsd:element name="Member"> 
+	    <xsd:annotation> 
+	      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	    </xsd:annotation>  
+	    <xsd:complexType> 
+	      <xsd:all> 
+	        <xsd:element maxOccurs="1" minOccurs="1" name="Participant_ID" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element>  
+	        <xsd:element maxOccurs="1" minOccurs="0" name="Master_Tier" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element> 
+	      </xsd:all> 
+	    </xsd:complexType>  
+	    <xsd:unique name="Member"> 
+	      <xsd:selector xpath="."/>  
+	      <xsd:field xpath="Participant_ID"/> 
+	    </xsd:unique> 
+    </xsd:element>  
+    <xsd:element name="xRef_Party"> 
+	    <xsd:annotation> 
+	      <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	    </xsd:annotation>  
+	    <xsd:complexType> 
+	      <xsd:all> 
+	        <xsd:element maxOccurs="1" minOccurs="1" name="ID" type="AUTO_INCREMENT"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element>  
+	        <xsd:element maxOccurs="1" minOccurs="1" name="Party_ID" type="xsd:string"> 
+	          <xsd:annotation> 
+	            <xsd:appinfo source="X_ForeignKey">Party/Party_ID</xsd:appinfo>  
+	            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>  
+	            <xsd:appinfo source="X_ForeignKey_NotSep">true</xsd:appinfo> 
+	          </xsd:annotation> 
+	        </xsd:element> 
+	      </xsd:all> 
+	    </xsd:complexType>  
+	    <xsd:unique name="xRef_Party"> 
+	      <xsd:selector xpath="."/>  
+	      <xsd:field xpath="ID"/> 
+	    </xsd:unique> 
+    </xsd:element> 
 </xsd:schema>

--- a/org.talend.mdm.query/src/com/amalto/core/storage/record/DataRecord.java
+++ b/org.talend.mdm.query/src/com/amalto/core/storage/record/DataRecord.java
@@ -161,8 +161,11 @@ public class DataRecord {
                 if (value != null) { // Support explicit projection type fields
                     return value;
                 }
-                throw new IllegalArgumentException("Field '" + field.getName() + "' isn't reachable from type '" + type.getName()
-                        + "'");
+                path = MetaDataUtils.path(type, field, true).iterator();
+                if (!path.hasNext()) {
+                    throw new IllegalArgumentException("Field '" + field.getName() + "' isn't reachable from type '" + type.getName()
+                            + "'");
+                }
             }
             DataRecord current = this;
             while (path.hasNext()) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-15023
What is the current behavior? (You should also link to an open issue here)

Ref_address_party referenced to Party and Party referenced to Member.
Throw exception when got the path of field in Member from Ref_address_party.

What is the new behavior?
if got the path failed. try again by set includeReferences true.
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
