### PR TITLE
TMDM-13537 [Integrated Matching] when Merging or Splitting TDS Tasks : records not processed to Master Data Browser

### DIFF
--- a/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
+++ b/org.talend.mdm.core.storage.sql/src/main/java/com/amalto/core/storage/hibernate/HibernateStorage.java
@@ -864,6 +864,7 @@ public class HibernateStorage implements Storage {
      * @param taskId
      * @return
      */
+    @Override
     public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
         Session session = this.getCurrentSession();
         try {

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/server/TransactionTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/server/TransactionTest.java
@@ -346,5 +346,10 @@ public class TransactionTest extends TestCase {
         public Set<String> findTablesToDrop(List<ComplexTypeMetadata> sortedTypesToDrop) {
             return null;
         }
+
+        @Override
+        public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+            return null;
+        }
     }
 }

--- a/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/task/MetadataRepositoryTaskTest.java
+++ b/org.talend.mdm.core.storage.sql/src/test/java/com/amalto/core/storage/task/MetadataRepositoryTaskTest.java
@@ -327,6 +327,10 @@ public class MetadataRepositoryTaskTest extends TestCase {
         public Set<String> findTablesToDrop(List<ComplexTypeMetadata> sortedTypesToDrop) {
             return null;
         }
+
+        public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+            return null;
+        }
     }
 
     private static class MockCommitter implements SaverSession.Committer {

--- a/org.talend.mdm.core/src/com/amalto/core/storage/CacheStorage.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/CacheStorage.java
@@ -131,6 +131,11 @@ public class CacheStorage implements Storage {
     }
 
     @Override
+    public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+        return delegate.getOldGroups(type, taskId);
+    }
+
+    @Override
     public void prepare(MetadataRepository repository, Set<Expression> optimizedExpressions, boolean force,
             boolean dropExistingData) {
         delegate.prepare(repository, optimizedExpressions, force, dropExistingData);

--- a/org.talend.mdm.core/src/com/amalto/core/storage/SecuredStorage.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/SecuredStorage.java
@@ -229,4 +229,9 @@ public class SecuredStorage implements Storage {
     public Set<String> findTablesToDrop(List<ComplexTypeMetadata> sortedTypesToDrop) {
         return delegate.findTablesToDrop(sortedTypesToDrop);
     }
+
+    @Override
+    public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+        return delegate.getOldGroups(type, taskId);
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/StagingStorage.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/StagingStorage.java
@@ -227,6 +227,11 @@ public class StagingStorage implements Storage {
     }
 
     @Override
+    public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+        return delegate.getOldGroups(type, taskId);
+    }
+
+    @Override
     public String getName() {
         return delegate.getName();
     }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/Storage.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/Storage.java
@@ -273,4 +273,12 @@ public interface Storage {
      * @param sortedTypesToDrop
      */
     Set<String> findTablesToDrop(List<ComplexTypeMetadata> sortedTypesToDrop);
+
+    /**
+     * Get METADATA_STAGING_OLD_GROUP list by Task ID
+     *
+     * @param type
+     * @param taskId
+     */
+    List<String> getOldGroups(ComplexTypeMetadata type, String taskId);
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/StorageLogger.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/StorageLogger.java
@@ -211,4 +211,9 @@ public class StorageLogger implements Storage {
     public Set<String> findTablesToDrop(List<ComplexTypeMetadata> sortedTypesToDrop) {
         return delegate.findTablesToDrop(sortedTypesToDrop);
     }
+
+    @Override
+    public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+        return delegate.getOldGroups(type, taskId);
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/dispatch/CompositeStorage.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/dispatch/CompositeStorage.java
@@ -268,4 +268,9 @@ public class CompositeStorage implements Storage {
     public Set<String> findTablesToDrop(List<ComplexTypeMetadata> sortedTypesToDrop) {
         return new HashSet<String>();
     }
+
+    @Override
+    public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+        return new ArrayList<String>();
+    }
 }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/inmemory/InMemoryStorage.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/inmemory/InMemoryStorage.java
@@ -254,6 +254,11 @@ public class InMemoryStorage implements Storage {
         return new HashSet<String>();
     }
 
+    @Override
+    public List<String> getOldGroups(ComplexTypeMetadata type, String taskId) {
+        return new ArrayList<String>();
+    }
+
     private static interface ValueBuilder {
 
         Object getValue(DataRecord record);


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-13537
**What is the current behavior?** (You should also link to an open issue here)
move method getOldGroups of class HibernateStorage to interface Storage

**What is the new behavior?**
move method getOldGroups of class HibernateStorage to interface Storage

**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
