### PR TITLE
TMDM-15103  Logout generate URLs with double slash (//) causing issue when MDM server accessed using reverse proxy combined with SiteMider

### DIFF
--- a/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/client/SessionAwareAsyncCallback.java
+++ b/org.talend.mdm.webapp.base/src/main/java/org/talend/mdm/webapp/base/client/SessionAwareAsyncCallback.java
@@ -31,6 +31,7 @@ public abstract class SessionAwareAsyncCallback<T> implements AsyncCallback<T> {
 
     final private static String OIDC_REDIRECTION_META = "<meta name=\"description\" content=\"Redirection to UI site\" />"; //$NON-NLS-1$
 
+    @Override
     public final void onFailure(Throwable caught) {
         if (Log.isErrorEnabled()) {
             Log.error(caught.toString());
@@ -39,10 +40,11 @@ public abstract class SessionAwareAsyncCallback<T> implements AsyncCallback<T> {
             MessageBox.alert(BaseMessagesFactory.getMessages().warning_title(),
                     BaseMessagesFactory.getMessages().session_timeout_error(), new Listener<MessageBoxEvent>() {
 
+                        @Override
                         public void handleEvent(MessageBoxEvent be) {
                             Cookies.removeCookie("JSESSIONID"); //$NON-NLS-1$
                             Cookies.removeCookie("JSESSIONIDSSO"); //$NON-NLS-1$
-                            Window.Location.replace(GWT.getHostPageBaseURL() + "/logout"); //$NON-NLS-1$
+                            Window.Location.replace(GWT.getHostPageBaseURL() + "logout"); //$NON-NLS-1$
                         }
                     });
         } else {

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/DownloadFilePanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/DownloadFilePanel.java
@@ -345,6 +345,6 @@ public class DownloadFilePanel extends FormPanel {
     }
 
     protected String getActionUrl() {
-        return GWT.getHostPageBaseURL() + "/browserecords/download"; //$NON-NLS-1$
+        return GWT.getHostPageBaseURL() + "browserecords/download"; //$NON-NLS-1$
     }
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemDetailToolBar.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/ItemDetailToolBar.java
@@ -1316,7 +1316,7 @@ public class ItemDetailToolBar extends ToolBar {
                     if (itemsDetailPanel.getFirstTabWidget() instanceof ItemPanel) {
                         ItemPanel itemPanel = (ItemPanel) itemsDetailPanel.getFirstTabWidget();
                         String frameUrl = GWT.getHostPageBaseURL()
-                                + "/browserecords/SmartViewServlet?ids=" + URL.encodeQueryString(itemBean.getIds()) + "&concept=" //$NON-NLS-1$ //$NON-NLS-2$
+                                + "browserecords/SmartViewServlet?ids=" + URL.encodeQueryString(itemBean.getIds()) + "&concept=" //$NON-NLS-1$ //$NON-NLS-2$
                                 + itemBean.getConcept() + "&isStaging=" + isStaging + "&language=" + Locale.getLanguage(); //$NON-NLS-1$ //$NON-NLS-2$
                         if (se.getSelectedItem().get("key") != null) { //$NON-NLS-1$
                             frameUrl += ("&name=" + se.getSelectedItem().get("key")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -1355,7 +1355,7 @@ public class ItemDetailToolBar extends ToolBar {
                 if (smartViewCombo.getSelection() != null && smartViewCombo.getSelection().size() > 0) {
 
                     StringBuilder url = new StringBuilder();
-                    url.append(GWT.getHostPageBaseURL()).append("/browserecords/SmartViewServlet?ids=") //$NON-NLS-1$
+                    url.append(GWT.getHostPageBaseURL()).append("browserecords/SmartViewServlet?ids=") //$NON-NLS-1$
                             .append(URL.encodeQueryString(itemBean.getIds())).append("&concept=") //$NON-NLS-1$
                             .append(itemBean.getConcept()).append("&isStaging=").append(isStaging).append("&language=") //$NON-NLS-1$ //$NON-NLS-2$
                             .append(Locale.getLanguage()).append("&name=") //$NON-NLS-1$

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/NavigatorPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/NavigatorPanel.java
@@ -266,7 +266,7 @@ public class NavigatorPanel extends ContentPanel {
             public void handleEvent(MessageBoxEvent be) {
                 Cookies.removeCookie("JSESSIONID"); //$NON-NLS-1$
                 Cookies.removeCookie("JSESSIONIDSSO"); //$NON-NLS-1$
-                com.google.gwt.user.client.Window.Location.replace(GWT.getHostPageBaseURL() + "/logout"); //$NON-NLS-1$
+                com.google.gwt.user.client.Window.Location.replace(GWT.getHostPageBaseURL() + "logout"); //$NON-NLS-1$
             }
         });
     }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/UploadFileFormPanel.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecords/client/widget/UploadFileFormPanel.java
@@ -434,7 +434,7 @@ public class UploadFileFormPanel extends FormPanel implements Listener<FormEvent
     }
 
     protected String getActionUrl() {
-        return GWT.getHostPageBaseURL() + "/browserecords/upload"; //$NON-NLS-1$
+        return GWT.getHostPageBaseURL() + "browserecords/upload"; //$NON-NLS-1$
     }
 
     private String filterFormatTag(String message) {

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecordsinstaging/client/widget/DownloadFilePanel4Staging.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecordsinstaging/client/widget/DownloadFilePanel4Staging.java
@@ -24,6 +24,6 @@ public class DownloadFilePanel4Staging extends DownloadFilePanel {
 
     @Override
     protected String getActionUrl() {
-        return GWT.getHostPageBaseURL() + "/browserecords/download4Staging"; //$NON-NLS-1$
+        return GWT.getHostPageBaseURL() + "browserecords/download4Staging"; //$NON-NLS-1$
     }
 }

--- a/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecordsinstaging/client/widget/UploadFileFormPanel4Staging.java
+++ b/org.talend.mdm.webapp.browserecords/src/main/java/org/talend/mdm/webapp/browserecordsinstaging/client/widget/UploadFileFormPanel4Staging.java
@@ -28,6 +28,6 @@ public class UploadFileFormPanel4Staging extends UploadFileFormPanel {
 
     @Override
     protected String getActionUrl() {
-        return GWT.getHostPageBaseURL() + "/browserecords/upload4Staging"; //$NON-NLS-1$
+        return GWT.getHostPageBaseURL() + "browserecords/upload4Staging"; //$NON-NLS-1$
     }
 }

--- a/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/actions/GeneralAction.java
+++ b/org.talend.mdm.webapp.general/src/main/java/org/talend/mdm/webapp/general/server/actions/GeneralAction.java
@@ -275,7 +275,7 @@ public class GeneralAction implements GeneralService {
     public String logout() throws ServiceException {
         try {
             if (com.amalto.core.util.Util.isEnterprise()) {
-                return "/logout"; //$NON-NLS-1$
+                return "logout"; //$NON-NLS-1$
             } else {
                 Util.getPort().logout(new WSLogout(StringUtils.EMPTY)).getValue();
                 HttpSession session = SessionContextHolder.currentSession();

--- a/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/client/widget/JournalSearchPanel.java
+++ b/org.talend.mdm.webapp.journal/src/main/java/org/talend/mdm/webapp/journal/client/widget/JournalSearchPanel.java
@@ -544,7 +544,7 @@ public class JournalSearchPanel extends FormPanel {
     }
 
     protected void exportAction() {
-        PostDataUtil.postData(GWT.getHostPageBaseURL() + "/journal/journalExport", getCriteriaMap()); //$NON-NLS-1$
+        PostDataUtil.postData(GWT.getHostPageBaseURL() + "journal/journalExport", getCriteriaMap()); //$NON-NLS-1$
     }
 
     protected List<String> generateOperatorList() {


### PR DESCRIPTION
**What is the current behavior?** (You should also link to an open issue here)



**What is the new behavior?**
Remove redundant slash from logout url after cve upgrade


**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) ?

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
