### PR TITLE
Make it easier for SAST scanners to detect the XXE fixes

### DIFF
--- a/org.talend.mdm.core/src/com/amalto/core/server/DefaultDataModel.java
+++ b/org.talend.mdm.core/src/com/amalto/core/server/DefaultDataModel.java
@@ -64,7 +64,7 @@ public class DefaultDataModel implements DataModel {
         try {
             DOCUMENT_BUILDER_FACTORY.setNamespaceAware(true);
             DOCUMENT_BUILDER_FACTORY.setExpandEntityReferences(false);
-            DOCUMENT_BUILDER_FACTORY.setFeature(MDMXMLUtils.FEATURE_DISALLOW_DOCTYPE, true);
+            DOCUMENT_BUILDER_FACTORY.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         } catch (Exception e) {
             throw new XmlBeanDefinitionException("Error occurred to initialize DocumentBuilderFactory", e);
         }

--- a/org.talend.mdm.core/src/com/amalto/core/storage/datasource/DataSourceFactory.java
+++ b/org.talend.mdm.core/src/com/amalto/core/storage/datasource/DataSourceFactory.java
@@ -67,6 +67,18 @@ public class DataSourceFactory implements ApplicationContextAware {
 
     private static boolean updated = false;
 
+    static {
+        try {
+            factory.setExpandEntityReferences(false);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        } catch (Exception e) {
+            throw new RuntimeException("Exception occurred during data sources XML configuration parsing", e);
+        }
+    }
+
     public static DataSourceFactory getInstance() {
         if (applicationContext != null) {
             return applicationContext.getBean(DataSourceFactory.class);
@@ -120,11 +132,6 @@ public class DataSourceFactory implements ApplicationContextAware {
     private static Map<String, DataSourceDefinition> readDocument(InputStream configurationAsStream) {
         Document document;
         try {
-            factory.setExpandEntityReferences(false);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             DocumentBuilder documentBuilder = factory.newDocumentBuilder();
             document = documentBuilder.parse(configurationAsStream);
         } catch (Exception e) {

--- a/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
+++ b/org.talend.mdm.webapp.core/src/main/java/com/amalto/webapp/core/util/Util.java
@@ -438,7 +438,7 @@ public abstract class Util {
         try {
             // initialize the sax parser which uses Xerces
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            factory.setFeature(MDMXMLUtils.FEATURE_DISALLOW_DOCTYPE, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             // Schema validation based on schemaURL
             factory.setNamespaceAware(true);
             factory.setExpandEntityReferences(false);


### PR DESCRIPTION
Semgrep is detecting a few false positives for XXE issues because of the way the files are structured, this entirely non-functional change restructures the code a bit to avoid these issues.