### PR TITLE
TMDM-10696 search error when repeatable date field on viewable business element

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageQueryTest.java
@@ -411,7 +411,8 @@ public class StorageQueryTest extends StorageTestCase {
         allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>2</ID_0><ID_1>2</ID_1><FieldX>2</FieldX><FieldA><Name>2</Name><FKEntity>[5][5]</FKEntity></FieldA></OrgEntity>"));
         allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>3</ID_0><ID_1>3</ID_1><FieldX>3</FieldX><FieldA><Name>3</Name><FKEntity>[2][2]</FKEntity></FieldA></OrgEntity>"));
         allRecords.add(factory.read(repository, orgEntity, "<OrgEntity><ID_0>4</ID_0><ID_1>4</ID_1><FieldX>4</FieldX><FieldA><Name>4</Name><FKEntity>[1][1]</FKEntity></FieldA></OrgEntity>"));
-
+        allRecords.add(factory.read(repository, test2Dates, "<Test2Dates><ID>2</ID><ChangeDate>2021-02-11</ChangeDate><ChangeDate>2021-02-18</ChangeDate></Test2Dates>"));
+        
         try {
             storage.begin();
             storage.update(allRecords);
@@ -2235,6 +2236,24 @@ public class StorageQueryTest extends StorageTestCase {
             results.close();
         }
 
+    }
+    
+    public void testDate2Values() throws Exception {
+        UserQueryBuilder qb = from(test2Dates).where(eq(test2Dates.getField("ID"), "2"));
+        StorageResults results = storage.fetch(qb.getSelect());
+        try {
+            assertEquals(1, results.getCount());   
+            ViewSearchResultsWriter writer = new ViewSearchResultsWriter();
+            StringWriter resultWriter = new StringWriter();
+            for (DataRecord result : results) {
+                writer.write(result, resultWriter);
+            }
+            assertEquals("<result xmlns:metadata=\"http://www.talend.com/mdm/metadata\" "
+                    + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n" + "\t<ID>2</ID>\n"
+                    + "\t<ChangeDate>2021-02-11,2021-02-18</ChangeDate>\n" + "</result>", resultWriter.toString());
+        } finally {
+            results.close();
+        }   
     }
 
     public void testInterFieldCondition1() throws Exception {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/query/StorageTestCase.java
@@ -182,6 +182,8 @@ public class StorageTestCase extends TestCase {
     protected static final ComplexTypeMetadata orgPerson;
 
     protected static final ComplexTypeMetadata orgEntity;
+    
+    protected static final ComplexTypeMetadata test2Dates;
 
     public static final String DATABASE = "H2";
 
@@ -269,6 +271,7 @@ public class StorageTestCase extends TestCase {
         orgActivity = repository.getComplexType("OrgActivity");
         orgPerson = repository.getComplexType("OrgPerson");
         orgEntity = repository.getComplexType("OrgEntity");
+        test2Dates = repository.getComplexType("Test2Dates");
 
         systemStorage = new SecuredStorage(new HibernateStorage("MDM", StorageType.SYSTEM), userSecurity);
         systemRepository = buildSystemRepository();

--- a/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
+++ b/org.talend.mdm.core.storage.sql/src/test/resources/com/amalto/core/query/metadata.xsd
@@ -3265,4 +3265,32 @@
             <xsd:field xpath="ID_1" />
         </xsd:unique>
     </xsd:element>
+    <xsd:element name="Test2Dates">
+        <xsd:annotation>
+            <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:sequence>
+                <xsd:element maxOccurs="1" minOccurs="1" name="ID">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                    <xsd:simpleType>
+                        <xsd:restriction base="xsd:string">
+                            <xsd:maxLength value="9" />
+                        </xsd:restriction>
+                    </xsd:simpleType>
+                </xsd:element>
+                <xsd:element maxOccurs="2" minOccurs="0" name="ChangeDate" type="xsd:date">
+                    <xsd:annotation>
+                        <xsd:appinfo source="X_Write">Demo_Manager</xsd:appinfo>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+        </xsd:complexType>
+        <xsd:unique name="Test2Dates">
+            <xsd:selector xpath="." />
+            <xsd:field xpath="ID" />
+        </xsd:unique>
+    </xsd:element>
 </xsd:schema>

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
@@ -17,9 +17,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.List;
 
 import javax.xml.XMLConstants;
 

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
@@ -94,7 +94,7 @@ public class ViewSearchResultsWriter implements DataRecordWriter {
             }
         } else if (Types.DATETIME.equals(type.getName())) {
             synchronized (DateTimeConstant.DATE_FORMAT) {
-                stringValue = formatDateValue(DateConstant.DATE_FORMAT, value);
+                stringValue = formatDateValue(DateTimeConstant.DATE_FORMAT, value);
             }
         } else if (Types.TIME.equals(type.getName())) {
             synchronized (TimeConstant.TIME_FORMAT) {
@@ -150,7 +150,6 @@ public class ViewSearchResultsWriter implements DataRecordWriter {
             } catch (ParseException e) {
                 throw new IOException(e);
             }
-
             return sb.toString();
         } else {
             return dateFormat.format(value);

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Date;
+import java.util.List;
 
 import javax.xml.XMLConstants;
 
@@ -137,7 +138,7 @@ public class ViewSearchResultsWriter implements DataRecordWriter {
     }
 
     private String formatDateValue(DateFormat dateFormat, Object value) throws IOException {
-        if (String.valueOf(value).contains(",")) {
+        if (String.valueOf(value).contains(",") || value instanceof List) {
             String[] dates = String.valueOf(value).split(",");
             StringBuffer sb = new StringBuffer();
             try {
@@ -145,7 +146,7 @@ public class ViewSearchResultsWriter implements DataRecordWriter {
                     if (sb.length() > 0) {
                         sb.append(",");
                     }
-                    sb.append(dateFormat.format(dateFormat.parse(date)));
+                    sb.append(dateFormat.format(dateFormat.parse(date.replaceAll("\\[|\\]", ""))));
                 }
             } catch (ParseException e) {
                 throw new IOException(e);

--- a/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/record/ViewSearchResultsWriter.java
@@ -15,6 +15,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
 
 import javax.xml.XMLConstants;
 
@@ -87,15 +92,15 @@ public class ViewSearchResultsWriter implements DataRecordWriter {
         }
         if (Types.DATE.equals(type.getName())) {
             synchronized (DateConstant.DATE_FORMAT) {
-                stringValue = (DateConstant.DATE_FORMAT).format(value);
+                stringValue = formatDateValue(DateConstant.DATE_FORMAT, value);
             }
         } else if (Types.DATETIME.equals(type.getName())) {
             synchronized (DateTimeConstant.DATE_FORMAT) {
-                stringValue = (DateTimeConstant.DATE_FORMAT).format(value);
+                stringValue = formatDateValue(DateConstant.DATE_FORMAT, value);
             }
         } else if (Types.TIME.equals(type.getName())) {
             synchronized (TimeConstant.TIME_FORMAT) {
-                stringValue = (TimeConstant.TIME_FORMAT).format(value);
+                stringValue = formatDateValue(TimeConstant.TIME_FORMAT, value);
             }
         } else if (value instanceof Object[]) {
             StringBuilder valueAsString = new StringBuilder();
@@ -133,4 +138,24 @@ public class ViewSearchResultsWriter implements DataRecordWriter {
         out.append(StringEscapeUtils.escapeXml(stringValue));
     }
 
+    private String formatDateValue(DateFormat dateFormat, Object value) throws IOException {
+        if (String.valueOf(value).contains(",")) {
+            String[] dates = String.valueOf(value).split(",");
+            StringBuffer sb = new StringBuffer();
+            try {
+                for (String date : dates) {
+                    if (sb.length() > 0) {
+                        sb.append(",");
+                    }
+                    sb.append(dateFormat.format(dateFormat.parse(date)));
+                }
+            } catch (ParseException e) {
+                throw new IOException(e);
+            }
+
+            return sb.toString();
+        } else {
+            return dateFormat.format(value);
+        }
+    }
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
@@ -499,11 +499,26 @@ public class CommonUtil {
                         }
 
                         try {
-                            Date date = sdf.parse(dataText.trim());
-                            originalMap.put(key, date);
                             Calendar calendar = Calendar.getInstance();
-                            calendar.setTime(date);
-                            String formatValue = com.amalto.webapp.core.util.Util.formatDate(value[0], calendar);
+                            String formatValue;
+                            if (tm.getMaxOccurs()>1 && dataText.contains(",")) {
+                                originalMap.put(key, dataText);
+                                String[] dates = dataText.split(",");
+                                StringBuffer sb = new StringBuffer();
+                                for (String dateString : dates) {
+                                    calendar.setTime(sdf.parse(dateString.trim()));
+                                    if (sb.length()>0) {
+                                        sb.append(",");
+                                    }
+                                    sb.append(com.amalto.webapp.core.util.Util.formatDate(value[0], calendar));
+                                }
+                                formatValue = sb.toString();
+                            } else {
+                                Date date = sdf.parse(dataText.trim());
+                                originalMap.put(key, date);                               
+                                calendar.setTime(date);
+                                formatValue = com.amalto.webapp.core.util.Util.formatDate(value[0], calendar);                              
+                            }  
                             formateValueMap.put(key, formatValue);
                             node.setText(formatValue);
                         } catch (Exception e) {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-10696

**What is the current behavior?** (You should also link to an open issue here)

Error message displays when do viewSearch for the date field in viewable elements has 2 values .

**What is the new behavior?**
The record displays correctly when do viewSearch for the date field in viewable elements has 2 values .

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
