### PR TITLE
TMDM-15038 display issue when repeatable date field with display format on viewable business element

### DIFF
--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtil.java
@@ -501,7 +501,7 @@ public class CommonUtil {
                         try {
                             Calendar calendar = Calendar.getInstance();
                             String formatValue;
-                            if (tm.getMaxOccurs()>1 && dataText.contains(",")) {
+                            if (tm.getMaxOccurs() != 1 && dataText.contains(",")) {
                                 originalMap.put(key, dataText);
                                 String[] dates = dataText.split(",");
                                 StringBuffer sb = new StringBuffer();

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
@@ -407,7 +407,7 @@ public class CommonUtilTest extends TestCase {
                 org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "personinfo/aa/a_dob"));
         assertEquals("012",
                 org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "personinfo/aa/a_age"));
-        assertEquals("14/07/17,17/04/19", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_date"));
+        assertEquals("14/07/17", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_date"));
         assertEquals("1 World!", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_name"));
         assertEquals("001", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_age"));
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
@@ -407,7 +407,7 @@ public class CommonUtilTest extends TestCase {
                 org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "personinfo/aa/a_dob"));
         assertEquals("012",
                 org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "personinfo/aa/a_age"));
-        assertEquals("14/07/17", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_date"));
+        assertEquals("14/07/17,17/04/19", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_date"));
         assertEquals("1 World!", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_name"));
         assertEquals("001", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_age"));
 

--- a/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
+++ b/org.talend.mdm.webapp.browserecords/src/test/java/org/talend/mdm/webapp/browserecords/server/util/CommonUtilTest.java
@@ -370,7 +370,7 @@ public class CommonUtilTest extends TestCase {
 
         Map<String, String[]> formatMap = CommonUtil.checkDisplayFormat(testModel, language);
         String result = "<result xmlns:metadata=\"http://www.talend.com/mdm/metadata\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><personId>1</personId><name>1</name>"
-                + "<DOB>2017-07-14</DOB><age>1</age><a_name>1</a_name><a_dob>2017-07-06</a_dob><a_age>12</a_age><b_date>2017-07-14</b_date><b_name>1</b_name><b_age>1</b_age><taskId/></result>";
+                + "<DOB>2017-07-14</DOB><age>1</age><a_name>1</a_name><a_dob>2017-07-06</a_dob><a_age>12</a_age><b_date>2017-07-14,2019-04-17</b_date><b_name>1</b_name><b_age>1</b_age><taskId/></result>";
 
         org.dom4j.Document doc2 = org.talend.mdm.webapp.base.server.util.XmlUtil.parseText(result);
         Map<String, Object> returnValue = CommonUtil.formatQuerylValue(formatMap, doc2, testModel, concept);
@@ -384,7 +384,7 @@ public class CommonUtilTest extends TestCase {
         assertEquals("1 World!", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "a_name"));
         assertEquals("06/07/17", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "a_dob"));
         assertEquals("012", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "a_age"));
-        assertEquals("14/07/17", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_date"));
+        assertEquals("14/07/17,17/04/19", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_date"));
         assertEquals("1 World!", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_name"));
         assertEquals("001", org.talend.mdm.webapp.base.server.util.XmlUtil.getTextValueFromXpath(resultDoc, "b_age"));
 

--- a/org.talend.mdm.webapp.browserecords/src/test/resources/org/talend/mdm/webapp/browserecords/Person.xsd
+++ b/org.talend.mdm.webapp.browserecords/src/test/resources/org/talend/mdm/webapp/browserecords/Person.xsd
@@ -10,7 +10,7 @@
                         <xsd:appinfo source="X_Display_Format_EN">%s World!</xsd:appinfo>
                     </xsd:annotation>
                 </xsd:element>
-                <xsd:element maxOccurs="1" minOccurs="0" name="b_date" type="xsd:date">
+                <xsd:element maxOccurs="-1" minOccurs="0" name="b_date" type="xsd:date">
                     <xsd:annotation>
                         <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo>
                         <xsd:appinfo source="X_Display_Format_EN">%1$td/%1$tm/%1$ty</xsd:appinfo>

--- a/org.talend.mdm.webapp.browserecords/src/test/resources/org/talend/mdm/webapp/browserecords/Person.xsd
+++ b/org.talend.mdm.webapp.browserecords/src/test/resources/org/talend/mdm/webapp/browserecords/Person.xsd
@@ -10,7 +10,7 @@
                         <xsd:appinfo source="X_Display_Format_EN">%s World!</xsd:appinfo>
                     </xsd:annotation>
                 </xsd:element>
-                <xsd:element maxOccurs="-1" minOccurs="0" name="b_date" type="xsd:date">
+                <xsd:element maxOccurs="1" minOccurs="0" name="b_date" type="xsd:date">
                     <xsd:annotation>
                         <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo>
                         <xsd:appinfo source="X_Display_Format_EN">%1$td/%1$tm/%1$ty</xsd:appinfo>

--- a/org.talend.mdm.webapp.browserecords/src/test/resources/org/talend/mdm/webapp/browserecords/server/util/Person.xsd
+++ b/org.talend.mdm.webapp.browserecords/src/test/resources/org/talend/mdm/webapp/browserecords/server/util/Person.xsd
@@ -358,7 +358,7 @@
                         <xsd:appinfo source="X_Display_Format_EN">%s World!</xsd:appinfo>
                     </xsd:annotation>
                 </xsd:element>
-                <xsd:element maxOccurs="1" minOccurs="0" name="b_date" type="xsd:date">
+                <xsd:element maxOccurs="-1" minOccurs="0" name="b_date" type="xsd:date">
                     <xsd:annotation>
                         <xsd:appinfo source="X_Write">System_Admin</xsd:appinfo>
                         <xsd:appinfo source="X_Display_Format_EN">%1$td/%1$tm/%1$ty</xsd:appinfo>


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-15038
**What is the current behavior?** (You should also link to an open issue here)



**What is the new behavior?**

Format result is not correct when the field is 0-many.

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
